### PR TITLE
Update WoWPro_Recorder.lua

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -142,7 +142,7 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
         mapxy = ("%.2f,%.2f"):format(x * 100, y * 100)
     end
 
-    local targetName = _G.GetUnitName("target")
+    local targetName = _G.UnitName and _G.UnitName("target")
     if event == "CHAT_MSG_SYSTEM" then
         WoWPro.Recorder:dbp("CHAT_MSG_SYSTEM detected.")
         local msg = ...


### PR DESCRIPTION
Fix recorder taint from target name lookup

Replace GetUnitName(target) with UnitName(target) in the recorder event handler. 
Avoid Blizzard UnitFrame secret-string compare taint during combat. 
Preserve target-name note recording behavior while preventing the related UI error.