### PR TITLE
Add optional warband quest completion support for guide step filtering

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -318,6 +318,7 @@ local defaults = { profile = {
     checksound = true,
     checksoundfile = 567416, -- MapPing
     rank = 2,
+    useWarbandCompletion = false,
     resize = false,
     autoresize = true,
     numsteps = 1,

--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -367,6 +367,7 @@ function WoWPro:OnInitialize()
     WoWProDB.char = WoWProDB.char or {}
     WoWProCharDB.Guide = WoWProCharDB.Guide or {}
     WoWProCharDB.completedQIDs = WoWProCharDB.completedQIDs or {}
+    WoWProCharDB.completedQIDsWarband = WoWProCharDB.completedQIDsWarband or {}
     WoWProCharDB.skippedQIDs = WoWProCharDB.skippedQIDs or {}
     WoWProDB.profile.position = WoWProDB.profile.position or {"CENTER", "UIParent" , "CENTER", 0, 0}
     WoWProDB.profile.anchorpoint = nil  -- Clean out old setting

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4565,6 +4565,7 @@ end
 function WoWPro:IsQuestFlaggedCompleted(qid,force)
     if qid == "*" then return nil; end
     local QID = tonumber(qid)
+    local includeWarband = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
     if not QID then
         -- is it a QID list?
         local quids = select("#", ("^&"):split(qid))

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4590,7 +4590,7 @@ function WoWPro:IsQuestFlaggedCompleted(qid,force)
     if not WoWProCharDB.completedQIDs then
         WoWProCharDB.completedQIDs = {}
     end
-    if (WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion) and (not WoWProCharDB.completedQIDsWarband) then
+    if not WoWProCharDB.completedQIDsWarband then
         WoWProCharDB.completedQIDsWarband = {}
     end
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4625,14 +4625,14 @@ function WoWPro:IsQuestFlaggedCompleted(qid,force)
     end
     if QID > 0 then
         if is_int(QID) then
-            return questCompleted(QID)
+            return questCompleted(QID, force)
         else
             QID = floor(QID)
             WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]
             return WoWProCharDB.completedQIDs[QID]
         end
     else
-        return not questCompleted(-QID)
+        return not questCompleted(-QID, force)
     end
 end
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2635,7 +2635,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 local numprereqs = select("#", ("&"):split(pre))
                 for j=1,numprereqs do
                     local jprereq = select(numprereqs-j+1, ("&"):split(pre))
-                    if WoWProCharDB.skippedQIDs[tonumber(jprereq)] then
+                    if WoWProCharDB.skippedQIDs[tonumber(jprereq)] and not WoWPro:IsQuestFlaggedCompleted(jprereq, true) then
                         skip = true
                         WoWPro.why[guideIndex] = "NextStep(): Skipping step with skipped prerequisite."
                         WoWPro:dbp("MissingPreReq2(%d)",guideIndex)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4561,6 +4561,21 @@ local function is_int(number)
     return floor(number) == ceil(number)
 end
 
+local function questCompleted(questID, force)
+    local hasCharacterCache = type(WoWProCharDB.completedQIDs[questID]) ~= "nil"
+    local useWarbandCompletion = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
+    local hasWarbandCache = (not useWarbandCompletion) or (type(WoWProCharDB.completedQIDsWarband[questID]) ~= "nil")
+    if not force and hasCharacterCache and hasWarbandCache then
+        return WoWProCharDB.completedQIDs[questID] or (useWarbandCompletion and WoWProCharDB.completedQIDsWarband[questID]) or false
+    end
+
+    WoWProCharDB.completedQIDs[questID] = WoWPro.QuestLog_IsQuestFlaggedCompleted(questID) or false
+    if useWarbandCompletion then
+        WoWProCharDB.completedQIDsWarband[questID] = WoWPro.QuestLog_IsQuestFlaggedCompletedOnAccount(questID) or false
+    end
+    return WoWProCharDB.completedQIDs[questID] or (useWarbandCompletion and WoWProCharDB.completedQIDsWarband[questID]) or false
+end
+
 -- Cached version of function
 function WoWPro:IsQuestFlaggedCompleted(qid,force)
     if qid == "*" then return nil; end
@@ -4594,32 +4609,17 @@ function WoWPro:IsQuestFlaggedCompleted(qid,force)
         WoWProCharDB.completedQIDsWarband = {}
     end
 
-    local function questCompleted(questID)
-        local hasCharacterCache = type(WoWProCharDB.completedQIDs[questID]) ~= "nil"
-        local useWarbandCompletion = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
-        local hasWarbandCache = (not useWarbandCompletion) or (type(WoWProCharDB.completedQIDsWarband[questID]) ~= "nil")
-        if not force and hasCharacterCache and hasWarbandCache then
-            return WoWProCharDB.completedQIDs[questID] or (useWarbandCompletion and WoWProCharDB.completedQIDsWarband[questID]) or false
-        end
-
-        WoWProCharDB.completedQIDs[questID] = WoWPro.QuestLog_IsQuestFlaggedCompleted(questID) or false
-        if useWarbandCompletion then
-            WoWProCharDB.completedQIDsWarband[questID] = WoWPro.QuestLog_IsQuestFlaggedCompletedOnAccount(questID) or false
-        end
-        return WoWProCharDB.completedQIDs[questID] or (useWarbandCompletion and WoWProCharDB.completedQIDsWarband[questID]) or false
-    end
-
     if not force and type(WoWProCharDB.completedQIDs[QID]) ~= "nil" then
         if QID > 0 then
             if is_int(QID) then
-                return questCompleted(QID)
+                return questCompleted(QID, force)
             else
                 QID = floor(QID)
                 WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]
                 return WoWProCharDB.completedQIDs[-QID]
             end
         else
-            local value = questCompleted(-QID)
+            local value = questCompleted(-QID, force)
             return not value
         end
     end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4565,7 +4565,6 @@ end
 function WoWPro:IsQuestFlaggedCompleted(qid,force)
     if qid == "*" then return nil; end
     local QID = tonumber(qid)
-    local includeWarband = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
     if not QID then
         -- is it a QID list?
         local quids = select("#", ("^&"):split(qid))
@@ -4591,31 +4590,53 @@ function WoWPro:IsQuestFlaggedCompleted(qid,force)
     if not WoWProCharDB.completedQIDs then
         WoWProCharDB.completedQIDs = {}
     end
+    if (WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion) and (not WoWProCharDB.completedQIDsWarband) then
+        WoWProCharDB.completedQIDsWarband = {}
+    end
+
+    local function questCompleted(questID)
+        local hasCharacterCache = type(WoWProCharDB.completedQIDs[questID]) ~= "nil"
+        local useWarbandCompletion = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
+        local hasWarbandCache = (not useWarbandCompletion) or (type(WoWProCharDB.completedQIDsWarband[questID]) ~= "nil")
+        if not force and hasCharacterCache and hasWarbandCache then
+            return WoWProCharDB.completedQIDs[questID] or (useWarbandCompletion and WoWProCharDB.completedQIDsWarband[questID]) or false
+        end
+
+        WoWProCharDB.completedQIDs[questID] = WoWPro.QuestLog_IsQuestFlaggedCompleted(questID) or false
+        if useWarbandCompletion then
+            WoWProCharDB.completedQIDsWarband[questID] = WoWPro.QuestLog_IsQuestFlaggedCompletedOnAccount(questID) or false
+        end
+        return WoWProCharDB.completedQIDs[questID] or (useWarbandCompletion and WoWProCharDB.completedQIDsWarband[questID]) or false
+    end
+
     if not force and type(WoWProCharDB.completedQIDs[QID]) ~= "nil" then
         if QID > 0 then
             if is_int(QID) then
-                return WoWProCharDB.completedQIDs[QID]
+                local useWarbandCompletion = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
+                local wbCached = useWarbandCompletion and WoWProCharDB.completedQIDsWarband and WoWProCharDB.completedQIDsWarband[QID]
+                if (not useWarbandCompletion) or type(wbCached) ~= "nil" then
+                    return WoWProCharDB.completedQIDs[QID] or wbCached or false
+                end
             else
                 QID = floor(QID)
                 WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]
                 return WoWProCharDB.completedQIDs[-QID]
             end
         else
-            return not WoWProCharDB.completedQIDs[-QID]
+            local value = questCompleted(-QID)
+            return not value
         end
     end
     if QID > 0 then
         if is_int(QID) then
-            WoWProCharDB.completedQIDs[QID] = WoWPro.QuestLog_IsQuestFlaggedCompleted(QID) or false
-            return WoWProCharDB.completedQIDs[QID]
+            return questCompleted(QID)
         else
             QID = floor(QID)
             WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]
             return WoWProCharDB.completedQIDs[QID]
         end
     else
-        WoWProCharDB.completedQIDs[-QID] = WoWPro.QuestLog_IsQuestFlaggedCompleted(-QID) or false
-        return not WoWProCharDB.completedQIDs[-QID]
+        return not questCompleted(-QID)
     end
 end
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4612,11 +4612,7 @@ function WoWPro:IsQuestFlaggedCompleted(qid,force)
     if not force and type(WoWProCharDB.completedQIDs[QID]) ~= "nil" then
         if QID > 0 then
             if is_int(QID) then
-                local useWarbandCompletion = WoWProDB and WoWProDB.profile and WoWProDB.profile.useWarbandCompletion
-                local wbCached = useWarbandCompletion and WoWProCharDB.completedQIDsWarband and WoWProCharDB.completedQIDsWarband[QID]
-                if (not useWarbandCompletion) or type(wbCached) ~= "nil" then
-                    return WoWProCharDB.completedQIDs[QID] or wbCached or false
-                end
+                return questCompleted(QID)
             else
                 QID = floor(QID)
                 WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -194,6 +194,20 @@ function WoWPro.QuestLog_IsQuestFlaggedCompleted(questID)
     return _G.C_QuestLog.IsQuestFlaggedCompleted(questID)
 end
 
+function WoWPro.QuestLog_IsQuestFlaggedCompletedOnAccount(questID)
+    if not _G.C_QuestLog then
+        return false
+    end
+    if _G.C_QuestLog.IsQuestFlaggedCompletedOnAccount then
+        return _G.C_QuestLog.IsQuestFlaggedCompletedOnAccount(questID)
+    end
+    if _G.C_QuestLog.IsQuestFlaggedCompletedForAccount then
+        return _G.C_QuestLog.IsQuestFlaggedCompletedForAccount(questID)
+    end
+    return false
+end
+
+
 
 --[[ C_SuperTrack ]]--
 function WoWPro.SuperTrack_SetSuperTrackedQuestID(questID)

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -138,6 +138,7 @@ local function createDisplayConfig()
                 type = "toggle",
                 name = L["Use Warband Quest Completion"],
                 desc = L["Treat quests completed by another character in your Warband as completed for step filtering."],
+                hidden = function() return not WoWPro.RETAIL end,
                 get = function(info) return WoWProDB.profile.useWarbandCompletion end,
                 set = function(info,val)
                     WoWProDB.profile.useWarbandCompletion = val

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -133,19 +133,6 @@ local function createDisplayConfig()
                 set = function(info,val) WoWProDB.profile.track = val
                     WoWPro:UpdateGuide("Config: Quest Tracking") end
             },
-                        warbandcompleted = {
-                order = 10.2,
-                type = "toggle",
-                name = L["Use Warband Quest Completion"],
-                desc = L["Treat quests completed by another character in your Warband as completed for step filtering."],
-                hidden = function() return not WoWPro.RETAIL end,
-                get = function(info) return WoWProDB.profile.useWarbandCompletion end,
-                set = function(info,val)
-                    WoWProDB.profile.useWarbandCompletion = val
-                    WoWProCharDB.completedQIDsWarband = {}
-                    WoWPro:UpdateGuide("Config: Use Warband Quest Completion")
-                end
-            },
             showcoords = {
                 order = 11,
                 type = "toggle",
@@ -875,6 +862,19 @@ local function createMainConfig()
                             WoWProCharDB.EnableTreasures = true
                         end
                     end
+            },
+             warbandcompleted = {
+                order = 24.5,
+                type = "toggle",
+                name = L["Use Warband Quest Completion"],
+                desc = L["Treat quests completed by another character in your Warband as completed for step filtering."],
+                hidden = function() return not WoWPro.RETAIL end,
+                get = function(info) return WoWProDB.profile.useWarbandCompletion end,
+                set = function(info,val)
+                    WoWProDB.profile.useWarbandCompletion = val
+                    WoWProCharDB.completedQIDsWarband = {}
+                    WoWPro:UpdateGuide("Config: Use Warband Quest Completion")
+                end
             },
             doDungeons = {
                 order = 25,

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -133,6 +133,19 @@ local function createDisplayConfig()
                 set = function(info,val) WoWProDB.profile.track = val
                     WoWPro:UpdateGuide("Config: Quest Tracking") end
             },
+                        warbandcompleted = {
+                order = 10.2,
+                type = "toggle",
+                name = L["Use Warband Quest Completion"],
+                desc = L["Treat quests completed by another character in your Warband as completed for step filtering."],
+                get = function(info) return WoWProDB.profile.useWarbandCompletion end,
+                set = function(info,val)
+                    WoWProDB.profile.useWarbandCompletion = val
+                    WoWProCharDB.completedQIDs = {}
+                    WoWProCharDB.completedQIDsWarband = {}
+                    WoWPro:UpdateGuide("Config: Use Warband Quest Completion")
+                end
+            },
             showcoords = {
                 order = 11,
                 type = "toggle",

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -142,7 +142,6 @@ local function createDisplayConfig()
                 get = function(info) return WoWProDB.profile.useWarbandCompletion end,
                 set = function(info,val)
                     WoWProDB.profile.useWarbandCompletion = val
-                    WoWProCharDB.completedQIDs = {}
                     WoWProCharDB.completedQIDsWarband = {}
                     WoWPro:UpdateGuide("Config: Use Warband Quest Completion")
                 end


### PR DESCRIPTION
This change adds support for treating warband-completed quests as completed in the guide engine, while keeping existing character-only behavior as the default.

What changed:

Added a compatibility wrapper that checks for available account/warband quest completion APIs and safely falls back when unavailable. 
Updated quest completion caching logic to optionally merge character completion and warband completion.
Added a new profile setting to enable or disable warband quest completion checks. 
Reset relevant completion caches when the setting changes so results update immediately. 
Added a profile default for the new setting, defaulting to disabled for backward compatibility. 

Behavior:

Default behavior is unchanged (character-only completion). 
When enabled, quest completion checks return true if either: the current character completed the quest, or
another character in the warband completed it.
On clients where warband/account APIs are missing, logic safely degrades to character-only completion. 

Why:
Rank remains useful, but newer expansion quest flows are increasingly campaign and account-progress driven. 
This improves post-Shadowlands guide behaviour with a more meaningful completion signal for multi-character players.