### PR TITLE
Update WoWPro_Recorder_Frames.lua

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -1270,6 +1270,7 @@ function WoWPro.Recorder:CreateRecorderFrame()
                         if val == "" then val = nil end
                         WoWPro.note[WoWPro.Recorder.SelectedStep] = val
                         WoWPro:UpdateGuide();
+                        WoWPro.Recorder:SaveGuide()
                     end,
                 },
             },

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -1206,6 +1206,8 @@ function WoWPro.Recorder:CreateRecorderFrame()
                                 WoWPro.lootitem[WoWPro.Recorder.SelectedStep][tonumber(itemID)] = tonumber(qty) or 1
                             end
                         end
+                        WoWPro:UpdateGuide();
+                        WoWPro.Recorder:SaveGuide()
                     end,
                 },
                 level = {


### PR DESCRIPTION
fix(Recorder): persist lootitem edits in the Edit Step dialog

The lootitem setter in "WoWPro Recorder - Edit" was updating WoWPro.lootitem but never calling UpdateGuide() or SaveGuide(), so any looted item changes were lost on guide reload. Added the missing calls to match every other field in the same dialog.