### PR TITLE
Comment lines within the guide section of the lua

### DIFF
--- a/WoWPro_Leveling/WoWPro_Leveling_Parser.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling_Parser.lua
@@ -183,7 +183,8 @@ local function ParseQuests(...)
 	end
 	for j=1,select("#", ...) do
 		local text = select(j, ...)
-		if text ~= "" then
+		text = text:trim()
+		if text ~= "" and text:sub(1,1) ~= ";" then
 			local class, race = text:match("|C|([^|]*)|?"), text:match("|R|([^|]*)|?")
 			if class then
 				-- deleting whitespaces and capitalizing, to compare with Blizzard's class tokens


### PR DESCRIPTION
Added a ';' step that is just a comment.
Tested using an existing guide that I altered as follows:

<pre>
diff --git a/WoWPro_Leveling/Alliance/12_20_Svens_Bloodmyst.lua b/WoWPro_Leveling/Alliance/12_20_Svens_Bloodmyst.lua
index 810f233..1535f6d 100644
--- a/WoWPro_Leveling/Alliance/12_20_Svens_Bloodmyst.lua
+++ b/WoWPro_Leveling/Alliance/12_20_Svens_Bloodmyst.lua
@@ -1,6 +1,8 @@
 WoWPro.Leveling:RegisterGuide("SveBlo1220", "Bloodmyst Isle", "Sven", "12", "20", "###", "Alliance", function()
 return [[
-
+; Bloodmyst Island Guide
+; Revision 1.2.3
+; Oy!
 R Bloodmyst Isle |QID|9663| |N|Go to Bloodmyst Isle |
 T Hero's Call: Bloodmyst Isle!|QID|28559|M|63.1,87.9|
 T Elekks Are Serious Business |QID|9625|N|If you have this quest, turn it in (requires having done Azuremyst previously).|
</pre>


Verified the skipping of the steps by adding an 'else WoWPro:dbp("Skipped step "..text)' line after the if statement.
