### PR TITLE
Guide frame not behaving

### DIFF
--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -789,6 +789,7 @@ function WoWPro.RowSizeSet()
             local wasClampedToScreen = WoWPro.MainFrame:IsClampedToScreen()
             WoWPro.MainFrame:SetClampedToScreen(false)
             WoWPro.MainFrame:SetHeight(totalh)
+            WoWPro.PaddingSet()
             WoWPro.MainFrame:SetClampedToScreen(wasClampedToScreen)
 
             -- For bottom-anchored frames, re-establish the anchor after resize to ensure bottom doesn't drift

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -541,6 +541,7 @@ function WoWPro.RowSizeSet()
     local pad = WoWProDB.profile.pad
     local biggeststep = 0
     local totalh, maxh = 0, WoWPro.GuideFrame:GetHeight()
+    local guideWindowCropped = false
 
     -- Get current expansion anchor (default to TOPLEFT if not set)
     local expansionAnchor = WoWProDB.profile.expansionAnchor or "TOPLEFT"
@@ -692,6 +693,7 @@ function WoWPro.RowSizeSet()
         else
             totalh = totalh + newh
             if totalh > maxh then
+                guideWindowCropped = true
                 for j=i,15 do
                     WoWPro.rows[j]:Hide()
                         if not _G.InCombatLockdown() then
@@ -783,6 +785,9 @@ function WoWPro.RowSizeSet()
             end
 
             -- Clamp calculated height to not exceed screen edge
+            if totalh > maxHeightScreen then
+                guideWindowCropped = true
+            end
             totalh = math.min(totalh, maxHeightScreen)
 
             -- Temporarily disable clamping to allow frame to grow upward for bottom-anchored frames
@@ -816,6 +821,17 @@ function WoWPro.RowSizeSet()
         elseif frameTop and frameTop > screenH and frameBottom then
             local newHeight = math.max(minHeight, screenH - frameBottom)
             WoWPro.MainFrame:SetHeight(newHeight)
+        end
+    end
+
+    if not _G.InCombatLockdown() then
+        if guideWindowCropped then
+            if not WoWPro.CroppedGuideWarning then
+                WoWPro:Print("|cffffff00WoWPro: Screen height limits guide visibility. Enable mouseover notes or reduce displayed rows.|r")
+                WoWPro.CroppedGuideWarning = true
+            end
+        else
+            WoWPro.CroppedGuideWarning = nil
         end
     end
 


### PR DESCRIPTION
### Fix guide frame layout after auto-resize
**Problem:**
- ` WoWPro.RowSizeSet()` resized `WoWPro.MainFrame` but did not update `WoWPro.GuideFrame`, which let the bottom row draw outside the window border

**Fix:**
- call `WoWPro.PaddingSet()` immediately after `MainFrame:SetHeight(totalh)`

**Why:**
- ensures WoWPro.GuideFrame resizes with WoWPro.MainFrame so the bottom row does not draw outside the window border

### Warn on screen-height clipping
Problem:
- `WoWPro.GuideFrame` can be limited by screen height, causing extra guide rows to be cut off and hidden, and users were not informed.

Fix:
- add guideWindowCropped detection and a one-time warning

Why:
- the warning tells users their only option is to reduce UI space usage (mouseover notes / fewer rows / smaller UI) because you can’t make the screen taller

**_On a side note for authors:_**
We need to keep this in mind when considering visible rows, be they sticky or regular.