### PR TITLE
H step completion and verification check

### DIFF
--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -398,12 +398,23 @@ function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
 
     WoWProCharDB.hearth = loc
     WoWPro:dbp("AutoCompleteSetHearth: hearth bound to [%s] globally via event [%s]", loc, tostring(event))
+    if not WoWPro.rows or not WoWPro.action or not WoWPro.step or not WoWProDB or not WoWProDB.char or not WoWProDB.char.currentguide then
+        return
+    end
+    local currentGuide = WoWProDB.char.currentguide
+    local guideData = WoWProCharDB.Guide and WoWProCharDB.Guide[currentGuide]
+    if not guideData then
+        return
+    end
     for i = 1,15 do
-        local index = WoWPro.rows[i].index
-        if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
-        and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
-            WoWPro:dbp("AutoCompleteSetHearth: completing h-step index %d step [%s] because hearth matches", index, loc)
-            WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate)
+        local row = WoWPro.rows[i]
+        if row and row.index then
+            local index = row.index
+            if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
+            and not guideData.completion[index] then
+                WoWPro:dbp("AutoCompleteSetHearth: completing h-step index %d step [%s] because hearth matches", index, loc)
+                WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate)
+            end
         end
     end
 end

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -396,7 +396,7 @@ function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
         return
     end
 
-    WoWProCharDB.Guide.hearth = loc
+    WoWProCharDB.hearth = loc
     for i = 1,15 do
         local index = WoWPro.rows[i].index
         if WoWPro.action[index] == "h" and WoWPro.step[index] == loc

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -396,7 +396,8 @@ function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
         return
     end
 
-    WoWProCharDB.hearth = loc
+    WoWProDB.char = WoWProDB.char or {}
+    WoWProDB.char.hearth = loc
     WoWPro:dbp("AutoCompleteSetHearth: hearth bound to [%s] globally via event [%s]", loc, tostring(event))
     if not WoWPro.rows or not WoWPro.action or not WoWPro.step or not WoWProDB or not WoWProDB.char or not WoWProDB.char.currentguide then
         return

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -397,10 +397,12 @@ function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
     end
 
     WoWProCharDB.hearth = loc
+    WoWPro:dbp("AutoCompleteSetHearth: hearth bound to [%s] globally via event [%s]", loc, tostring(event))
     for i = 1,15 do
         local index = WoWPro.rows[i].index
         if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
         and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
+            WoWPro:dbp("AutoCompleteSetHearth: completing h-step index %d step [%s] because hearth matches", index, loc)
             WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate)
         end
     end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2090,8 +2090,11 @@ function WoWPro.UpdateGuideReal(From)
     if not module or not module:IsEnabled() then return end
 
     -- Reconcile saved hearth location before selecting active step --
-    if WoWProCharDB.Guide[GID] and WoWProCharDB.Guide[GID].hearth then
-        WoWPro:AutoCompleteSetHearth(nil, WoWProCharDB.Guide[GID].hearth, true)
+    if WoWProCharDB.hearth then
+        WoWPro:AutoCompleteSetHearth(nil, WoWProCharDB.hearth, true)
+    elseif WoWProCharDB.Guide[GID] and WoWProCharDB.Guide[GID].hearth then
+        WoWProCharDB.hearth = WoWProCharDB.Guide[GID].hearth
+        WoWPro:AutoCompleteSetHearth(nil, WoWProCharDB.hearth, true)
     end
 
     -- Finding the active step in the guide --

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2853,6 +2853,8 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 local zonetext, subzonetext = _G.GetZoneText(), _G.GetSubZoneText():trim()
                 if (step == zonetext or step == subzonetext) and ( rowIndex == 1) and not guide.completion[guideIndex] then
                     WoWPro.CompleteStep(guideIndex,"AutoCompleteZoneBroker")
+                    WoWPro:dbp("Step %s [%s/%s] skipped because current zone matches step location",stepAction,step,tostring(QID))
+                    WoWPro.why[guideIndex] = "NextStep(): Skipping travel step because current zone matches current location."
                     skip = true
                     break
                 end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2845,6 +2845,13 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 break
             end
 
+            -- Auto-complete "h" steps if the hearth is already set to that location
+            if stepAction == "h" and WoWProCharDB.hearth and step == WoWProCharDB.hearth then
+                WoWPro.CompleteStep(guideIndex, "AutoCompleteSetHearth", true)
+                skip = true
+                break
+            end
+
             -- Complete Travel steps if we are in the right zone already
             if stepAction == "F" or stepAction == "H" or stepAction == "b" or stepAction == "P" or stepAction == "R" then
                 local zonetext, subzonetext = _G.GetZoneText(), _G.GetSubZoneText():trim()

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2090,8 +2090,8 @@ function WoWPro.UpdateGuideReal(From)
     if not module or not module:IsEnabled() then return end
 
     -- If we already know the current hearth bind, try to auto-complete any matching h step before selecting the active step --
-    if WoWProCharDB.hearth then
-        WoWPro:AutoCompleteSetHearth(nil, WoWProCharDB.hearth, true)
+    if WoWProDB.char and WoWProDB.char.hearth then
+        WoWPro:AutoCompleteSetHearth(nil, WoWProDB.char.hearth, true)
     end
 
     -- Finding the active step in the guide --
@@ -2846,7 +2846,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             end
 
             -- Auto-complete "h" steps if the hearth is already set to that location
-            if stepAction == "h" and WoWProCharDB.hearth and step == WoWProCharDB.hearth then
+            if stepAction == "h" and WoWProDB.char and WoWProDB.char.hearth and step == WoWProDB.char.hearth then
                 WoWPro.CompleteStep(guideIndex, "AutoCompleteSetHearth", true)
                 skip = true
                 break

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2089,11 +2089,8 @@ function WoWPro.UpdateGuideReal(From)
     local module = WoWPro:GetModule(WoWPro.Guides[GID].guidetype)
     if not module or not module:IsEnabled() then return end
 
-    -- Reconcile saved hearth location before selecting active step --
+    -- If we already know the current hearth bind, try to auto-complete any matching h step before selecting the active step --
     if WoWProCharDB.hearth then
-        WoWPro:AutoCompleteSetHearth(nil, WoWProCharDB.hearth, true)
-    elseif WoWProCharDB.Guide[GID] and WoWProCharDB.Guide[GID].hearth then
-        WoWProCharDB.hearth = WoWProCharDB.Guide[GID].hearth
         WoWPro:AutoCompleteSetHearth(nil, WoWProCharDB.hearth, true)
     end
 

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -238,7 +238,7 @@ WoWPro.RegisterEventHandler("ADDON_ACTION_FORBIDDEN", function(event, ...)
 WoWPro.RegisterEventHandler("ADDON_ACTION_BLOCKED", WoWPro.ADDON_ACTION_FORBIDDEN, true)
 
 function WoWPro:InitializeHearthBind()
-    local loc = WoWProCharDB and WoWProCharDB.hearth
+    local loc = WoWProDB.char and WoWProDB.char.hearth
     if not loc or loc == "" or loc == "none" then
         if _G.GetBindLocation then
             loc = _G.GetBindLocation()
@@ -247,8 +247,8 @@ function WoWPro:InitializeHearthBind()
     if not loc or loc == "" or loc == "none" or (_G.issecretvalue and _G.issecretvalue(loc)) then
         return
     end
-    WoWProCharDB = WoWProCharDB or {}
-    WoWProCharDB.hearth = loc
+    WoWProDB.char = WoWProDB.char or {}
+    WoWProDB.char.hearth = loc
     WoWPro:AutoCompleteSetHearth(nil, loc, true)
 end
 

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -237,9 +237,27 @@ WoWPro.RegisterEventHandler("ADDON_ACTION_FORBIDDEN", function(event, ...)
     end, true)
 WoWPro.RegisterEventHandler("ADDON_ACTION_BLOCKED", WoWPro.ADDON_ACTION_FORBIDDEN, true)
 
+function WoWPro:InitializeHearthBind()
+    local loc = WoWProCharDB and WoWProCharDB.hearth
+    if not loc or loc == "" or loc == "none" then
+        if _G.GetBindLocation then
+            loc = _G.GetBindLocation()
+        end
+    end
+    if not loc or loc == "" or loc == "none" or (_G.issecretvalue and _G.issecretvalue(loc)) then
+        return
+    end
+    WoWProCharDB = WoWProCharDB or {}
+    WoWProCharDB.hearth = loc
+    WoWPro:AutoCompleteSetHearth(nil, loc, true)
+end
+
 WoWPro.RegisterEventHandler("SAVED_VARIABLES_TOO_LARGE", function(event) return; end)
 WoWPro.RegisterEventHandler("ADDON_LOADED", function(event) return; end)
-WoWPro.RegisterEventHandler("PLAYER_LOGIN", function(event) return; end)
+WoWPro.RegisterEventHandler("PLAYER_LOGIN", function(event)
+    WoWPro:InitializeHearthBind()
+    return
+end)
 WoWPro.RegisterEventHandler("VARIABLES_LOADED", function(event) return; end)
 
 WoWPro.RegisterEventHandler("SPELLS_CHANGED", function(event)
@@ -254,6 +272,7 @@ WoWPro.RegisterEventHandler("PLAYER_ENTERING_WORLD", function(event, ...)
     WoWPro.LockdownCounter = 5  -- times until release and give up to wait for other addons
     WoWPro.LockdownTimer = 1.5
     WoWPro.AutoHideFrame("|cff33ff33Battleground Exit Auto Show|r: "..event, "INSTANCE")
+    WoWPro:InitializeHearthBind()
     WoWPro:UpdateTradeSkills()
     end, true)
 

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -679,12 +679,12 @@ function WoWPro.RowSizeSet()
             else
                 for j=i,15 do
                     WoWPro.rows[j]:Hide()
-                        if not _G.InCombatLockdown() then
-                            if WoWPro.rows[j].itembutton then WoWPro.rows[j].itembutton:Hide() end
-                            if WoWPro.rows[j].targetbutton then WoWPro.rows[j].targetbutton:Hide() end
-                            if WoWPro.rows[j].jumpbutton then WoWPro.rows[j].jumpbutton:Hide() end
-                            if WoWPro.rows[j].eabutton then WoWPro.rows[j].eabutton:Hide() end
-                        end
+                    if not _G.InCombatLockdown() then
+                        if WoWPro.rows[j].itembutton then WoWPro.rows[j].itembutton:Hide() end
+                        if WoWPro.rows[j].targetbutton then WoWPro.rows[j].targetbutton:Hide() end
+                        if WoWPro.rows[j].jumpbutton then WoWPro.rows[j].jumpbutton:Hide() end
+                        if WoWPro.rows[j].eabutton then WoWPro.rows[j].eabutton:Hide() end
+                    end
                 end
                 break
             end
@@ -694,12 +694,12 @@ function WoWPro.RowSizeSet()
             if totalh > maxh then
                 for j=i,15 do
                     WoWPro.rows[j]:Hide()
-                        if not _G.InCombatLockdown() then
-                            if WoWPro.rows[j].itembutton then WoWPro.rows[j].itembutton:Hide() end
-                            if WoWPro.rows[j].targetbutton then WoWPro.rows[j].targetbutton:Hide() end
-                            if WoWPro.rows[j].jumpbutton then WoWPro.rows[j].jumpbutton:Hide() end
-                            if WoWPro.rows[j].eabutton then WoWPro.rows[j].eabutton:Hide() end
-                        end
+                    if not _G.InCombatLockdown() then
+                        if WoWPro.rows[j].itembutton then WoWPro.rows[j].itembutton:Hide() end
+                        if WoWPro.rows[j].targetbutton then WoWPro.rows[j].targetbutton:Hide() end
+                        if WoWPro.rows[j].jumpbutton then WoWPro.rows[j].jumpbutton:Hide() end
+                        if WoWPro.rows[j].eabutton then WoWPro.rows[j].eabutton:Hide() end
+                    end
                 end
                 break
             else

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -789,7 +789,6 @@ function WoWPro.RowSizeSet()
             local wasClampedToScreen = WoWPro.MainFrame:IsClampedToScreen()
             WoWPro.MainFrame:SetClampedToScreen(false)
             WoWPro.MainFrame:SetHeight(totalh)
-            WoWPro.PaddingSet()
             WoWPro.MainFrame:SetClampedToScreen(wasClampedToScreen)
 
             -- For bottom-anchored frames, re-establish the anchor after resize to ensure bottom doesn't drift

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -789,6 +789,7 @@ function WoWPro.RowSizeSet()
             local wasClampedToScreen = WoWPro.MainFrame:IsClampedToScreen()
             WoWPro.MainFrame:SetClampedToScreen(false)
             WoWPro.MainFrame:SetHeight(totalh)
+            WoWPro.PaddingSet()
             WoWPro.MainFrame:SetClampedToScreen(wasClampedToScreen)
 
             -- For bottom-anchored frames, re-establish the anchor after resize to ensure bottom doesn't drift

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -541,7 +541,6 @@ function WoWPro.RowSizeSet()
     local pad = WoWProDB.profile.pad
     local biggeststep = 0
     local totalh, maxh = 0, WoWPro.GuideFrame:GetHeight()
-    local guideWindowCropped = false
 
     -- Get current expansion anchor (default to TOPLEFT if not set)
     local expansionAnchor = WoWProDB.profile.expansionAnchor or "TOPLEFT"
@@ -693,7 +692,6 @@ function WoWPro.RowSizeSet()
         else
             totalh = totalh + newh
             if totalh > maxh then
-                guideWindowCropped = true
                 for j=i,15 do
                     WoWPro.rows[j]:Hide()
                         if not _G.InCombatLockdown() then
@@ -785,9 +783,6 @@ function WoWPro.RowSizeSet()
             end
 
             -- Clamp calculated height to not exceed screen edge
-            if totalh > maxHeightScreen then
-                guideWindowCropped = true
-            end
             totalh = math.min(totalh, maxHeightScreen)
 
             -- Temporarily disable clamping to allow frame to grow upward for bottom-anchored frames
@@ -821,17 +816,6 @@ function WoWPro.RowSizeSet()
         elseif frameTop and frameTop > screenH and frameBottom then
             local newHeight = math.max(minHeight, screenH - frameBottom)
             WoWPro.MainFrame:SetHeight(newHeight)
-        end
-    end
-
-    if not _G.InCombatLockdown() then
-        if guideWindowCropped then
-            if not WoWPro.CroppedGuideWarning then
-                WoWPro:Print("|cffffff00WoWPro: Screen height limits guide visibility. Enable mouseover notes or reduce displayed rows.|r")
-                WoWPro.CroppedGuideWarning = true
-            end
-        else
-            WoWPro.CroppedGuideWarning = nil
         end
     end
 

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -541,6 +541,7 @@ function WoWPro.RowSizeSet()
     local pad = WoWProDB.profile.pad
     local biggeststep = 0
     local totalh, maxh = 0, WoWPro.GuideFrame:GetHeight()
+    local guideWindowCropped = false
 
     -- Get current expansion anchor (default to TOPLEFT if not set)
     local expansionAnchor = WoWProDB.profile.expansionAnchor or "TOPLEFT"
@@ -692,6 +693,7 @@ function WoWPro.RowSizeSet()
         else
             totalh = totalh + newh
             if totalh > maxh then
+                guideWindowCropped = true
                 for j=i,15 do
                     WoWPro.rows[j]:Hide()
                         if not _G.InCombatLockdown() then
@@ -783,6 +785,9 @@ function WoWPro.RowSizeSet()
             end
 
             -- Clamp calculated height to not exceed screen edge
+            if totalh > maxHeightScreen then
+                guideWindowCropped = true
+            end
             totalh = math.min(totalh, maxHeightScreen)
 
             -- Temporarily disable clamping to allow frame to grow upward for bottom-anchored frames
@@ -816,6 +821,17 @@ function WoWPro.RowSizeSet()
         elseif frameTop and frameTop > screenH and frameBottom then
             local newHeight = math.max(minHeight, screenH - frameBottom)
             WoWPro.MainFrame:SetHeight(newHeight)
+        end
+    end
+
+    if not _G.InCombatLockdown() then
+        if guideWindowCropped then
+            if not WoWPro.CroppedGuideWarning then
+                WoWPro:Print("|cffffff00WoWPro: Screen height limits guide visibility. Enable mouseover notes or reduce displayed rows.|r")
+                WoWPro.CroppedGuideWarning = true
+            end
+        else
+            WoWPro.CroppedGuideWarning = nil
         end
     end
 


### PR DESCRIPTION
_* These changes are based on EventConsolidation_

### What changed
- **WoWPro_Broker.lua**
    - Removed `h` from the `C/T` quest-log gating condition.
    - Kept travel/hearth auto-complete logic separate so h is handled by hearth-specific behavior rather than quest-log checks.
    - Added debug logging and `WoWPro.why[...]` text when a travel step is auto-completed/skipped because the player is already in the matching zone.

- **WoWPro_AutoComplete.lua**
    - Added debug log output when a hearthstone bind is saved.
    - Added debug log output when an h step is auto-completed because the hearth location matches the step.
    - Changed hearth persistence from guide-scoped storage (`WoWProCharDB.Guide.hearth`) to global storage (`WoWProCharDB.hearth`).

### Purpose
- Keep `h` steps from being treated like quest complete/turn-in steps.
- Ensure hearth bind state is global and not guide-specific.
- Improve traceability with explicit debug messages for hearth bind and auto-completion events.

_Written with assistance from AI_