### PR TITLE
Fix sticky boundary logic for S!US steps

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1150,6 +1150,9 @@ function WoWPro:RowUpdate(offset)
     -- Now sort: stickies first, then regular
     local completion = WoWProCharDB.Guide[GID].completion
     local stickyBoundary = WoWPro.ActiveStep or k
+    if WoWPro.ActiveStep and k < WoWPro.ActiveStep then
+        stickyBoundary = k
+    end
     local stickySteps = {}
     local regularSteps = {}
     for _, stepIdx in ipairs(allSteps) do
@@ -1164,16 +1167,14 @@ function WoWPro:RowUpdate(offset)
                 local available = WoWPro.available and WoWPro.available[stepIdx]
                 local activeReq = WoWPro.active and WoWPro.active[stepIdx]
 
-                local isSUS = WoWPro.sticky[stepIdx] and WoWPro.unsticky[stepIdx]
-                -- Never show sticky steps that are beyond current progression (except S!US, which stays visible until its condition completes)
-                if not isSUS and stepIdx > stickyBoundary then
+                -- Never show sticky steps that are after the current active step
+                if stepIdx > stickyBoundary then
                     showSticky = false
 
                 -- Respect AVAILABLE/ACTIVE tags for sticky visibility (filters, not triggers)
-                -- S!US should always show until completion, regardless of these filters
-                elseif not isSUS and available and not WoWPro.QuestAvailable(available, false, "AVAILABLE") then
+                elseif available and not WoWPro.QuestAvailable(available, false, "AVAILABLE") then
                     showSticky = false
-                elseif not isSUS and activeReq and not WoWPro:QIDsInTableLogical(activeReq, WoWPro.QuestLog) then
+                elseif activeReq and not WoWPro:QIDsInTableLogical(activeReq, WoWPro.QuestLog) then
                     showSticky = false
                 -- For C steps with QID and QO, check if specific objective is incomplete
                 elseif action == "C" and QID and questtext then
@@ -1212,8 +1213,7 @@ function WoWPro:RowUpdate(offset)
                     end
                 -- For other sticky types, show if we've reached that step
                 else
-                    -- S!US steps should remain visible while incomplete, even if they are past the current active step
-                    if isSUS or stepIdx <= k then
+                    if stepIdx <= k then
                         showSticky = true
                     end
                 end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1149,6 +1149,8 @@ function WoWPro:RowUpdate(offset)
 
     -- Now sort: stickies first, then regular
     local completion = WoWProCharDB.Guide[GID].completion
+    -- Never show sticky steps that are after the current active step.
+    -- If the row list starts before the active step, keep the boundary at ActiveStep.
     local stickyBoundary = WoWPro.ActiveStep or k
     local stickySteps = {}
     local regularSteps = {}
@@ -1205,12 +1207,12 @@ function WoWPro:RowUpdate(offset)
                     end
                 -- For C steps without QID (loot collection), only show if we've reached that step
                 elseif action == "C" and not QID then
-                    if stepIdx <= k then
+                    if stepIdx <= stickyBoundary then
                         showSticky = true
                     end
                 -- For other sticky types, show if we've reached that step
                 else
-                    if stepIdx <= k then
+                    if stepIdx <= stickyBoundary then
                         showSticky = true
                     end
                 end
@@ -4220,6 +4222,7 @@ end
 
 WoWPro.QuestLog = {}
 WoWPro.FauxQuestLog = {}
+WoWPro.missingQuests = {}
 
 local function  tablecopy(orig)
     local  copy = {}
@@ -4291,7 +4294,10 @@ function WoWPro.PopulateQuestLog()
         WoWPro.oldQuests = WoWPro.QuestLog or {}
         WoWPro.inhibit_oldQuests_update = true
     end
-    WoWPro.newQuest, WoWPro.missingQuest = false, false
+    local newQuests = {}
+    local missingQuests = {}
+    WoWPro.newQuest = false
+    WoWPro.missingQuests = missingQuests
 
     -- Generating the Quest Log table --
     WoWPro.QuestLog = tablecopy(WoWPro.FauxQuestLog) -- Reinitiallizing the Quest Log table
@@ -4385,6 +4391,7 @@ function WoWPro.PopulateQuestLog()
         for QID, questInfo in pairs(WoWPro.QuestLog) do
             if not WoWPro.oldQuests[QID] then
                 WoWPro.newQuest = QID
+                newQuests[QID] = true
                 WoWPro:print("New Quest %s: [%s]", tostring(QID), questInfo.title)
                 delta = delta + 1
                 -- Is this an auto-switch quest?
@@ -4396,14 +4403,13 @@ function WoWPro.PopulateQuestLog()
         end
     end
 
-    -- Finding WoWPro.missingQuest --
+    -- Finding missing quests --
     for QID, oldQuestInfo in pairs(WoWPro.oldQuests) do
         if not WoWPro.QuestLog[QID] then
+            missingQuests[QID] = true
             if WoWPro:IsQuestFlaggedCompleted(QID) then
-                WoWPro.missingQuest = QID
                 WoWPro:print("Completed Quest: %d [%s]", QID, tostring(oldQuestInfo.title))
             else
-                WoWPro.missingQuest = QID
                 WoWPro:print("Missing Quest: %d [%s]", QID, tostring(oldQuestInfo.title))
             end
             delta = delta + 1
@@ -4444,7 +4450,7 @@ function WoWPro.PopulateQuestLog()
     -- Stop Tracking the QuestLogs for debugging for Emmaleah
     WoWProDB.char.Emmaleah = nil
     WoWPro:SendMessage("WoWPro_PostQuestLogUpdate")
-    return delta
+    return delta, newQuests, missingQuests
 end
 
 function WoWPro.PostQuestLogUpdate()

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1150,9 +1150,6 @@ function WoWPro:RowUpdate(offset)
     -- Now sort: stickies first, then regular
     local completion = WoWProCharDB.Guide[GID].completion
     local stickyBoundary = WoWPro.ActiveStep or k
-    if WoWPro.ActiveStep and k < WoWPro.ActiveStep then
-        stickyBoundary = k
-    end
     local stickySteps = {}
     local regularSteps = {}
     for _, stepIdx in ipairs(allSteps) do


### PR DESCRIPTION
### The Bug
- The sticky boundary was being calculated from `WoWPro.ActiveStep` by default.
- When the visible row block started earlier than the current active step (`k < WoWPro.ActiveStep`), the display logic still used `ActiveStep` as the cutoff.
- That meant sticky rows could be considered eligible too early, before the guide had actually reached the visible start row.
- The fix makes the boundary use `k` when `k` is earlier than `ActiveStep`, so sticky visibility is anchored to the current visible start instead of the later active step.

**The bug was not an exception in `S!US` handling.**
- It was in the sticky display filter inside `WoWPro:RowUpdate()`.
- When the visible row window started before `WoWPro.ActiveStep`, the code still used `ActiveStep` as the sticky cutoff.
- That made sticky rows appear too early, including `S!US` steps, because visibility was being allowed based on a later step index instead of the current visible start.

So the fix is about the boundary used to decide whether a sticky step is allowed to show, not about `S!US` parsing or the exception logic itself.

### Why only `S!US` was noticeable
- S!US is a special case: the first part is a sticky `S` step and the second part is an unsticky US step.
- The bug was in the sticky visibility filter for sticky steps, especially for `C`-type stickies with quest objectives.
- Normal `S` steps usually only show when the guide has reached them and they don’t have the paired `US` activation/completion handshake, so they did not trigger the visible bug as clearly.
- `S!US` steps are more sensitive because:
    - the `S` part is sticky,
    - the `US` part is hidden until that `S` part is completed,
    - and the boundary logic decided whether a sticky step was “after the current active step.”
- That made the `S` half of an `S!US` pair appear too early, while plain `S` steps stayed within normal sticky visibility rules.