### PR TITLE
Few More Recorder Fixes

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -233,7 +233,7 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
                 zone = zonetag
             }
             if targetName then stepInfo.note = "At "..targetName.."." end
-            WoWPro.Recorder:dbp("Adding get FP ".._G.GetSubZoneText() or _G.GetZoneText())
+            WoWPro.Recorder:dbp("Adding get FP "..(_G.GetSubZoneText() or _G.GetZoneText()))
             WoWPro.Recorder.AddStep(stepInfo)
             WoWPro:AutoCompleteGetFP(event, ...)
         end

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -536,7 +536,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                         if WoWPro.Recorder.QIDtoAdd and WoWPro.QuestLog[WoWPro.Recorder.QIDtoAdd].leaderBoard then
                             local text = ""
                             for i,objective in pairs(WoWPro.QuestLog[WoWPro.Recorder.QIDtoAdd].leaderBoard) do
-                                if i== 1 then text = objective else text = (";"):join(text, objective) end
+                                if i== 1 then text = objective else text = text .. ";" .. objective end
                             end
                             WoWPro.Recorder.stepInfo.questtext = text
                             return text


### PR DESCRIPTION
Fix(recorder): prevent runtime errors in objective join and FP debug text


- replace invalid string join call in recorder objective aggregation
- Use safe string concatenation for quest objectives with semicolon delimiter
- Fix operator precedence in FP debug logging to avoid nil concatenation


- Preserve existing behavior while preventing two recorder runtime crashes