### PR TITLE
We cannot read chat in combat any more!

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -145,7 +145,7 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
     if event == "CHAT_MSG_SYSTEM" then
         WoWPro.Recorder:dbp("CHAT_MSG_SYSTEM detected.")
         local msg = ...
-        if not (_G.issecretvalue and _G.issecretvalue(msg)) then 
+        if not (_G.issecretvalue and _G.issecretvalue(msg)) then
             local _, _, loc = msg:find(L["(.*) is now your home."])
             if loc then
                 local stepInfo = {


### PR DESCRIPTION
- Recorder won't be able to detect when we set hearth if we do it in combat