### PR TITLE
Fix autocomplete questupdate

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4297,8 +4297,10 @@ function WoWPro.PopulateQuestLog()
     end
     local newQuests = {}
     local missingQuests = {}
-    WoWPro.newQuest = false
-    WoWPro.missingQuests = missingQuests
+    -- Legacy scalar quest state, preserved only for compatibility.
+    -- New code should use explicit diff tables instead.
+    -- WoWPro.newQuest = false
+    -- WoWPro.missingQuests = missingQuests
 
     -- Generating the Quest Log table --
     WoWPro.QuestLog = tablecopy(WoWPro.FauxQuestLog) -- Reinitiallizing the Quest Log table
@@ -4391,7 +4393,8 @@ function WoWPro.PopulateQuestLog()
     if numLoggedQuests > 0 then
         for QID, questInfo in pairs(WoWPro.QuestLog) do
             if not WoWPro.oldQuests[QID] then
-                WoWPro.newQuest = QID
+                -- Legacy scalar quest state, preserve only for compatibility.
+                -- WoWPro.newQuest = QID
                 newQuests[QID] = true
                 WoWPro:print("New Quest %s: [%s]", tostring(QID), questInfo.title)
                 delta = delta + 1

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4295,7 +4295,7 @@ function WoWPro.PopulateQuestLog()
         WoWPro.oldQuests = WoWPro.QuestLog or {}
         WoWPro.inhibit_oldQuests_update = true
     end
-    WoWPro.newQuest, WoWPro.missingQuest = false, false
+    WoWPro.newQuest = false
     WoWPro.missingQuests = {}
 
     -- Generating the Quest Log table --
@@ -4401,7 +4401,7 @@ function WoWPro.PopulateQuestLog()
         end
     end
 
-    -- Finding WoWPro.missingQuest --
+    -- Finding missing quests --
     for QID, oldQuestInfo in pairs(WoWPro.oldQuests) do
         if not WoWPro.QuestLog[QID] then
             WoWPro.missingQuests[QID] = true

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4223,6 +4223,7 @@ end
 
 WoWPro.QuestLog = {}
 WoWPro.FauxQuestLog = {}
+WoWPro.missingQuests = {}
 
 local function  tablecopy(orig)
     local  copy = {}
@@ -4295,6 +4296,7 @@ function WoWPro.PopulateQuestLog()
         WoWPro.inhibit_oldQuests_update = true
     end
     WoWPro.newQuest, WoWPro.missingQuest = false, false
+    WoWPro.missingQuests = {}
 
     -- Generating the Quest Log table --
     WoWPro.QuestLog = tablecopy(WoWPro.FauxQuestLog) -- Reinitiallizing the Quest Log table
@@ -4402,11 +4404,10 @@ function WoWPro.PopulateQuestLog()
     -- Finding WoWPro.missingQuest --
     for QID, oldQuestInfo in pairs(WoWPro.oldQuests) do
         if not WoWPro.QuestLog[QID] then
+            WoWPro.missingQuests[QID] = true
             if WoWPro:IsQuestFlaggedCompleted(QID) then
-                WoWPro.missingQuest = QID
                 WoWPro:print("Completed Quest: %d [%s]", QID, tostring(oldQuestInfo.title))
             else
-                WoWPro.missingQuest = QID
                 WoWPro:print("Missing Quest: %d [%s]", QID, tostring(oldQuestInfo.title))
             end
             delta = delta + 1

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4295,8 +4295,10 @@ function WoWPro.PopulateQuestLog()
         WoWPro.oldQuests = WoWPro.QuestLog or {}
         WoWPro.inhibit_oldQuests_update = true
     end
+    local newQuests = {}
+    local missingQuests = {}
     WoWPro.newQuest = false
-    WoWPro.missingQuests = {}
+    WoWPro.missingQuests = missingQuests
 
     -- Generating the Quest Log table --
     WoWPro.QuestLog = tablecopy(WoWPro.FauxQuestLog) -- Reinitiallizing the Quest Log table
@@ -4390,6 +4392,7 @@ function WoWPro.PopulateQuestLog()
         for QID, questInfo in pairs(WoWPro.QuestLog) do
             if not WoWPro.oldQuests[QID] then
                 WoWPro.newQuest = QID
+                newQuests[QID] = true
                 WoWPro:print("New Quest %s: [%s]", tostring(QID), questInfo.title)
                 delta = delta + 1
                 -- Is this an auto-switch quest?
@@ -4404,7 +4407,7 @@ function WoWPro.PopulateQuestLog()
     -- Finding missing quests --
     for QID, oldQuestInfo in pairs(WoWPro.oldQuests) do
         if not WoWPro.QuestLog[QID] then
-            WoWPro.missingQuests[QID] = true
+            missingQuests[QID] = true
             if WoWPro:IsQuestFlaggedCompleted(QID) then
                 WoWPro:print("Completed Quest: %d [%s]", QID, tostring(oldQuestInfo.title))
             else
@@ -4448,7 +4451,7 @@ function WoWPro.PopulateQuestLog()
     -- Stop Tracking the QuestLogs for debugging for Emmaleah
     WoWProDB.char.Emmaleah = nil
     WoWPro:SendMessage("WoWPro_PostQuestLogUpdate")
-    return delta
+    return delta, newQuests, missingQuests
 end
 
 function WoWPro.PostQuestLogUpdate()

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -312,12 +312,14 @@ end
 
 
 -- Auto-Complete: Quest Update --
-function WoWPro:AutoCompleteQuestUpdate(questComplete)
+function WoWPro:AutoCompleteQuestUpdate(questComplete, newQuests, missingQuests)
     local GID = WoWProDB.char.currentguide
     if not GID or not WoWPro.Guides[GID] then return end
     if not WoWProCharDB.Guide then return end
     if not WoWProCharDB.Guide[GID] then return end
     if not WoWProCharDB.Guide[GID].completion then return end
+    newQuests = newQuests or {}
+    missingQuests = missingQuests or {}
 
     WoWPro:dbp("Running: AutoCompleteQuestUpdate(questComplete=%s)",tostring(questComplete))
 
@@ -335,7 +337,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                 QID = tonumber(QID)
 
                 -- Quest Turn-Ins --
-                if WoWPro.CompletingQuest and action == "T" and not completion and WoWPro.missingQuests[QID]
+                if WoWPro.CompletingQuest and action == "T" and not completion and (missingQuests[QID] or WoWPro.missingQuests[QID])
                 and (not WoWPro.QuestLog[QID] or WoWPro:IsQuestFlaggedCompleted(QID)) then
                     WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.")
                     if not WoWPro.nocache[i] then
@@ -356,7 +358,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
 					end
                 end
                 -- Quest Accepts --
-                if WoWPro.newQuest == QID and action == "A" and not completion then
+                if (newQuests[QID] or WoWPro.newQuest == QID) and action == "A" and not completion then
                     if questLogEntry then
                         WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: Accept")
                         WoWPro.newQuest = nil -- We got it, dont let the recorder get it!
@@ -1106,7 +1108,7 @@ if WoWPro.RETAIL then
 end
 
 WoWPro.RegisterEventHandler("QUEST_LOG_UPDATE", function(event, ...)
-    local delta = WoWPro.PopulateQuestLog()
+    local delta, newQuests, missingQuests = WoWPro.PopulateQuestLog()
     if WoWPro.DEBUG_REPEATABLE then
         WoWPro:dbp("QUEST_LOG_UPDATE: delta = %d", delta)
     end
@@ -1120,7 +1122,7 @@ WoWPro.RegisterEventHandler("QUEST_LOG_UPDATE", function(event, ...)
         return
     end
     if WoWPro.Ready(event) then
-        WoWPro:AutoCompleteQuestUpdate(nil)
+        WoWPro:AutoCompleteQuestUpdate(nil, newQuests, missingQuests)
         WoWPro:UpdateGuide(event)
         if WoWProCharDB.AutoSelect and delta == 1 then
         -- OK, now get the next quest if QuestCount is set

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -351,6 +351,8 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     WoWPro:UpdateGuide("ACQU: Abandoned Quest")
                 end
 
+                local questLogEntry = WoWPro.QuestLog[QID]
+
                 -- Quest AutoComplete --
                 if questComplete and (action == "A" or action == "C" or action == "T" or action == "N") and QID == questComplete then
 					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
@@ -361,8 +363,12 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                 end
                 -- Quest Accepts --
                 if WoWPro.newQuest == QID and action == "A" and not completion then
-                    WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: Accept")
-                    WoWPro.newQuest = nil -- We got it, dont let the recorder get it!
+                    if questLogEntry then
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: Accept")
+                        WoWPro.newQuest = nil -- We got it, dont let the recorder get it!
+                    else
+                        WoWPro:dbp("AutoCompleteQuestUpdate: newQuest %d not found in QuestLog, skipping Accept auto-complete.", QID)
+                    end
                 end
 
                 -- Quest Completion via QuestLog--

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -337,32 +337,50 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete, newQuests, missingQuests)
                 QID = tonumber(QID)
 
                 -- Quest Turn-Ins --
-                if WoWPro.CompletingQuest and action == "T" and not completion and (missingQuests[QID] or WoWPro.missingQuests[QID])
+                -- Legacy fallback path (commented out):
+                -- if WoWPro.CompletingQuest and action == "T" and not completion and (missingQuests[QID] or WoWPro.missingQuests[QID])
+                -- and (not WoWPro.QuestLog[QID] or WoWPro:IsQuestFlaggedCompleted(QID)) then
+                --     WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.")
+                --     if not WoWPro.nocache[i] then
+                --         WoWProCharDB.completedQIDs[QID] = true
+                --     end
+                --     WoWPro.CompletingQuest = false
+                --     WoWPro.missingQuests[QID] = nil  -- We got it, dont let the recorder get it!
+                -- end
+                if WoWPro.CompletingQuest and action == "T" and not completion and missingQuests[QID]
                 and (not WoWPro.QuestLog[QID] or WoWPro:IsQuestFlaggedCompleted(QID)) then
                     WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.")
                     if not WoWPro.nocache[i] then
                         WoWProCharDB.completedQIDs[QID] = true
                     end
                     WoWPro.CompletingQuest = false
-                    WoWPro.missingQuests[QID] = nil  -- We got it, dont let the recorder get it!
+                    -- WoWPro.missingQuests[QID] = nil  -- Legacy cleanup disabled for explicit diff mode
                 end
 
                 local questLogEntry = WoWPro.QuestLog[QID]
 
                 -- Quest AutoComplete --
                 if questComplete and (action == "A" or action == "C" or action == "T" or action == "N") and QID == questComplete then
-					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
-						return
-					else
-						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
-					end
+                    if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
+                        return
+                    else
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
+                    end
                 end
                 -- Quest Accepts --
-                if (newQuests[QID] or WoWPro.newQuest == QID) and action == "A" and not completion then
+                -- Legacy fallback path (commented out):
+                -- if (newQuests[QID] or WoWPro.newQuest == QID) and action == "A" and not completion then
+                --     if questLogEntry then
+                --         WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: Accept")
+                --         WoWPro.newQuest = nil -- We got it, dont let the recorder get it!
+                --     else
+                --         WoWPro:dbp("AutoCompleteQuestUpdate: newQuest %d not found in QuestLog, skipping Accept auto-complete.", QID)
+                --     end
+                -- end
+                if newQuests[QID] and action == "A" and not completion then
                     if questLogEntry then
                         WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: Accept")
-                        WoWPro.newQuest = nil -- We got it, dont let the recorder get it!
-                    else
+                        -- WoWPro.newQuest = nil -- Legacy cleanup disabled for explicit diff mode
                         WoWPro:dbp("AutoCompleteQuestUpdate: newQuest %d not found in QuestLog, skipping Accept auto-complete.", QID)
                     end
                 end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -345,13 +345,6 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     WoWPro.missingQuests[QID] = nil  -- We got it, dont let the recorder get it!
                 end
 
-                -- Abandoned Quests --
-                if not WoWPro.CompletingQuest and ( action == "A" or action == "C" )
-                and completion and WoWPro.missingQuest == QID then
-                    WoWProCharDB.Guide[GID].completion[i] = nil
-                    WoWPro:UpdateGuide("ACQU: Abandoned Quest")
-                end
-
                 local questLogEntry = WoWPro.QuestLog[QID]
 
                 -- Quest AutoComplete --

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -335,13 +335,14 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                 QID = tonumber(QID)
 
                 -- Quest Turn-Ins --
-                if WoWPro.CompletingQuest and action == "T" and not completion and WoWPro.missingQuest == QID then
+                if WoWPro.CompletingQuest and action == "T" and not completion and WoWPro.missingQuests[QID]
+                and (not WoWPro.QuestLog[QID] or WoWPro:IsQuestFlaggedCompleted(QID)) then
                     WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.")
                     if not WoWPro.nocache[i] then
                         WoWProCharDB.completedQIDs[QID] = true
                     end
                     WoWPro.CompletingQuest = false
-                    WoWPro.missingQuest = nil  -- We got it, dont let the recorder get it!
+                    WoWPro.missingQuests[QID] = nil  -- We got it, dont let the recorder get it!
                 end
 
                 -- Abandoned Quests --

--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -277,27 +277,6 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
             WoWPro.Recorder.AddStep(stepInfo)
             WoWPro:AutoCompleteQuestUpdate()
 
-        elseif WoWPro.missingQuest and WoWPro.CompletingQuest then
-            local questInfo = WoWPro.oldQuests[WoWPro.missingQuest]
-            local stepInfo = {
-                action = "T",
-                step = questInfo.title,
-                QID = WoWPro.missingQuest,
-                map = mapxy,
-                zone = zonetag,
-                class = checkClassQuest(WoWPro.missingQuest,WoWPro.oldQuests)
-            }
-			if WoWPro.Recorder.PREquest and WoWPro.Recorder.PrevStep == "T" then
-				WoWPro.Recorder.PREquest = WoWPro.Recorder.PREquest .. "&" .. WoWPro.missingQuest
-			else
-				WoWPro.Recorder.PREquest = WoWPro.missingQuest
-			end
-			WoWPro.Recorder.PrevStep = "T"
-            if targetName then stepInfo.note = "To "..targetName.."." end
-            WoWPro.Recorder:dbp("Turning in quest "..stepInfo.QID)
-            WoWPro.Recorder.AddStep(stepInfo)
-            WoWPro:AutoCompleteQuestUpdate()
-
         else
             WoWPro.Recorder:dbp("Got PQLU and looking for changed quest status")
             for QID, questInfo in pairs(WoWPro.QuestLog) do


### PR DESCRIPTION
### Bug explanation
1. A step false auto-complete
    - A step completion was being triggered and decided by WoWPro.newQuest alone.
    - That signal is only a “new quest seen” hint from the log scan, not definitive proof the accept step was actually matched and active.
    - As a result, an A step could auto-complete prematurely.

2. T step missingQuest scalar bug
    - WoWPro.missingQuest was a single retained QID.
    - that scalar could be overwritten or stale across quest-log changes.
    - as a result, turn-in completion could use the wrong missing QID or lose the correct one.

### TL;DR: 
- A step fix: require the quest to actually exist in WoWPro.QuestLog before auto-completing on newQuest
- T step fix: replace the stale single WoWPro.missingQuest scalar with QID-specific WoWPro.missingQuests
    - **Result**: turn-in completion now matches exact missing quest IDs and avoids stale/mismatched T auto-complete state

### What changed
1. **A step fix**
    - WoWPro.newQuest is still used as the initial match signal.
    - But accept auto-complete now also requires that WoWPro.QuestLog[QID] exists.
    - newQuest remains as a trigger, not the final decision.
2. **T step fix**
 - converted missingQuest from a scalar into QID-specific missing-quest tracking
 - PopulateQuestLog() now records WoWPro.missingQuests[QID] = true
 - AutoCompleteQuestUpdate() now only completes a T step when the exact missing QID matches
 - the matched missing QID is cleared immediately after use
### Why it works
- the A step fix prevents premature completion from newQuest alone
- the T step fix prevents stale scalar missingQuest state from mis-matching later turn-ins 
    - (I did ask a lot of questions as to why this was necessary)

_**Written with help/guidance from Raptor mini AI**_