### PR TITLE
Recorder Improvements (Potential?)

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -29,12 +29,11 @@ function WoWPro.Recorder:OnInitialize()
 end
 
 function WoWPro.Recorder:OnEnable()
-    if WoWProCharDB then
-        if WoWProCharDB.Advanced == nil then
-            WoWProCharDB.Advanced = true
-        end
-        WoWPro.Recorder.Advanced = WoWProCharDB.Advanced
+    WoWProCharDB = WoWProCharDB or {}
+    if WoWProCharDB.Advanced == nil then
+        WoWProCharDB.Advanced = WoWPro.Recorder.Advanced
     end
+    WoWPro.Recorder.Advanced = WoWProCharDB.Advanced and true or false
     -- Set LoadingGuide flag to prevent quest recording during initialization
     WoWPro.Recorder.LoadingGuide = true
 
@@ -66,7 +65,7 @@ function WoWPro.Recorder:OnDisable()
 end
 
 function WoWPro.Recorder:OnUIReloaded()
-    if WoWProCharDB.Advanced then
+    if WoWPro.Recorder.Advanced then
         WoWPro.RecorderFrame:SetWidth(350)
         WoWPro.MainFrame:SetWidth(350)
     else
@@ -76,11 +75,9 @@ function WoWPro.Recorder:OnUIReloaded()
 end
 
 function WoWPro.Recorder:ToggleAdvanced()
-    if WoWProCharDB.Advanced then
-        WoWProCharDB.Advanced = false
-    else
-        WoWProCharDB.Advanced = true
-    end
+    WoWProCharDB = WoWProCharDB or {}
+    WoWProCharDB.Advanced = not (WoWProCharDB.Advanced == true)
+    WoWPro.Recorder.Advanced = WoWProCharDB.Advanced
     _G.ReloadUI();
 end
 

--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -14,7 +14,7 @@ WoWPro:Embed(WoWPro.Recorder)
 WoWPro.Recorder.Version = WoWPro.GetAddOnMetadata("WoWPro_Recorder", "Version")
 WoWPro.Recorder.stepInfo = {}
 WoWPro.Recorder.LoadingGuide = false
-WoWPro.Recorder.Advanced = false
+WoWPro.Recorder.Advanced = true
 WoWPro.Recorder.PREquest = nil
 WoWPro.Recorder.PrevStep = nil
 WoWPro.Recorder.Flights = nil
@@ -29,9 +29,12 @@ function WoWPro.Recorder:OnInitialize()
 end
 
 function WoWPro.Recorder:OnEnable()
-	if WoWProCharDB then
-		WoWPro.Recorder.Advanced = WoWProCharDB.Advanced or false
-	end
+    if WoWProCharDB then
+        if WoWProCharDB.Advanced == nil then
+            WoWProCharDB.Advanced = true
+        end
+        WoWPro.Recorder.Advanced = WoWProCharDB.Advanced
+    end
     -- Set LoadingGuide flag to prevent quest recording during initialization
     WoWPro.Recorder.LoadingGuide = true
 

--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -76,7 +76,7 @@ end
 
 function WoWPro.Recorder:ToggleAdvanced()
     WoWProCharDB = WoWProCharDB or {}
-    WoWProCharDB.Advanced = not (WoWProCharDB.Advanced == true)
+    WoWProCharDB.Advanced = WoWProCharDB.Advanced ~= true
     WoWPro.Recorder.Advanced = WoWProCharDB.Advanced
     _G.ReloadUI();
 end

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -1,6 +1,6 @@
 -- luacheck: globals WoWPro_RecorderDB
 -- luacheck: globals ipairs pairs tinsert
--- luacheck: globals tostring tonumber
+-- luacheck: globals tostring tonumber string table
 
 ------------------------------------------
 --      WoWPro.Recorder_Frames.lua      --

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -744,6 +744,45 @@ function WoWPro.Recorder:CreateRecorderFrame()
                     type = "header",
                     name = "Required Info",
                 },
+                gotostep = {
+                    order = 0.1,
+                    type = "input",
+                    name = "Go To Step:",
+                    desc = "Jump to a step index while staying in the editor.",
+                    width = 1.5,
+                    get = function(info)
+                        local selected = WoWPro.Recorder.SelectedStep or WoWPro.ActiveStep or 1
+                        WoWPro.Recorder.EditGoToStep = WoWPro.Recorder.EditGoToStep or selected
+                        return tostring(WoWPro.Recorder.EditGoToStep)
+                    end,
+                    set = function(info, val)
+                        WoWPro.Recorder.EditGoToStep = tonumber(val)
+                    end,
+                },
+                gotostepbtn = {
+                    order = 0.2,
+                    type = "execute",
+                    name = "Go",
+                    width = 0.5,
+                    func = function(info, val)
+                        local step = tonumber(WoWPro.Recorder.EditGoToStep)
+                        local total = WoWPro.stepcount or 0
+                        if not step then
+                            WoWPro:Error("Please enter a valid step number.")
+                            return
+                        end
+                        if step < 1 or step > total then
+                            WoWPro:Error("Step %d is out of range. Valid range is 1 to %d.", step, total)
+                            return
+                        end
+                        WoWPro.Recorder.SelectedStep = step
+                        WoWPro.GuideOffset = step
+                        if WoWPro.Scrollbar then
+                            WoWPro.Scrollbar:SetValue(step)
+                        end
+                        WoWPro:UpdateGuide("WoWPro.Recorder:EditGoToStep")
+                    end,
+                },
                 action = {
                     order = 1,
                     type = "select",
@@ -1220,15 +1259,13 @@ function WoWPro.Recorder:CreateRecorderFrame()
                     values = function()
                         local infoTable = {}
                         for GID, guideInfo in pairs(WoWPro.Guides) do
-                            if WoWPro_RecorderDB[GID] then
-                                if WoWPro.Recorder.Advanced then
-                                    infoTable[GID] = GID .." "..tostring(guideInfo.zone).." by "..guideInfo.author
-                                    if WoWPro_RecorderDB[GID] then
-                                        infoTable[GID] = "!" .. infoTable[GID]
-                                    end
-                                else
-                                    infoTable[GID] = GID
+                            if WoWPro.Recorder.Advanced then
+                                infoTable[GID] = GID .." "..tostring(guideInfo.zone).." by "..tostring(guideInfo.author)
+                                if WoWPro_RecorderDB and WoWPro_RecorderDB[GID] then
+                                    infoTable[GID] = "!" .. infoTable[GID]
                                 end
+                            else
+                                infoTable[GID] = GID
                             end
                         end
                         return infoTable
@@ -1244,6 +1281,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
             },
         })
         dialog:SetDefaultSize("WoWPro Recorder - Open", 300, 125)
+
     WoWPro.SaveButton = CreateButton("Save", "Click to save the current guide.", WoWPro.OpenButton)
     WoWPro.SaveButton:SetScript("OnMouseUp", function(this, button)
         if button == "LeftButton" then

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -11,6 +11,34 @@ local dialog = _G.LibStub("AceConfigDialog-3.0")
 
 local initSpecs = {}
 
+local function RecorderSelectedOrActiveStep()
+    return WoWPro.Recorder.SelectedStep or WoWPro.ActiveStep or 1
+end
+
+local function BuildCurrentGuideStepList()
+    local total = WoWPro.stepcount or 0
+    local selected = RecorderSelectedOrActiveStep()
+    local lines = {}
+
+    if total < 1 then
+        return "No steps are loaded in the current guide."
+    end
+
+    for index = 1, total do
+        local prefix = "  "
+        local text = WoWPro.EmitSafeStep(index)
+
+        if index == selected then
+            prefix = ">>"
+        end
+
+        text = tostring(text):gsub("[\r\n]+", " ")
+        lines[#lines + 1] = string.format("%s %d. %s", prefix, index, text)
+    end
+
+    return table.concat(lines, "\n")
+end
+
 -- [0] UI Name , [1] UI Desc, [2]UI Var, [3] guide Var, Register ordinal
 initSpecs["Leveling"] = {
     { "GID:", "The ID for this guide.", "GID" , nil},
@@ -735,6 +763,37 @@ function WoWPro.Recorder:CreateRecorderFrame()
         dialog:SetDefaultSize("WoWPro Recorder - Subtract", 300, 200)
 
     WoWPro.EditButton = CreateButton("Edit", "Click to open the step editor for the selected step.", WoWPro.SubtractButton)
+        config:RegisterOptionsTable("WoWPro Recorder - Current Guide Steps", {
+            name = "Current Guide Steps",
+            type = "group",
+            args = {
+                message = {
+                    order = 0,
+                    type = "description",
+                    fontSize = "medium",
+                    name = function()
+                        local guideId = WoWProDB and WoWProDB.char and WoWProDB.char.currentguide or "Unknown"
+                        local total = WoWPro.stepcount or 0
+                        return string.format("Guide: %s\nSteps: %d\nSelected: %d\n", guideId, total, RecorderSelectedOrActiveStep())
+                    end,
+                    width = "full",
+                },
+                steplist = {
+                    order = 1,
+                    type = "input",
+                    multiline = 22,
+                    width = "full",
+                    name = "Step List",
+                    desc = "Full emitted guide lines for the current guide. The selected step is prefixed with >>.",
+                    get = function()
+                        return BuildCurrentGuideStepList()
+                    end,
+                    set = function()
+                    end,
+                },
+            },
+        })
+        dialog:SetDefaultSize("WoWPro Recorder - Current Guide Steps", 900, 560)
         config:RegisterOptionsTable("WoWPro Recorder - Edit", {
             name = "Edit Step",
             type = "group",
@@ -751,7 +810,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                     desc = "Jump to a step index while staying in the editor.",
                     width = 1.5,
                     get = function(info)
-                        local selected = WoWPro.Recorder.SelectedStep or WoWPro.ActiveStep or 1
+                        local selected = RecorderSelectedOrActiveStep()
                         WoWPro.Recorder.EditGoToStep = WoWPro.Recorder.EditGoToStep or selected
                         return tostring(WoWPro.Recorder.EditGoToStep)
                     end,
@@ -781,6 +840,16 @@ function WoWPro.Recorder:CreateRecorderFrame()
                             WoWPro.Scrollbar:SetValue(step)
                         end
                         WoWPro:UpdateGuide("WoWPro.Recorder:EditGoToStep")
+                    end,
+                },
+                showguidesteps = {
+                    order = 0.3,
+                    type = "execute",
+                    name = "Current Guide",
+                    width = 1,
+                    desc = "Open a numbered list of every step in the current guide.",
+                    func = function()
+                        dialog:Open("WoWPro Recorder - Current Guide Steps", WoWPro.DialogFrame)
                     end,
                 },
                 action = {


### PR DESCRIPTION
Feel free to reject or change if needed


Subject:
recorder: default advanced mode and add edit-step jump navigation

Body:

make Advanced mode the default for new users
preserve existing users’ saved Advanced preference (true/false)
add Go To Step controls directly in Edit Step dialog
validate jump range and keep guide viewport/scrollbar synced to selected step

This means you can edit live guides directly in edit step now with a jump to step button :)

All live guides now show when using the open a guide to edit button

<img width="502" height="723" alt="image" src="https://github.com/user-attachments/assets/bb6a03cf-ff8d-4c6f-9fd7-aa587c3d2955" />

When using the go to step option, the step jumps to the step number you input for direct editing

<img width="800" height="759" alt="image" src="https://github.com/user-attachments/assets/50419fcd-8b4c-4128-ae87-1b753f82870d" />

Edited Step

<img width="1569" height="915" alt="Edited Step" src="https://github.com/user-attachments/assets/ca1e1a77-caad-4dbf-8dee-f1c375448dbf" />


Added a 'Current Guide' Button to the edit step screen so you can see the full guide and know which step you wish to work on

<img width="1715" height="760" alt="image" src="https://github.com/user-attachments/assets/955514c1-11a4-4b3f-91b7-c9178192e8d1" />

