### PR TITLE
Fix some bugs

### DIFF
--- a/WoWPro/WoWPro_Zones.lua
+++ b/WoWPro/WoWPro_Zones.lua
@@ -52,7 +52,7 @@ end
 function WoWPro.DefineZone3(mapId, zone, mapType, parent_map, group_id, ... )
     if WoWPro.Client ~= 3 then return end
     if WoWPro.Zone2MapID[zone] then
-        WoWPro:dbp("DupCheck(): DefineZone2(%q) is overriding map %d", zone, WoWPro.Zone2MapID[zone])
+        WoWPro:dbp("DupCheck(): DefineZone3(%q) is overriding map %d", zone, WoWPro.Zone2MapID[zone])
     end
     WoWPro.MapInfo[mapId] = {mapID=mapId, name=zone, mapType=mapType, parent_map=parent_map, group_id=group_id, children={...}}
     WoWPro.Zone2MapID[zone] = mapId
@@ -61,7 +61,7 @@ end
 function WoWPro.DefineZone4(mapId, zone, mapType, parent_map, group_id, ... )
     if WoWPro.Client ~= 4 then return end
     if WoWPro.Zone2MapID[zone] then
-        WoWPro:dbp("DupCheck(): DefineZone2(%q) is overriding map %d", zone, WoWPro.Zone2MapID[zone])
+        WoWPro:dbp("DupCheck(): DefineZone4(%q) is overriding map %d", zone, WoWPro.Zone2MapID[zone])
     end
     WoWPro.MapInfo[mapId] = {mapID=mapId, name=zone, mapType=mapType, parent_map=parent_map, group_id=group_id, children={...}}
     WoWPro.Zone2MapID[zone] = mapId
@@ -70,7 +70,7 @@ end
 function WoWPro.DefineZone5(mapId, zone, mapType, parent_map, group_id, ... )
     if WoWPro.Client ~= 5 then return end
     if WoWPro.Zone2MapID[zone] then
-        WoWPro:dbp("DupCheck(): DefineZone2(%q) is overriding map %d", zone, WoWPro.Zone2MapID[zone])
+        WoWPro:dbp("DupCheck(): DefineZone5(%q) is overriding map %d", zone, WoWPro.Zone2MapID[zone])
     end
     WoWPro.MapInfo[mapId] = {mapID=mapId, name=zone, mapType=mapType, parent_map=parent_map, group_id=group_id, children={...}}
     WoWPro.Zone2MapID[zone] = mapId

--- a/WoWPro/WoWPro_Zones.lua
+++ b/WoWPro/WoWPro_Zones.lua
@@ -231,10 +231,6 @@ local function ptable_inner(item)
         tinsert(ptable_buf, ("%q"):format(item))
         return
     end
-    if item_type == "number" then
-        tinsert(ptable_buf, tostring(item))
-        return
-    end
     if item_type == "boolean" then
         tinsert(ptable_buf, tostring(item))
         return


### PR DESCRIPTION
This PR cleans up two low-risk issues in the zone utility code:

Removes an unreachable duplicate number branch from the table pretty-printer in WoWPro_Zones.lua

Fixes misleading duplicate-map debug messages so DefineZone3, DefineZone4, and DefineZone5 log their actual function names in WoWPro_Zones.lua

Why
The pretty-printer had a dead copy/paste branch that could never execute, which added noise and made the type handling harder to read.

The zone registration helpers for client versions 3, 4, and 5 were emitting DefineZone2 in their duplicate override debug output. That did not affect runtime behavior, but it made debugging duplicate zone registrations misleading.

Impact
No intended functional behavior change to map registration
Cleaner and more maintainable type handling in the debug table serializer
More accurate debug output when duplicate zone mappings are detected