### PR TITLE
Quick Fixes

### DIFF
--- a/WoWPro_Leveling/Retail/TimeRunning/Neutral/TR_LEGION_Suramar.lua
+++ b/WoWPro_Leveling/Retail/TimeRunning/Neutral/TR_LEGION_Suramar.lua
@@ -410,15 +410,15 @@ K Kill Siegemaster Aedrin|QID|43369|M|37.0,21.2|Z|0680; Suramar|ITEM|140406|T|Si
 C Precious Little Left|QID|40967|M|36.36,16.75|QO|1|NC|N|Up the stairs to find 'Anthology of the Guard' on a table.|
 K Kill Artificer Lothaire|QID|43717|QO|1|M|34.27,15.38|Z|0680; Suramar|ITEM|140372|T|Artificer Lothaire|N|Silver - Up more stairs to kill this rare for treasure and resources. The Trap Rune doesn't affect the Artificer or his companions. Aggro the Artificer and then the Constructs will attack, first one, then two.  Then the Artificer will attack.|RANK|2|RARE|
 C Precious Little Left|QID|40967|M|34.07,17.89|Z|0680; Suramar|QO|3|NC|N|Back down the stairs and 'Aftermath of the Well' is against the wall inside this room.|
--- K Kill Commander Domitille|AVAILABLE|40762|M|36.14,18.56|Z|0680; Suramar|ITEM|141672|L|136851|T|Commander Domitille|N|Kill and loot for an optional quest.|RANK|2|
--- A Zealot's Dues|QID|40762|M|PLAYER|O|U|136851|N|Accepted from Commander Domitille's helm which you just picked up.|
+; K Kill Commander Domitille|AVAILABLE|40762|M|36.14,18.56|Z|0680; Suramar|ITEM|141672|L|136851|T|Commander Domitille|N|Kill and loot for an optional quest.|RANK|2|
+; A Zealot's Dues|QID|40762|M|PLAYER|O|U|136851|N|Accepted from Commander Domitille's helm which you just picked up.|
 C Precious Little Left|QID|40967|M|34.80,22.53|Z|0680; Suramar|QO|2|NC|N|'Magical Manifest of the Moon' in on the table in the covered patio.|U|133882|
 C Stop the Spell Seekers|QID|41032|M|36.45,17.00|Z|0680; Suramar|US|NC|N|Finish closing the purple portals.|
 l Recovering Stolen Power|ACTIVE|40968|M|PLAYER|L|133957 10|S|N|Continue killing Nightborne until you have 10 spell focus fragments.|RANK|2|
 T Precious Little Left|QID|40967|M|36.44,22.40|Z|0680; Suramar|N|To Lothrius Mooncaller.|
 T Lay Waste, Lay Mines|QID|40965|M|36.44,22.40|Z|0680; Suramar|N|To Lothrius Mooncaller.|
 T Stop the Spell Seekers|QID|41032|M|36.44,22.40|Z|0680; Suramar|N|To Lothrius Mooncaller.|
--- T Zealot's Dues|QID|40762|M|36.44,22.40|Z|0680; Suramar|N|To Lothrius Mooncaller.|
+; T Zealot's Dues|QID|40762|M|36.44,22.40|Z|0680; Suramar|N|To Lothrius Mooncaller.|
 A Starweaver's Fate|QID|40969|PRE|40967&40965&41032|M|36.44,22.40|Z|0680; Suramar|N|From Lothrius Mooncaller.|
 T Starweaver's Fate|QID|40969|M|32.20,12.73|Z|0680; Suramar|N|Click on the Elemental Summoners, Follow the summoned elementals, they will wipe out the mobs for you. follow all the way into the room at the top of the stairs (despite the last elemental not going that way). Turn quest in to Syrana Starweaver.|
 A The Orchestrator of Our Demise|QID|40970|PRE|40969|M|32.20,12.73|Z|0680; Suramar|N|From Syrana Starweaver.|


### PR DESCRIPTION
-- Ley Station Moonfall: Available QID was incorrect.
-- Zealot's Dues - the quest starter isn;t dropping from Commander Domitille