### PR TITLE
Recorder Fixes

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -55,9 +55,10 @@ end
 
 function WoWPro.Recorder:OnDisable()
     -- Unregistering Recorder Module Events --
-    local events = {}
-    for _, event in ipairs(events) do
-        WoWPro.GuideFrame:UnregisterEvent(event)
+    if WoWPro.RecorderFrame and WoWPro.Recorder.events then
+        for _, event in ipairs(WoWPro.Recorder.events) do
+            WoWPro.RecorderFrame:UnregisterEvent(event)
+        end
     end
 end
 

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -306,7 +306,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                     values = function()
                         local questList = {}
                         for QID, info in pairs(WoWPro.QuestLog) do
-                            tinsert(questList, QID, info.title)
+                            questList[QID] = info.title
                         end
                         return questList
                     end,
@@ -568,7 +568,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                         if WoWPro.Recorder.QIDtoAdd and not WoWPro.Recorder.stepInfo.use then
                             WoWPro.Recorder.stepInfo.use = WoWPro.QuestLog[WoWPro.Recorder.QIDtoAdd].use
                             return WoWPro.QuestLog[WoWPro.Recorder.QIDtoAdd].use
-                        else return WoWPro.Recorder.stepInfo.optional end
+                        else return WoWPro.Recorder.stepInfo.use end
                     end,
                     set = function(info,val)
                         if val == "" then val = nil end
@@ -673,7 +673,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                         WoWPro.Recorder.AddStep(WoWPro.Recorder.stepInfo)
                         WoWPro.Recorder.stepInfo = {}
                         WoWPro.Recorder.QIDtoAdd = nil
-                        WoWPro.Recorder.questtextset = true
+                        WoWPro.Recorder.questtextset = nil
                         dialog:Close("WoWPro Recorder - Add - Edit Step");
                     end,
                 },


### PR DESCRIPTION
Fix four bugs in WoWPro_Recorder

- OnDisable() was unregistering events from the wrong frame (GuideFrame) using an empty local list; now correctly unregisters WoWPro.Recorder.events from WoWPro.RecorderFrame 
- Quest picker in Add Step dialog used tinsert(questList, QID, info.title) which silently fails for sparse/high quest IDs; changed to questList[QID] = info.title
-  "Useable Item ID" field getter fell back to returning stepInfo.optional instead of stepInfo.use (copy/paste error)
-  After registering a step via Add Step, questtextset was set to true instead of nil, blocking objective auto-prefill on subsequent adds