### PR TITLE
Quest Tweaks

### DIFF
--- a/WoWPro_Leveling/Retail/TimeRunning/Alliance/TR_LEGION_Stormheim.lua
+++ b/WoWPro_Leveling/Retail/TimeRunning/Alliance/TR_LEGION_Stormheim.lua
@@ -133,7 +133,7 @@ C No Wings Required|QID|38318|M|42.88,64.85|N|Click on the hook with the big Yel
 A Assault the Drekirjar-Bonus Objective|QID|38374|M|42.88,64.85|N|Auto-accepted when you enter the area.|RANK|2|LVL|-45|CT|
 C Assault the Drekirjar-Bonus Objective|QID|38374|M|42.88,64.85|S|NOCACHE|N|Go about your quests to advance this objective.|RANK|2|
 C Stormheim Savagery|QID|40179|M|42.88,64.85|Z|Stormheim|P|Leatherworking;165;6|S|N|Kill Vrykul to get the Bindings.|
-A Built to Scale|QID|38337|M|42.88,64.85|N|Kill a Stormwing Drake to get this quest from the UI.|
+; A Built to Scale|QID|38337|M|42.88,64.85|N|Kill a Stormwing Drake to get this quest from the UI.| - This quest just would not drop for me.
 C Built to Scale|QID|38337|M|42.88,64.85|S|N|Kill drakes and loot the 'Storm Drake Scales'.|
 K Kill Glimar Ironfist|QID|38333|M|41.5,66.7|QO|1|ITEM|129291|T|Glimar Ironfist|N|Silver - Kill and loot for a bit of treasure and resources.|RANK|2|RARE|
 C To Weather the Storm|QID|38405|M|41.86,68.40|QO|2|N|Loot Climbing Treads.|

--- a/WoWPro_Leveling/Retail/TimeRunning/Neutral/TR_LEGION_Highmountain.lua
+++ b/WoWPro_Leveling/Retail/TimeRunning/Neutral/TR_LEGION_Highmountain.lua
@@ -392,7 +392,7 @@ C Going Down, Going Up|QID|42425|M|49.39,39.25|NC|N|Click on the rappel point, c
 T Going Down, Going Up|QID|42425|M|49.43,39.28|N|To Oren Windstrider.|RANK|2|
 A Empty Nest|QID|39305|M|49.43,39.28|N|From Oren Windstrider.|PRE|42425|RANK|2|
 C Empty Nest|QID|39305|M|51.68,36.77|QO|1|NC|N|Eagle Eggs placed.|RANK|2|
-T Empty Nest|QID|39305|M|50.88,36.57|N|To Oren Windstrider (just inside the cave).|RANK|2|
+T Empty Nest|QID|39305|M|50.88,36.57;49.43,39.23|CN|N|To Oren Windstrider (just inside the cave). If Oren isn't there he'll be back where you picked the quest up.|RANK|2|
 U Learn Companion Pet|AVAILABLE|38913|U|129277|N|Click to add to your pet collection. Manually check this step off.|RANK|2|
 T The Skyhorn Tribe|QID|38913|M|52.47,44.70|N|To Lasan Skyhorn.|
 A Nursing the Wounds|QID|39318|M|52.47,44.70|N|From Lasan Skyhorn.|PRE|38913|
@@ -464,7 +464,6 @@ T The Three|QID|39321|M|49.21,36.61|N|To Lasan Skyhorn.|
 T Assaulting the Haglands|QID|39429|M|49.21,36.61|N|To Lasan Skyhorn.|
 A The Witchqueen|QID|39322|M|49.21,36.61|N|From Lasan Skyhorn.|PRE|39321^39429|
 K Kill the Exiled Shaman|QID|39782|QO|1|M|41.92,41.61|ITEM|129175|T|Tenpack Flametotem|N|Silver - Run down this path to find kill this shaman and adopt a new pet.|RANK|2|RARE|
-U Learn companion pet|ACTIVE|39322|M|41.92,41.61|U|129175|N|Click to add Crispin to your pet journal. (manually close this step.)|RANK|2|
 C The Witchqueen|QID|39322|M|46.36,39.97|T|High Crawliac|N|Kill High Crawliac.|
 $ Treasure Chest|QID|40507|M|46.81,40.13|N|Loot for a bit of treasure and resources.|RANK|2|
 T The Witchqueen|QID|39322|M|45.69,39.15|N|To Lasan Skyhorn.|


### PR DESCRIPTION
- Built to Scale quest just would not drop for me (confirmed on Wowhead), I've  left the C and T steps so they trigger if it gets hotfixed to drop.
- Crispin pet is AWOL (likely 'cos I already have it!)
- Build to Scale  - quest handin seems to move around a bit
