### PR TITLE
Fix recorder button alignment and bar size

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -205,7 +205,6 @@ function WoWPro.Recorder:CreateRecorderFrame()
         tile = true, tileSize = 16,
         insets = { left = 4,  right = 3,  top = 4,  bottom = 3 }
     })
-    recorderframe:SetBackdropColor(1,1,1,1)
     recorderframe:RegisterForClicks("AnyUp")
     WoWPro.RecorderFrame = recorderframe
     -- Scripts --


### PR DESCRIPTION
As it turns out it was broken in all, versions so need to do anything special for 11.2.7.
There is still a weird grey background on 11.2.7 - but that seems to be due to SetBackgroundColor in 11.2.7 ignoring the Alpha value - which I suspect is Blizzard side bug they will need to fix!