### PR TITLE
Troubleshooting S!US Visibility Issue

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1164,14 +1164,16 @@ function WoWPro:RowUpdate(offset)
                 local available = WoWPro.available and WoWPro.available[stepIdx]
                 local activeReq = WoWPro.active and WoWPro.active[stepIdx]
 
-                -- Never show sticky steps that are beyond current progression
-                if stepIdx > stickyBoundary then
+                local isSUS = WoWPro.sticky[stepIdx] and WoWPro.unsticky[stepIdx]
+                -- Never show sticky steps that are beyond current progression (except S!US, which stays visible until its condition completes)
+                if not isSUS and stepIdx > stickyBoundary then
                     showSticky = false
 
                 -- Respect AVAILABLE/ACTIVE tags for sticky visibility (filters, not triggers)
-                elseif available and not WoWPro.QuestAvailable(available, false, "AVAILABLE") then
+                -- S!US should always show until completion, regardless of these filters
+                elseif not isSUS and available and not WoWPro.QuestAvailable(available, false, "AVAILABLE") then
                     showSticky = false
-                elseif activeReq and not WoWPro:QIDsInTableLogical(activeReq, WoWPro.QuestLog) then
+                elseif not isSUS and activeReq and not WoWPro:QIDsInTableLogical(activeReq, WoWPro.QuestLog) then
                     showSticky = false
                 -- For C steps with QID and QO, check if specific objective is incomplete
                 elseif action == "C" and QID and questtext then
@@ -1210,7 +1212,8 @@ function WoWPro:RowUpdate(offset)
                     end
                 -- For other sticky types, show if we've reached that step
                 else
-                    if stepIdx <= k then
+                    -- S!US steps should remain visible while incomplete, even if they are past the current active step
+                    if isSUS or stepIdx <= k then
                         showSticky = true
                     end
                 end


### PR DESCRIPTION
**Problem**

- _S!US_ steps were intended to act as permanent sticky steps (no separate US needed).
- Code treat` S!US` as sticky but previous visibility logic could hide it too early:
   - _ACTIVE_/_AVAILABLE_ in _NextStep()_ could skip it
   - "sticky boundary" (active-step walk) could push it out of the rendered rows
- Combined effect: _S!US_ step could disappear before its real completion condition (e.g., loot target) was met.

**Fix**
- _RowUpdate()_ now:
   - keeps _S!US_ sticky visible even when beyond active step boundary
   - shows _S!US_ while incomplete
- _NextStep()_ still enforces parser filters (ACTIVE, AVAILABLE, QID etc.) and completion condition, as intended
- Result: _S!US_ behaves as "sticky until truly complete", not as a timed transient state.