### PR TITLE
Aura scanning in combat is not allowed

### DIFF
--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -134,7 +134,7 @@ function WoWPro:CheckAnimaPowers()
 	local numBuffs = 0
 	for i=1, 44 do
 		local _, _, _, _, _, _, _, _, _, spellID = WoWPro.UnitAura("player", i, "MAW")
-		if spellID then
+		if not ( _G.issecretvalue and _G.issecretvalue(BuffSpellId) ) and spellID then
 			numBuffs = numBuffs + 1
 		end
 	end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -134,7 +134,7 @@ function WoWPro:CheckAnimaPowers()
 	local numBuffs = 0
 	for i=1, 44 do
 		local _, _, _, _, _, _, _, _, _, spellID = WoWPro.UnitAura("player", i, "MAW")
-		if not ( _G.issecretvalue and _G.issecretvalue(BuffSpellId) ) and spellID then
+		if not ( _G.issecretvalue and _G.issecretvalue(spellID) ) and spellID then
 			numBuffs = numBuffs + 1
 		end
 	end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -145,15 +145,19 @@ function WoWPro.AuraScan(tabula, filter)
     local BuffIndex = 1
     local BuffString = tabula[0] or ""
     local BuffName, _, BuffCount, _, _, _, _, _, _, BuffSpellId = WoWPro.UnitAura("player",BuffIndex,filter)
+    -- Aura scanning is now restricted in combat
     while BuffName do
-        tabula[BuffSpellId] = BuffCount or 1
-        if BuffString ~= "" then
-            BuffString = BuffString .. ","
+        if not ( _G.issecretvalue and _G.issecretvalue(BuffSpellId) ) then
+            tabula[BuffSpellId] = BuffCount or 1
+            if BuffString ~= "" then
+                BuffString = BuffString .. ","
+            end
+            BuffString = BuffString .. ("%s(%d)"):format(BuffName, BuffSpellId)
+            BuffIndex = BuffIndex + 1
+            BuffName, _, BuffCount, _, _, _, _, _, _, BuffSpellId = WoWPro.UnitAura("player",BuffIndex,filter)
         end
-        BuffString = BuffString .. ("%s(%d)"):format(BuffName, BuffSpellId)
-        BuffIndex = BuffIndex + 1
-        BuffName, _, BuffCount, _, _, _, _, _, _, BuffSpellId = WoWPro.UnitAura("player",BuffIndex,filter)
     end
+
     tabula[0] = BuffString
     return tabula
 end


### PR DESCRIPTION
Reported by ticket-4-feraluna

This will delay the completion of steps with |BUFF| until player drops combat or leaves an instance. The UpdateGuide call in the PLAYER_REGEN_ENABLED handler should ensure the step is rechecked up once they drop combat allowing the guide to catch up.

I've added a note to the wiki to avoid using |BUFF| in instances or where player is expected to remain in combat between steps.