### PR TITLE
"DONE" label in progress column in guide list

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -1281,6 +1281,29 @@ function WoWPro:GetGuideProgress(guideID)
     return
 end
 
+function WoWPro:IsCurrentGuideTitlebarComplete(guideID)
+    local currentGuide = WoWProDB.char.currentguide
+    if not currentGuide then
+        return false
+    end
+    if guideID and guideID ~= currentGuide then
+        return false
+    end
+    local total = WoWPro.stepcount or 0
+    if total <= 0 then
+        return false
+    end
+    if WoWProDB.profile.guideprogress then
+        local currentStep = WoWPro.ActiveStep or 1
+        return currentStep >= total
+    end
+    local currentMainStep = WoWPro.NextStepNotSticky()
+    if not currentMainStep then
+        return false
+    end
+    return currentMainStep >= total
+end
+
 function WoWPro:GetGuideName(GID)
     if GID and WoWPro.Guides[GID] then
         return WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone or GID

--- a/WoWPro/WoWPro_Localization.lua
+++ b/WoWPro/WoWPro_Localization.lua
@@ -16,6 +16,7 @@ local english = {
     -- Leveling Module --
     ["Available WoW-Pro leveling guides are listed below. \nSelect one and hit \"Okay\" to load. \nShift+click a guide to clear it."] = "Available WoW-Pro leveling guides are listed below. \nSelect one and hit \"Okay\" to load. \nShift+click a guide to clear it.",
     ["Guide List"] = "Guide List",
+    ["DONE"] = "DONE",
     ["Zone"] = "Zone",
     ["Level"] = "Level",
     ["Author"] = "Author",
@@ -205,6 +206,7 @@ if loc == "deDE" then L = {
     ["Right click for options"] = "Rechtsklick für Optionen",
     ["Left-click to enable/disable addon"] = "Linksklick, um Addon zu aktivieren/deaktivieren",
     ["Right-click to open config panel"] = "Rechtsklick, um das Konfigurationsmenü zu öffnen",
+    ["DONE"] = "FERTIG",
 
 } end
 
@@ -389,6 +391,7 @@ if loc == "frFR" then L = {
     ["Right click for options"] = "Clic droit pour les options",
     ["Left-click to enable/disable addon"] = "Clic gauche pour activer/désactiver l'addon",
     ["Right-click to open config panel"] = "Clic droit pour ouvrir le panneau de configuration",
+    ["DONE"] = "TERMINE",
 } end
 
 ----------------------
@@ -572,6 +575,7 @@ if loc == "ruRU" then L = {
     ["Right click for options"] = "Щелкните правой кнопкой мыши для выбора",
     ["Left-click to enable/disable addon"] = "Щелкните левой кнопкой мыши, чтобы включить/отключить аддон",
     ["Right-click to open config panel"] = "Щелкните правой кнопкой мыши, чтобы открыть панель настроек",
+    ["DONE"] = "ГОТОВО",
 } end
 
 
@@ -735,6 +739,7 @@ if loc == "krKR" then L = {
     ["Right click for options"] = "옵션을 보려면 오른쪽 클릭",
     ["Left-click to enable/disable addon"] = "애드온을 활성화/비활성화하려면 왼쪽 클릭",
     ["Right-click to open config panel"] = "설정 패널을 열려면 오른쪽 클릭",
+    ["DONE"] = "완료",
 } end
 
 ----------------------
@@ -918,6 +923,7 @@ if loc == "esES" then L = {
     ["Right click for options"] = "Haz clic derecho para ver las opciones",
     ["Left-click to enable/disable addon"] = "Haz clic izquierdo para activar/desactivar el complemento",
     ["Right-click to open config panel"] = "Haz clic derecho para abrir el panel de configuración",
+    ["DONE"] = "HECHO",
     } end
 
 ----------------------
@@ -1101,6 +1107,7 @@ if loc == "ptBR" then L = {
     ["Right click for options"] = "Clique com o botão direito para ver as opções",
     ["Left-click to enable/disable addon"] = "Clique com o botão esquerdo para ativar/desativar o addon",
     ["Right-click to open config panel"] = "Clique com o botão direito para abrir o painel de configuração",
+    ["DONE"] = "FEITO",
     } end
 
 ----------------------
@@ -1284,6 +1291,7 @@ if loc == "itIT" then L = {
     ["Right click for options"] = "Fai clic con il pulsante destro per le opzioni",
     ["Left-click to enable/disable addon"] = "Fai clic con il pulsante sinistro per abilitare/disabilitare l'addon",
     ["Right-click to open config panel"] = "Fai clic con il pulsante destro per aprire il pannello di configurazione",
+    ["DONE"] = "FATTO",
     } end
 
 WoWPro_Locale = nil

--- a/WoWPro_Achievements/WoWPro_Achievements_GuideList.lua
+++ b/WoWPro_Achievements/WoWPro_Achievements_GuideList.lua
@@ -5,6 +5,7 @@
 --      WoWPro_Achievements_GuideList.lua      --
 ---------------------------------------------
 local Achievements = WoWPro.Achievements
+local L = WoWPro_Locale
 Achievements.GuideList = {}
 
 local function AddInfo(guide)
@@ -64,6 +65,10 @@ local function GetGuides()
             })
 
             guides[#guides].progress, guides[#guides].Progress = WoWPro:GetGuideProgress(guideID)
+            if (guides[#guides].progress and guides[#guides].progress >= 1)
+            or WoWPro:IsCurrentGuideTitlebarComplete(guideID) then
+                guides[#guides].Progress = L["DONE"]
+            end
         end
     end
 

--- a/WoWPro_Dailies/WoWPro_Dailies_GuideList.lua
+++ b/WoWPro_Dailies/WoWPro_Dailies_GuideList.lua
@@ -5,6 +5,7 @@
 --      WoWPro_Dailies_GuideList.lua      --
 --------------------------------------------
 local Dailies = WoWPro.Dailies
+local L = WoWPro_Locale
 Dailies.GuideList = {}
 
 
@@ -52,6 +53,10 @@ local function GetGuides()
             })
 
             guides[#guides].progress, guides[#guides].Progress = WoWPro:GetGuideProgress(guideID)
+            if (guides[#guides].progress and guides[#guides].progress >= 1)
+            or WoWPro:IsCurrentGuideTitlebarComplete(guideID) then
+                guides[#guides].Progress = L["DONE"]
+            end
         end
     end
 

--- a/WoWPro_Leveling/WoWPro_Leveling_GuideList.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling_GuideList.lua
@@ -5,6 +5,7 @@
 --      WoWPro_Leveling_GuideList.lua      --
 ---------------------------------------------
 local Leveling = WoWPro.Leveling
+local L = WoWPro_Locale
 Leveling.GuideList = {}
 
 local defaultXpac = _G.LE_EXPANSION_CLASSIC
@@ -147,6 +148,10 @@ local function GetGuides()
             }
             ResolveGuide(guide)
             guideInfo.progress, guideInfo.Progress = WoWPro:GetGuideProgress(guideID)
+            if (guideInfo.progress and guideInfo.progress >= 1)
+            or WoWPro:IsCurrentGuideTitlebarComplete(guideID) then
+                guideInfo.Progress = L["DONE"]
+            end
             tinsert(guides, guideInfo)
         end
     end

--- a/WoWPro_Profession/WoWPro_Profession_GuideList.lua
+++ b/WoWPro_Profession/WoWPro_Profession_GuideList.lua
@@ -4,6 +4,7 @@
 --      WoWPro_Profession_GuideList.lua      --
 ---------------------------------------------
 local Profession = WoWPro.Profession
+local L = WoWPro_Locale
 Profession.GuideList = {}
 
 local function GetGuides()
@@ -20,6 +21,10 @@ local function GetGuides()
             })
 
             guides[#guides].progress, guides[#guides].Progress = WoWPro:GetGuideProgress(guideID)
+            if (guides[#guides].progress and guides[#guides].progress >= 1)
+            or WoWPro:IsCurrentGuideTitlebarComplete(guideID) then
+                guides[#guides].Progress = L["DONE"]
+            end
         end
     end
 

--- a/WoWPro_WorldEvents/WoWPro_WorldEvents_GuideList.lua
+++ b/WoWPro_WorldEvents/WoWPro_WorldEvents_GuideList.lua
@@ -4,6 +4,7 @@
 --      WoWPro_WorldEvents_GuideList.lua      --
 ---------------------------------------------
 local WorldEvents = WoWPro.WorldEvents
+local L = WoWPro_Locale
 WorldEvents.GuideList = {}
 
 
@@ -39,6 +40,10 @@ local function GetGuides()
             })
 
             guides[#guides].progress, guides[#guides].Progress = WoWPro:GetGuideProgress(guideID)
+            if (guides[#guides].progress and guides[#guides].progress >= 1)
+            or WoWPro:IsCurrentGuideTitlebarComplete(guideID) then
+                guides[#guides].Progress = L["DONE"]
+            end
         end
     end
 


### PR DESCRIPTION
**Add localized "DONE" label to guide list when guide reaches completion**

Updated guide list completion display to use a localized DONE label and to respect the current guide's title-bar completion state, so a guide that reaches 100% in the title bar shows DONE even when the completion-based ratio is still below 1. Added a helper that mirrors title-bar logic and wired it into all guide list modules. Also added localized strings for DONE across supported locales.

**In its current state, if all of the steps are completed (100% is shown in titlebar), it will display DONE. However, as with any of the guides, the guide must be loaded at least once to get the current progress.

### Files touched:
- WoWPro.lua
- WoWPro_Localization.lua
- WoWPro_Leveling_GuideList.lua
- WoWPro_Achievements_GuideList.lua
- WoWPro_Dailies_GuideList.lua
- WoWPro_Profession_GuideList.lua
- WoWPro_WorldEvents_GuideList.lua

**Draft PR suggestion (for all guides): persist the title-bar percent per guide (e.g., WoWProCharDB.Guide[GID].percent) during guide updates and consume that cached percent in the guide list to mark DONE for any guide, not just the current one. This is a small change in the update loop where title-bar percent is computed, plus a list-side check against the stored percent.