### PR TITLE
SetRaidTarget taints entire UI in midnight.

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1577,7 +1577,9 @@ if step then
                 mtext = "/target [nodead] "..tar.."\n/"..emote
             else
                 mtext = "/cleartarget[dead]\n/target "..tar.."\n"
-                mtext = mtext .. "/run if GetRaidTargetIndex('target') ~= 8 and not UnitIsDead('target') then SetRaidTarget('target', 8) end"
+                if not WoWPro.MIDNIGHT then
+                    mtext = mtext .. "/run if GetRaidTargetIndex('target') ~= 8 and not UnitIsDead('target') then SetRaidTarget('target', 8) end"
+                end
             end
             currentRow.targetbutton:SetAttribute("macrotext", mtext)
             -- Run Module specific RowUpdateTarget() to override macrotext


### PR DESCRIPTION
- Using SetRaidTarget currently taints the entire UI in Midnight - even out of combat.

Blizzard have announced that they plan to restore access to SetRaidTarget  from the Secure Access Button Template in a future build. This will likely require some rework of our target button logic  as we currently use both secure and non secure button templates.

<img width="992" height="136" alt="image" src="https://github.com/user-attachments/assets/371c92b9-1d46-486b-9128-14db396c31b4" />

In the meantime I propose disabling using the target marker for midnight (but retain the set target with works OK).

Classic, MoP, and TWW are unaffected,