### PR TITLE
Update WoWPro_CurrentGuide.lua

### DIFF
--- a/WoWPro/WoWPro_CurrentGuide.lua
+++ b/WoWPro/WoWPro_CurrentGuide.lua
@@ -133,6 +133,7 @@ function WoWPro.UpdateCurrentGuidePanel()
             step = step.." (un-sticky)"
         end
 
+        if step then step = index .. ". " .. step end
         row.step:SetText(step)
         WoWPro.SetActionTexture(row)
 


### PR DESCRIPTION
Displays  the step number in current guide frame for support related issues.


<img width="721" height="567" alt="image" src="https://github.com/user-attachments/assets/645fc3ff-2144-413a-9a5f-eadbe064c432" />
