### PR TITLE
UI Event better than Chat Event

### DIFF
--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -407,19 +407,15 @@ end
 
 
 -- Auto-Complete: Set hearth --
-function WoWPro:AutoCompleteSetHearth(...)
-    local msg = ...
-    if not ( _G.issecretvalue and _G.issecretvalue(msg) ) then
-        local _, _, loc = msg:find(L["(.*) is now your home."])
-        if loc then
-            WoWProCharDB.Guide.hearth = loc
-            for i = 1,15 do
-                local index = WoWPro.rows[i].index
-                if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
-                and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
-                    WoWPro.CompleteStep(index, "AutoCompleteSetHearth")
-                end
-            end
+function WoWPro:AutoCompleteSetHearth()
+    local loc = _G.GetBindLocation()
+    if not loc then return end
+    -- WoWProCharDB.Guide.hearth = loc  ** Don't save it, just use it for auto-completion. If we save it, then we have to worry about it getting out of date and causing problems.
+    for i = 1,15 do
+        local index = WoWPro.rows[i].index
+        if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
+        and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
+            WoWPro.CompleteStep(index, "AutoCompleteSetHearth")
         end
     end
 end
@@ -432,6 +428,13 @@ function WoWPro.AutoCompleteZone()
     local targetzone = WoWPro.targetzone[currentindex] or "!"
     local zonetext, subzonetext = _G.GetZoneText(), _G.GetSubZoneText():trim()
     WoWPro:dbp("AutoCompleteZone: [%s] or [%s] .vs. %s [%s]/[%s]", zonetext, subzonetext, action, step, targetzone)
+
+    local hearthLocation = _G.GetBindLocation()
+    if action == "h" and hearthLocation and hearthLocation == step then
+        WoWPro.CompleteStep(currentindex, "Hearthstone already set")
+        return true
+    end
+
     if action == "F" or action == "H" or action == "b" or action == "P" or action == "R" then
         if not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[currentindex] then
             if (step == zonetext) or (step == subzonetext) then
@@ -1097,8 +1100,8 @@ function WoWPro.PLAYER_CONTROL_LOST_PUNTED(event, ...)
     end
 end
 
-WoWPro.RegisterEventHandler("CHAT_MSG_SYSTEM", function(event, ...)
-    WoWPro:AutoCompleteSetHearth(...)
+WoWPro.RegisterEventHandler("HEARTHSTONE_BOUND", function(event, ...)
+    WoWPro:AutoCompleteSetHearth()
 end)
 
 if WoWPro.RETAIL then

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -5,7 +5,6 @@
 --  WoWPro_Events.lua   --
 --------------------------
 
-local L =  WoWPro_Locale
 local successfulRequest = _G.C_ChatInfo.RegisterAddonMessagePrefix("WoWPro")
 -- Are we ready to roll?
 function WoWPro.Ready(who)


### PR DESCRIPTION
### Why a UI-driven event is better than a chat-driven event

- CHAT_MSG_SYSTEM is a raw chat stream. It carries everything the system prints, so you have to filter and parse text out of noise.
- UI_INFO_MESSAGE is a higher-level UI notification. It’s meant for informational messages, not general system chat.
- That means it’s less likely to be affected by chat filtering, custom chat windows, or unrelated system messages.
- It also makes the code more semantically correct: hearthstone bind is a UI info event, not really a chat message.

So a UI-driven event is better because it’s more specific, cleaner, and less brittle than relying on system chat text.

HEARTHSTONE_BOUND is a direct event trigger for the hearthstone bind action, which makes it a better choice than UI_INFO_MESSAGE.

### Summary

- Switched from text detection to a trigger event
    - removed the previous hearth auto-complete path that relied on message parsing AutoCompleteSetHearth() now runs from the event handler directly

- Chose HEARTHSTONE_BOUND instead of UI_INFO_MESSAGE
    - used the dedicated hearthstone-bound event instead of a generic UI info message
    - avoids relying on localized bind text or msg payload parsing
    - makes the trigger specific to the actual hearthstone bind action

- Removed WoWProCharDB.Guide.hearth reliance
    - commented out the line that stored the bind location in saved guide state
    - AutoCompleteSetHearth() now calls _G.GetBindLocation() directly
    - prevents stale saved hearth data and keeps completion logic stateless
