### PR TITLE
Fix error related with mouseover note

### DIFF
--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -191,7 +191,7 @@ function WoWPro.RowSizeSet()
 		
 		-- Setting the note frame size correctly, setting up mouseover notes --
 		local newh, noteh, trackh
-		if WoWProDB.profile.mousenotes and (WoWPro.note[row.index] or (WoWPro.map[row.index] and WoWProDB.profile.showcoords)) then
+		if WoWProDB.profile.mousenotes and row.index and (WoWPro.note[row.index] or (WoWPro.map[row.index] and WoWProDB.profile.showcoords)) then
 			noteh = 1
 			row.note:Hide()
 			WoWPro.mousenotes[i].note:SetText(row.note:GetText())


### PR DESCRIPTION
Fix error related with mouseover note and initial RowSizeSet, issue 267. Easy fix, but test it out to see if it didnt break anything else. 
