### PR TITLE
More Potential Recorder Tweaks

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -52,6 +52,13 @@ function WoWPro.Recorder:OnEnable()
     WoWPro.Recorder:RegisterSavedGuides()
     WoWPro.Recorder.ProcessScenarioStage(nil)
     WoWPro.Recorder:OnUIReloaded()
+    -- Fallback: if no guide is ever loaded, clear LoadingGuide so quest recording isn't permanently blocked
+    _G.C_Timer.After(5, function()
+        if WoWPro.Recorder.LoadingGuide then
+            WoWPro.Recorder.LoadingGuide = false
+            WoWPro.Recorder:dbp("OnEnable fallback: Clearing LoadingGuide flag after 5s")
+        end
+    end)
 end
 
 
@@ -262,6 +269,10 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
 
         if WoWPro.newQuest then
             local questInfo = WoWPro.QuestLog[WoWPro.newQuest]
+            if not questInfo then
+                WoWPro.Recorder:dbp("newQuest %s not found in QuestLog, skipping", tostring(WoWPro.newQuest))
+                return
+            end
             local stepInfo = {
                 action = "A",
                 step = questInfo.title,
@@ -280,6 +291,10 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
 
         elseif WoWPro.missingQuest and WoWPro.CompletingQuest then
             local questInfo = WoWPro.oldQuests[WoWPro.missingQuest]
+            if not questInfo then
+                WoWPro.Recorder:dbp("missingQuest %s not found in oldQuests, skipping", tostring(WoWPro.missingQuest))
+                return
+            end
             local stepInfo = {
                 action = "T",
                 step = questInfo.title,
@@ -402,6 +417,8 @@ function WoWPro.Recorder.PortalStep()
     local GID = WoWProDB.char.currentguide
     if WoWPro.Recorder.status == "STOP" or not WoWPro.Guides[GID] then return end
     WoWPro.Recorder:dbp("Portal Step Requested.")
+    -- Clear any stale pending flag so a new portal can always be recorded
+    WoWPro.Recorder.PortalRecordingPending = nil
 	local x, y = WoWPro:GetPlayerZonePosition()
     local zonetag = WoWPro.GetZoneText()
     if zonetag == WoWPro.Guides[GID].zone then

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -148,23 +148,25 @@ local function CreateInitSpecMenu(module)
             end
 
             local UnitFaction = WoWPro.Faction
+            -- Auto-detect faction from the player (more reliable than manual entry)
             if UnitFaction == "Horde" then
-                WoWPro.Recorder.CurrentGuide["Zone"] = "Orgrimmar"
-                WoWPro.Recorder.CurrentGuide["Faction"] = "Horde"
+                optArgs["faction"] = "Horde"
             else
-                WoWPro.Recorder.CurrentGuide["Zone"] = "Stormwind City"
-                WoWPro.Recorder.CurrentGuide["Faction"] = "Alliance"
+                optArgs["faction"] = "Alliance"
             end
-            WoWPro.Recorder.CurrentGuide["Author"] = "WoWPro Team"
-            WoWPro.Recorder.CurrentGuide["NextGID"] = "ChromieTime"
-            WoWPro.Recorder.CurrentGuide["StartLvl"] = "1"
-            WoWPro.Recorder.CurrentGuide["EndLvl"] = "60"
-            optArgs["zone"] = WoWPro.Recorder.CurrentGuide["Zone"]
-            optArgs["author"] = WoWPro.Recorder.CurrentGuide["Author"]
-            optArgs["nextGID"] = WoWPro.Recorder.CurrentGuide["NextGID"]
-            optArgs["startlevel"] = WoWPro.Recorder.CurrentGuide["StartLvl"]
-            optArgs["endlevel"] = WoWPro.Recorder.CurrentGuide["EndLvl"]
-            optArgs["faction"] = WoWPro.Recorder.CurrentGuide["Faction"]
+            -- Apply defaults only for fields the user left blank
+            if not optArgs["author"] or optArgs["author"] == "" then
+                optArgs["author"] = "WoWPro Team"
+            end
+            if not optArgs["nextGID"] or optArgs["nextGID"] == "" then
+                optArgs["nextGID"] = "ChromieTime"
+            end
+            if not optArgs["startlevel"] or optArgs["startlevel"] == "" then
+                optArgs["startlevel"] = "1"
+            end
+            if not optArgs["endlevel"] or optArgs["endlevel"] == "" then
+                optArgs["endlevel"] = "90"
+            end
 
             WoWPro.Recorder:InitGuide(WoWPro.Recorder.CurrentGuide.GID,WoWPro.Recorder.CurrentGuide.Type, optArgs)
             WoWPro:LoadGuide(WoWPro.Recorder.CurrentGuide.GID);
@@ -294,7 +296,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                         local x, y = WoWPro:GetPlayerZonePosition()
                         local zonetag, note
                         if _G.GetZoneText() ~= WoWPro.Guides[WoWProDB.char.currentguide].zone then zonetag = _G.GetZoneText() else zonetag = nil end
-                        if _G.GetUnitName("target") then note = "At ".._G.GetUnitName("target").."." end
+                        if _G.UnitName("target") then note = "At ".._G.UnitName("target").."." end
                         WoWPro.Recorder.AddStep({
                             action = "r",
                             step = "Repair/Restock",

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -296,7 +296,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                         local x, y = WoWPro:GetPlayerZonePosition()
                         local zonetag, note
                         if _G.GetZoneText() ~= WoWPro.Guides[WoWProDB.char.currentguide].zone then zonetag = _G.GetZoneText() else zonetag = nil end
-                        if _G.UnitName("target") then note = "At ".._G.UnitName("target").."." end
+                        if _G.GetUnitName("target") then note = "At ".._G.GetUnitName("target").."." end
                         WoWPro.Recorder.AddStep({
                             action = "r",
                             step = "Repair/Restock",


### PR DESCRIPTION
fix(Recorder): nil guards, stale flag, LoadingGuide fallback, preserve user input

- Guard against nil questInfo when WoWPro.QuestLog[newQuest] or oldQuests[missingQuest] is missing (race condition crash)
- Clear PortalRecordingPending at the start of PortalStep() so a stale flag from a dropped callback never blocks future portal recording
- Add 5s C_Timer fallback in OnEnable to clear LoadingGuide if PostGuideLoad never fires (no previously saved guide)

- New Guide registration no longer unconditionally overwrites Author, NextGID, StartLvl, and EndLvl with hardcoded values; defaults are applied only when the user left the field blank, and Zone is kept as entered rather than being replaced with Orgrimmar/Stormwind City