### PR TITLE
Prevent blank /wp log

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -48,13 +48,18 @@ function WoWPro:Add2Log(level, msg)
     if WoWPro.Serial > 2500 then
         WoWPro.Serial = 1
     end
-    if WoWProDB and WoWProDB.global and WoWProDB.global.Log then
+
+    if WoWProDB and WoWProDB.global then
+        WoWProDB.global.Log = WoWProDB.global.Log or {}
         if WoWPro.Log then
-            WoWProDB.global.Log = WoWPro.Log
+            for k,v in pairs(WoWPro.Log) do
+                WoWProDB.global.Log[k] = v
+            end
             WoWPro.Log = nil
         end
         WoWProDB.global.Log[WoWPro.Serial] = msg
     else
+        WoWPro.Log = WoWPro.Log or {}
         WoWPro.Log[WoWPro.Serial] = msg
     end
 end
@@ -203,12 +208,23 @@ local LogCo = nil
 local LogCall = nil
 local LogFrame = nil
 local function LogGrow(frame, elapsed)
+    local logtable = (WoWProDB and WoWProDB.global and WoWProDB.global.Log) and WoWProDB.global.Log or WoWPro.Log
+    if not logtable then
+        if LogFrame then
+            LogFrame:SetScript("OnUpdate",nil)
+        end
+        if LogCall then
+            LogCall("")
+        end
+        return
+    end
+
     if Log == nil then
         -- Start coroutine
         Log = ""
         LogCo = coroutine.create(function()
             local loops = 25
-            for key, val in ipairs(WoWProDB.global.Log) do
+            for key, val in ipairs(logtable) do
                 Log = Log .. ("%05d ~ %s\n"):format(key, val)
                 loops = loops - 1
                 if loops < 0 then
@@ -231,7 +247,8 @@ local function LogGrow(frame, elapsed)
 end
 
 function WoWPro:LogDump(callback)
-    if (not WoWProDB) or (not WoWProDB.global) or (not WoWProDB.global.Log) then return "" end
+    local logtable = (WoWProDB and WoWProDB.global and WoWProDB.global.Log) and WoWProDB.global.Log or WoWPro.Log
+    if not logtable then return "" end
     _G.DEFAULT_CHAT_FRAME:AddMessage("WoWPro:LogDump(): Generating log")
     WoWPro:Print("WoWPro Version %s, WoW Version/TOC %s/%d.", WoWPro.Version, _G.GetBuildInfo(), WoWPro.TocVersion)
     WoWPro:print("Class: %s, Race: %s, Faction: %s, Level %d, XP %d",


### PR DESCRIPTION
### One-off scenario (TL;DR)
- On startup or right after _/wp clear-log_, _WoWProDB.global.Log_ can be _{}_ (or uninitialized)
- But _WoWPro.Log_ may already contain recent entries (early _Add2Log_ calls)
- _/wp log_ might evaluate before global catches up
- Old behavior: display read only global, so _LogShow_ can return an empty window
- That’s exactly the one-off blank hit you had
### Why this patch fixes it permanently
- _Add2Log_: proactively syncs in-memory entries into global when available
- _LogDump_/_LogGrow_: uses fallback memory log if global is empty
- Eliminates the fragile precondition that “global must already contain recent lines”
### Result
- It won’t depend on startup order or the exact moment you press /wp log
- One-off blank condition becomes impossible in normal flow
- This ensures the behavior is stable and reproducible, not a random “happened once” edge case again.

**If you want the details...**

### Root cause
- **WoWPro** uses two log stores:
  - WoWProDB.global.Log (persistent saved-vars)
  - WoWPro.Log (in-memory runtime)
- WoWPro:Add2Log could write to in-memory log when persistent table isn’t present yet
- **LogShow** / **LogDump** / **LogGrow** was reading only _WoWProDB.global.Log_
- If persistent table was empty (startup/after clear) but memory had entries, **/wp log** showed blank
### What was changed
1. **WoWPro:Add2Log(level, msg)**
    - ensures _WoWProDB.global.Log_ exists
    - merges _WoWPro.Log_ into _WoWProDB.global.Log_ before writes
    - writes logs to global when possible, falls back to in-memory
2. **WoWPro:LogDump(callback)**
    - drop strict early return when global missing
    - choose source: _WoWProDB.global.Log_ or fallback _WoWPro.Log_
3. **LogGrow(frame, elapsed)**
    - iterate selected log source (_logtable_) not hardcoded global
    - handle nil source gracefully (resets loop)
### Effect
- _/wp log_ no longer can appear blank due to startup/clear race
- log output becomes deterministic: visible logs from both persistent and early runtime phases
- durability improved: reload/state changes no longer expose transient empty-log bug
- logical separation between debug event collection and debug window rendering preserved, now synced
### Behavioral regression fix
- Employed fallback path and source sync so user state is always up-to-date in /wp log:
  - persistent-first, memory-fallback
  - log contents are never “orphaned” in memory when display checks global.