### PR TITLE
Simplify Search Even More

### DIFF
--- a/WoWPro/WoWPro_GuideList.lua
+++ b/WoWPro/WoWPro_GuideList.lua
@@ -94,11 +94,7 @@ function GuideListMixin:GuideMatchesSearch(guide, filterText)
         end
     end
 
-    local guideData = guide.guide or {}
-    return GuideFieldMatches(guide.GID, filterText)
-        or GuideFieldMatches(guideData.name, filterText)
-        or GuideFieldMatches(guideData.zone, filterText)
-        or GuideFieldMatches(guideData.guidetype, filterText)
+        return false
 end
 
 function GuideListMixin:ApplySearchFilter()


### PR DESCRIPTION
## Summary

This changes the guide list search so it no longer matches hidden guide metadata.

Previously, the search could return rows that did not appear to match the text shown in the list because it also searched internal fields such as guide ID, internal name, zone, and guide type. That made results feel inconsistent from the UI.

## What changed

- Removed the fallback search against hidden/internal guide fields
- Kept search limited to the values shown in the active visible columns
- Preserved the existing substring matching behavior for visible column values

## Result

Search results now align with what the player can actually see in the guide list, which makes filtering more predictable and easier to understand.

## Example

Before:
- Searching for `za` could return rows like `Goblin: Intro` due to hidden metadata matches

After:
- Searching for `za` only returns rows where one of the visible columns contains `za`

## Notes

This does not change substring matching behavior within visible columns. For example, a search like `he` can still match `T**he** Burning Crusade` in the `Content` column.