### PR TITLE
Update WoWPro_Recorder.lua

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -1,5 +1,5 @@
 -- luacheck: globals WoWPro_RecorderDB
--- luacheck: globals table ipairs pairs tinsert tremove
+-- luacheck: globals table ipairs pairs tinsert tremove C_Timer
 -- luacheck: globals tonumber tostring type max
 
 -----------------------------------
@@ -183,7 +183,6 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
             end
             local portalMap = WoWPro.Recorder.Portals.map
             local portalZone = WoWPro.Recorder.Portals.zone or _G.GetZoneText()
-
             if C_Timer and C_Timer.After then
                 C_Timer.After(2, function()
                     local destZone = _G.GetZoneText()


### PR DESCRIPTION
This Hopefully fixes an issue that Cag and Emma reported in Discord where the portal steps were recording incorrectly

<img width="1244" height="404" alt="image" src="https://github.com/user-attachments/assets/b531dfa9-8d31-4f45-8aa1-2ef2d318ef3a" />


Now it seems to correctly record the destination and the note correctly tells you the place you will land?

<img width="719" height="133" alt="image" src="https://github.com/user-attachments/assets/db799d7c-a717-4e18-9b8c-2379343cb766" />

EDIT: I don't know if this will affect classic actually, i'll have to check at a later time unless someone can answer it





