### PR TITLE
Fix TitleBar Collapse and Expanded Isssue

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2053,9 +2053,13 @@ function WoWPro.UpdateGuideReal(From)
     end
     WoWPro:dbp("UpdateGuideReal(%s): Running", why)
     if not WoWPro.GuideFrame:IsVisible() then
-        -- Cinematic hides things ...
-        WoWPro:SendMessage("WoWPro_UpdateGuide","UpdateGuideReal()")
+        -- Cinematic hides things (or user collapsed frame with double-click).
+        -- Only re-queue if the user did not intentionally collapse the frame.
+        if not WoWPro.UserCollapsed then
+            WoWPro:SendMessage("WoWPro_UpdateGuide","UpdateGuideReal()")
+        end
         WoWPro:dbp("UpdateGuideReal(): Punting")
+        return
     end
     if not WoWPro.GuideLoaded then
         WoWPro:print("Suppresssed guide update. Guide %s is not loaded yet!",tostring(GID))

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -1730,6 +1730,7 @@ function WoWPro:CreateTitleBar()
         if WoWPro.GuideFrame:IsVisible() then
             if WoWPro.StickyFrame:IsShown() then WoWPro.StickyFrame:Hide(); WoWPro.StickyHide = true end
             WoWPro.GuideFrame:Hide()
+            WoWPro.UserCollapsed = true
             WoWPro.OldHeight = WoWPro.MainFrame:GetHeight()
             WoWPro.MainFrame:StartSizing("TOP")
             WoWPro.MainFrame:SetHeight(this:GetHeight())
@@ -1738,6 +1739,7 @@ function WoWPro:CreateTitleBar()
             WoWPro.AnchorStore("OnDoubleClick1")
         else
             WoWPro.GuideFrame:Show()
+            WoWPro.UserCollapsed = false
             if WoWPro.StickyHide then WoWPro.StickyFrame:Show(); WoWPro.StickyHide = false end
             WoWPro.MainFrame:StartSizing("TOP")
             WoWPro.MainFrame:SetHeight(WoWPro.OldHeight)


### PR DESCRIPTION
When the guide frame was collapsed via double-click, any game event (e.g. player movement) that triggered UpdateGuideReal would fall through without returning, causing autoresize/RowSizeSet to expand MainFrame while GuideFrame remained hidden.

- Add `return` after the punt in UpdateGuideReal when GuideFrame is not visible, so the update exits cleanly instead of running layout
- Add `WoWPro.UserCollapsed` flag set on double-click collapse/expand to suppress re-queuing of guide updates while intentionally collapsed

Please confirm this is the correct fix and Test!