### PR TITLE
Vanilla Horde naming scheme update

### DIFF
--- a/WoWPro_Leveling/Vanilla/Horde/01_12_Hendo_Durotar.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/01_12_Hendo_Durotar.lua
@@ -1,9 +1,9 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-01-12-Hendo-Durotar', 'Leveling', 'Durotar', 'Hendo72', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicDurotar0112', 'Leveling', 'Durotar', 'WoWPro Team', 'Horde', 1)
 WoWPro:GuideLevels(guide,1, 12)
-WoWPro:GuideNextGuide(guide, 'Classic-12-15-Hendo-Silverpine-Forest')
+WoWPro:GuideNextGuide(guide, 'ClassicSilverpineForest1215')
 WoWPro:GuideSteps(guide, function() return
 [[
 

--- a/WoWPro_Leveling/Vanilla/Horde/01_12_Hendo_Mulgore.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/01_12_Hendo_Mulgore.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-01-12-Hendo-Mulgore', "Leveling", 'Mulgore', 'Hendo72', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicMulgore0112', "Leveling", 'Mulgore', 'WoWPro Team', 'Horde', 1)
 WoWPro:GuideName(guide, 'Mulgore')
 WoWPro:GuideLevels(guide, 1, 12, 2)
-WoWPro:GuideNextGuide(guide, 'Classic-12-15-Hendo-Silverpine-Forest')
+WoWPro:GuideNextGuide(guide, 'ClassicSilverpineForest1215')
 WoWPro:GuideSteps(guide, function() return [[
 
 A The Hunt Begins|QID|747|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|

--- a/WoWPro_Leveling/Vanilla/Horde/01_12_Hendo_Tirisfal_Glades.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/01_12_Hendo_Tirisfal_Glades.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-01-12-Hendo-Tirisfal-Glades', "Leveling", 'Tirisfal Glades', 'Hendo72', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicTirisfalGlades0112', "Leveling", 'Tirisfal Glades', 'Hendo72', 'Horde', 1)
 WoWPro:GuideName(guide, 'Tirisfal Glades')
 WoWPro:GuideLevels(guide, 1, 10, 2)
-WoWPro:GuideNextGuide(guide, 'Classic-12-15-Hendo-Silverpine-Forest')
+WoWPro:GuideNextGuide(guide, 'ClassicSilverpineForest1215')
 WoWPro:GuideSteps(guide, function()
 return [[
 

--- a/WoWPro_Leveling/Vanilla/Horde/12_15_Hendo_Silverpine_Forest.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/12_15_Hendo_Silverpine_Forest.lua
@@ -1,9 +1,9 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-12-15-Hendo-Silverpine-Forest', 'Leveling', 'Silverpine Forest', 'Hendo72', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicSilverpineForest1215', 'Leveling', 'Silverpine Forest', 'Hendo72', 'Horde', 1)
 WoWPro:GuideLevels(guide, 10, 15)
-WoWPro:GuideNextGuide(guide, 'Classic-15-21-Hendo-TheBarrens')
+WoWPro:GuideNextGuide(guide, 'ClassicTheBarrens1521')
 WoWPro:GuideSteps(guide, function() return [[
 
 ; --- Travel to Tirisfal Glades from Orgrimmar

--- a/WoWPro_Leveling/Vanilla/Horde/15_21_Hendo_The_Barrens.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/15_21_Hendo_The_Barrens.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-15-21-Hendo-TheBarrens', 'Leveling', 'The Barrens', 'Hendo72', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicTheBarrens1521', 'Leveling', 'The Barrens', 'Hendo72', 'Horde', 1)
 WoWPro:GuideName(guide, 'The Barrens')
 WoWPro:GuideLevels(guide, 15, 21, 18)
-WoWPro:GuideNextGuide(guide, 'Classic-21-30-Hendo-HordeChapter1')
+WoWPro:GuideNextGuide(guide, 'ClassicHorde2130')
 WoWPro:GuideSteps(guide, function() return [[
 
 ; --- Druid 'Cure Poison' lv 14 class quest

--- a/WoWPro_Leveling/Vanilla/Horde/21_30_Hendo_HordeChapter1.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/21_30_Hendo_HordeChapter1.lua
@@ -1,39 +1,42 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-21-30-Hendo-HordeChapter1', 'Leveling', 'Stonetalon Mountains', 'Hendo', 'Horde',1)
+local guide = WoWPro:RegisterGuide('ClassicHorde2130', 'Leveling', 'Stonetalon Mountains', 'Hendo', 'Horde',1)
 WoWPro:GuideName(guide, 'Horde Chapter 1')
 WoWPro:GuideLevels(guide,21, 30)
-WoWPro:GuideNextGuide(guide, 'Classic-31-40-Hendo-HordeChapter2')
+WoWPro:GuideNextGuide(guide, 'ClassicHorde3140')
 WoWPro:GuideSteps(guide, function()
 return [[
 
 A Boulderslide Ravine|QID|6421|M|47.22,64.05|Z|1442; Stonetalon Mountains|N|From Mor'rogal at his camp just off the Charred Vale path.\n[color=FF0000]NOTE: [/color]The path is in east corner. Look for the sign.|
 h Sun Rock Retreat|ACTIVE|1483|M|47.46,62.13|Z|1442; Stonetalon Mountains|N|Head back down the path to the 'Inn' and set your hearthstone to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]If you're feeling adventurous and impatient, jump of the cliff into the water.|
 R Windshear Crag|ACTIVE|1483|M|53.15,61.61;59.97,71.14|CC|Z|1442; Stonetalon Mountains|N|Follow the road south out of Sun Rock Retreat to Windshear Crag (look for the sign).\n[color=FF0000]NOTE: [/color]If you don't mind a little falling damage, you can get in through the graveyard you pass along the way.|
-T Ziz Fizziks|QID|1483|M|58.99,62.61|Z|1442; Stonetalon Mountains|N|To Ziz Fizziks inside the hut in the SW alcove.|
+T Ziz Fizziks|QID|1483|M|58.99,62.61|Z|1442; Stonetalon Mountains|N|To Ziz Fizziks inside the hut in the SW alcove beneath the graveyard.|
 A Super Reaper 6000|QID|1093|PRE|1483|M|58.99,62.61|Z|1442; Stonetalon Mountains|N|From Ziz Fizziks.|
 C Super Reaper 6000|QID|1093|M|67.25,50.07|Z|1442; Stonetalon Mountains|L|5734|ITEM|5734|N|Venture Co. Operators.\n[color=FF0000]NOTE: [/color]You'll find them around equipment and buildings.|S|
 C Goblin Invaders|QID|1062|QO|1|M|64.94,54.87|Z|1442; Stonetalon Mountains|N|Kill Venture Co. Loggers.\n[color=FF0000]NOTE: [/color]Deforesters and Operators do not count.|S|
 N Lockpicking|ACTIVE|1062&1093|Z|1442; Stonetalon Mountains|N|You'll find Battered Footlockers scattered around the area that you can open for some goodies and a skill point.\nCheck this step off to continue.|C|Rogue|
-R Head into Windshear Crag|QID|1062|M|63.35,57.72|CC|Z|1442; Stonetalon Mountains|N|Head to the deforested area of Windshear Crag.|
-C Super Reaper 6000|QID|1093|M|67.25,50.07|Z|1442; Stonetalon Mountains|L|5734|ITEM|5734|N|Venture Co. Operators.\n[color=FF0000]NOTE: [/color]You'll find them around equipment and buildings.|T|Venture Co. Operator|US|
+R Head into Windshear Crag|ACTIVE|1093|M|63.35,57.72|CC|Z|1442; Stonetalon Mountains|N|Head to the deforested area of Windshear Crag.|
+C Super Reaper 6000|QID|1093|M|67.25,50.07|Z|1442; Stonetalon Mountains|L|5734|ITEM|5734|N|Venture Co. Operators.\n[color=FF0000]NOTE: [/color]You'll find them around equipment and buildings.\nThe Deforesters are casters and they hit hard.|T|Venture Co. Operator|US|
 C Goblin Invaders|QID|1062|QO|1|M|63.36,56.98|Z|1442; Stonetalon Mountains|N|Finish killing Venture Co. Loggers.\n[color=FF0000]NOTE: [/color]Deforesters and Operators do not count.|T|Venture Co. Logger|US|
 T Super Reaper 6000|QID|1093|M|58.99,62.61|Z|1442; Stonetalon Mountains|N|To Ziz Fizziks.|
 A Further Instructions|QID|1094|PRE|1093|M|58.99,62.61|Z|1442; Stonetalon Mountains|N|From Ziz Fizziks.|
 R Webwinder Path|ACTIVE|6421|QO|1|M|59.79,71.19|Z|1442; Stonetalon Mountains|N|Exit Windshear Crag to the main road.|
 A Arachnophobia|QID|6284|M|59.08,75.72|Z|1442; Stonetalon Mountains|N|Follow the road south and get the quest from the Wanted Poster located beside the road.\n[color=FF0000]NOTE: [/color]Strongly recommended only to accept this quest if you are over level or can find a PUG to do this.|
-R Sishir Canyon|ACTIVE|6284|QO|1|M|58.25,75.98|Z|1442; Stonetalon Mountains|N|Head over the hill into Sishir Canyon.|
-C Arachnophobia|QID|6284|M|53.48,74.52|Z|1442; Stonetalon Mountains|L|16192|ITEM|16192|N|Besseleth, a lv 21 Elite mob with multiple spawn points. You'll find her in one of the alcoves along the edge.\n[color=FF0000]NOTE: [/color]It's strongly recommended to only attempt this if you're over level, or you have help to do it.\nSkip this step if you wish to move on.|T|Besseleth|
-R Webwinder Path|ACTIVE|6284|M|58.25,75.98|Z|1442; Stonetalon Mountains|N|Exit Sishir Canyon and head back to the road.|
+R Sishir Canyon|ACTIVE|6284|QO|1|AVAILABLE|1058|M|58.25,75.98|Z|1442; Stonetalon Mountains|N|Head over the hill into Sishir Canyon.|IZ|1442; Stonetalon Mountains|
+C Arachnophobia|QID|6284|M|53.48,74.52|Z|1442; Stonetalon Mountains|L|16192|ITEM|16192|N|Besseleth, a lv 21 Elite mob with multiple spawn points. You'll find her in one of the alcoves along the edge.\n[color=FF0000]NOTE: [/color]It's strongly recommended to only attempt this if you're over level, or you have help to do it.\nSkip this step if you wish to move on.|T|Besseleth|IZ|Sishir Canyon|
+R Webwinder Path|ACTIVE|6284|M|58.25,75.98|Z|1442; Stonetalon Mountains|N|Exit Sishir Canyon and head back to the road.|IZ|Sishir Canyon|
 R Boulderslide Ravine|ACTIVE|6421|QO|1;2|M|66.24,89.37|Z|1442; Stonetalon Mountains|N|Follow the road south.|
 C Boulderslide Ravine|QID|6421|Z|1442; Stonetalon Mountains|L|16581 10|N|Collect Resonite Crystals.|S|
 R Boulderslide Cavern|ACTIVE|6421|M|61.98,93.16|Z|1442; Stonetalon Mountains|N|Make your way to the cave entrance.|
-R Investigate Cave|ACTIVE|6421|QO|2|M|58.95,90.12|Z|1442; Stonetalon Mountains|N|Make your way to the water at the back of the cave to complete this step.\n[color=FF0000]NOTE: [/color]Keep your path clear and watch you don't get overwhelmed.|
+R Investigate Cave|ACTIVE|6421|QO|2|M|58.95,90.12|Z|1442; Stonetalon Mountains|N|Make your way to the water at the back of the cave to complete this step.\n[color=FF0000]NOTE: [/color]Keep your path clear and watch you don't get overwhelmed.|C|-Druid,-Rogue|
+R Investigate Cave|ACTIVE|6421|QO|2|M|58.95,90.12|Z|1442; Stonetalon Mountains|N|Using your Stealth ability, make your way to the water at the back of the cave to complete this step.\n[color=FF0000]NOTE: [/color]Keep your distance from the mobs and or you'll get overwhelmed very quickly if detected.|C|Druid,Rogue|
 ; Level 23
-C Boulderslide Ravine|QID|6421|M|61.72,93.13|Z|1442; Stonetalon Mountains|L|16581 10|N|Finish collecting the Resonite Crystals.\n[color=FF0000]NOTE: [/color]Keep your path clear or you may find yourself overwhelmed very quickly.|US|
-R Webwinder Path|AVAILABLE|1058|M|67.76,86.64|Z|1442; Stonetalon Mountains|N|Exit the cave and make your way back to the road.|
-R Malaka'jin|AVAILABLE|1058|M|71.82,91.70|Z|1442; Stonetalon Mountains|N|Follow the road south to Malaka'jin to see Witch Doctor Jin'Zil.|
+C Boulderslide Ravine|QID|6421|M|61.72,93.13|Z|1442; Stonetalon Mountains|L|16581 10|N|Finish collecting the Resonite Crystals.\n[color=FF0000]NOTE: [/color]Keep your path clear or you may find yourself overwhelmed very quickly.|C|-Druid,-Rogue|US|
+C Boulderslide Ravine|QID|6421|M|61.72,93.13|Z|1442; Stonetalon Mountains|L|16581 10|N|Continuing to use your stealth ability, finish collecting the Resonite Crystals.\n[color=FF0000]NOTE: [/color]Break your stealth only to clear mobs when it's safe to do so or you may find yourself overwhelmed very quickly.|C|Druid,Rogue|US|
+R Webwinder Path|AVAILABLE|1058|M|67.76,86.64|Z|1442; Stonetalon Mountains|N|Exit the cave and make your way back to the road.|C|-Druid,-Rogue|
+R Webwinder Path|AVAILABLE|1058|M|67.76,86.64|Z|1442; Stonetalon Mountains|N|Use your stealth ability to exit the cave and make your way back to the road.|C|Druid,Rogue|
+R Malaka'jin|AVAILABLE|1058|M|71.82,91.70|Z|1442; Stonetalon Mountains|N|Follow the mountainside south to Malaka'jin to see Witch Doctor Jin'Zil.NOTE You can follow the road if you wish.|
 A Jin'Zil's Forest Magic|QID|1058|M|74.54,97.94|Z|1442; Stonetalon Mountains|N|From Witch Doctor Jin'Zil.|
 
 ; --- The Barrens
@@ -41,10 +44,10 @@ R The Barrens|ACTIVE|1062|M|72.95,93.74;83.53,97.88|CC|Z|1442; Stonetalon Mounta
 T Goblin Invaders|QID|1062|M|35.26,27.88|Z|1413; The Barrens|N|To Seereth Stonebreak.|
 A The Elder Crone|QID|1063|PRE|1062|M|35.26,27.88|Z|1413; The Barrens|N|From Seereth Stonebreak once offered.|
 A Shredding Machines|QID|1068|PRE|1062|M|35.26,27.88|Z|1413; The Barrens|N|From Seereth Stonebreak.|
-H Sun Rock Retreat|ACTIVE|6421^6284|M|49.51,61.02|Z|1442; Stonetalon Mountains|N|Hearth back to Sun Rock Retreat.|
-T Arachnophobia|QID|6284|M|47.20,61.16|Z|1442; Stonetalon Mountains|N|To Maggran Earthbinder.|
+H Sun Rock Retreat|ACTIVE|1063|M|49.51,61.02|Z|1442; Stonetalon Mountains|N|Hearth back to Sun Rock Retreat.|
+t Arachnophobia|QID|6284|M|47.20,61.16|Z|1442; Stonetalon Mountains|N|To Maggran Earthbinder.|IZ|Sun Rock Retreat|
 T Boulderslide Ravine|QID|6421|M|47.22,64.05|Z|1442; Stonetalon Mountains|N|To Mor'rogal at his camp in the hills overlooking Sun Rock.|
-A Earthen Arise|QID|6481|PRE|6421|M|47.22,64.05|Z|1442; Stonetalon Mountains|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Mor'rogal.\n[color=FF0000]NOTE: [/color]Skip this follow-up if you're not interested in the rewards.|NA|
+A Earthen Arise|QID|6481|PRE|6421|AVAILABLE|6571|M|47.22,64.05|Z|1442; Stonetalon Mountains|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Mor'rogal.\n[color=FF0000]NOTE: [/color]Skip this if you're not interested in the rewards and exp.|NA|
 F Thunder Bluff|ACTIVE|1063|M|45.13,59.84|Z|1442; Stonetalon Mountains|N|Fly to Thunder Bluff.|
 T The Elder Crone|QID|1063|M|69.86,30.93|Z|1456; Thunder Bluff|N|To Magatha Grimtotem.|
 A Forsaken Aid|QID|1064|PRE|1063|M|69.86,30.93|Z|1456; Thunder Bluff|N|From Magatha Grimtotem.|
@@ -53,26 +56,26 @@ T Forsaken Aid|QID|1064|M|22.84,20.93|Z|1456; Thunder Bluff|N|To Apothecary Zama
 A Journey to Tarren Mill|QID|1065|PRE|1064|M|22.84,20.93|Z|1456; Thunder Bluff|N|From Apothecary Zamah.|
 
 ; --- Ashenvale
-F Splintertree Post|AVAILABLE|6571|M|47.02,49.83|Z|1456; Thunder Bluff|N|Fly to Ashenvale for a quest turn in.|
+F Splintertree Post|AVAILABLE|6571|M|47.02,49.83|Z|1456; Thunder Bluff|N|Fly to Ashenvale to pick up a collection quest that wasn't available until now.|
 A Warsong Supplies|QID|6571|M|71.40,67.64|Z|1440; Ashenvale|N|From Locke Okarr, by the south watchtower.|
 
 ; --- Silverpine Forest
 ; This next section is for non-Undead toons (Undead have already done this stuff) - Hendo72
-F Orgrimmar|AVAILABLE|437^443|M|73.18,61.59|Z|1440; Ashenvale|N|Fly to Orgrimmar.|R|-Undead|IZ|1440; Ashenvale|
-h Orgrimmar|AVAILABLE|437^443|M|54.11,68.39|Z|1454; Orgrimmar|N|At Innkeeper Gryshka.\n[color=FF0000]NOTE: [/color]This will be a better option the next time you need to use your hearth.|R|-Undead|IZ|1454; Orgrimmar|
-b Tirisfal Glades|AVAILABLE|437^443|M|50.88,13.83|Z|1411; Durotar|N|Exit Orgrimmar and take the Zeppelin to Tirisfal Glades.|R|-Undead|
-; --- If you don't have the FP in Undercity
-R Undercity|AVAILABLE|437^443|M|66.22,1.74|Z|1458; Undercity|N|Enter Undercity.|R|-Undead|TAXI|-Undercity|
-f Undercity|AVAILABLE|437^443|M|63.26,48.54|Z|1458; Undercity|N|Grab the flight path from Michael Garrett.|R|-Undead|TAXI|-Undercity|
-; If you have the FP in Sepulcher
-R Undercity|AVAILABLE|437^443|M|66.22,1.74|Z|1458; Undercity|N|Enter Undercity.|R|-Undead|TAXI|Undercity|
-F The Sepulcher|AVAILABLE|437^443|M|63.26,48.54|Z|1458; Undercity|R|-Undead|TAXI|The Sepulcher|IZ|1458|
-; If you don't have the FP in Sepulcher
-R Leave Undercity|AVAILABLE|437^443|M|65.99,36.85;66.22,0.90|CC|Z|1458; Undercity|N|Take the elevator up and leave Undercity through the front gates.|R|-Undead|TAXI|-The Sepulcher|IZ|1458|
-; --- If you don't have the FP in Sepulcher but do have the FP in Undercity (No point going in if you can't go anywhere)
-R Silverpine Forest|AVAILABLE|437^443|M|54.46,74.62|Z|1420; Tirisfal Glades|N|Head over to the road and follow it south into Silverpine Forest.|R|-Undead|TAXI|-The Sepulcher|
-R The Sepulcher|AVAILABLE|437^443|M|46.21,41.59|Z|1421; Silverpine Forest|N|Head south until you reach the Sepulcher.|R|-Undead|TAXI|-The Sepulcher|
-f The Sepulcher|AVAILABLE|437^443|M|45.62,42.60|Z|1421; Silverpine Forest|N|Karos Razok|R|-Undead|TAXI|-The Sepulcher|
+F Orgrimmar|AVAILABLE|437^443|M|73.18,61.59|Z|1440; Ashenvale|N|Fly to Orgrimmar.|IZ|1440; Ashenvale|
+h Orgrimmar|AVAILABLE|437^443|M|54.11,68.39|Z|1454; Orgrimmar|N|At Innkeeper Gryshka.\n[color=FF0000]NOTE: [/color]This will be a better option the next time you need to use your hearth.|IZ|1454; Orgrimmar|
+b Tirisfal Glades|AVAILABLE|437^443|M|50.88,13.83|Z|1411; Durotar|N|Exit Orgrimmar and take the Zeppelin to Tirisfal Glades.|
+; --- If you don't have the FP in Undercity (If you don't have The Sepulcher, TAXI won't know if you have UC or not. So we have to assume you don't have it.)
+R Undercity|AVAILABLE|437^443|M|66.22,1.74|Z|1458; Undercity|N|Enter Undercity.\n[color=FF0000]NOTE: [/color]Skip this step if you already have the Undercity flightpath but not The Sepulcher.\nYou won't be able to use the flight path from Undercity until you have The Sepulcher.|TAXI|-Undercity|
+f Undercity|AVAILABLE|437^443|M|63.26,48.54|Z|1458; Undercity|N|Grab the flight path from Michael Garrett.NOTE You won't be able to use the flight path from Undercity until you have The Sepulcher.|TAXI|-Undercity|IZ|1458; Undercity|
+; If you have the FP in The Sepulcher
+R Undercity|AVAILABLE|437^443|M|66.22,1.74|Z|1458; Undercity|N|Enter Undercity.|TAXI|Undercity|
+F The Sepulcher|AVAILABLE|437^443|M|63.26,48.54|Z|1458; Undercity|N|Fly to The Sepulcher from Undercity.|TAXI|The Sepulcher|IZ|1458; Undercity|
+; If you don't have the FP in The Sepulcher
+R Tirisfal Glades|AVAILABLE|437^443|M|61.86,64.98|Z|1420; Tirisfal Glades|N|Take the elevator up and leave Undercity through the front gates.|TAXI|-The Sepulcher|IZ|1458; Undercity|
+; --- If you don't have the FP in The Sepulcher
+R Silverpine Forest|AVAILABLE|437^443|M|54.46,74.62|Z|1420; Tirisfal Glades|N|Head over to the road and follow it south into Silverpine Forest.|TAXI|-The Sepulcher|
+R The Sepulcher|AVAILABLE|437^443|M|46.21,41.59|Z|1421; Silverpine Forest|N|Head south until you reach the Sepulcher.|TAXI|-The Sepulcher|
+f The Sepulcher|AVAILABLE|437^443|M|45.62,42.60|Z|1421; Silverpine Forest|N|Get the flightpath from Karos Razok|TAXI|-The Sepulcher|
 ; ---
 ; --- Undead need to pass through Orgrimmar too to get to Silverpine Forest. - Hendo72
 F Orgrimmar|ACTIVE|443|QO|1|M|73.18,61.59|Z|1440; Ashenvale|N|Fly to Orgrimmar.|R|Undead|IZ|1440; Ashenvale|
@@ -92,58 +95,59 @@ T The Decrepit Ferry|QID|438|M|58.34,34.95|Z|1421; Silverpine Forest|N|Click the
 A Rot Hide Clues|QID|439|PRE|438|M|58.34,34.95|Z|1421; Silverpine Forest|N|From the Decrepit Ferry.|
 T Rot Hide Clues|QID|439|M|43.43,40.86|Z|1421; Silverpine Forest|N|To High Executor Hadrec.\nFollow the hillside just like you did to get here.|
 ; ---
-A Rot Hide Ichor|QID|443|PRE|439|M|43.43,40.86|Z|1421; Silverpine Forest|N|From High Executor Hadrec inside the crypt.|
+A Rot Hide Ichor|QID|443|PRE|439|M|43.43,40.86|Z|1421; Silverpine Forest|N|From High Executor Hadrec down inside the crypt.|
 R Fenris Isle|ACTIVE|443|QO|1|M|65.63,32.89|Z|1421; Silverpine Forest|N|Sticking to the hills to avoid unnecessary fighting, make your way to the lake and swim across.|
 l A Talking Head|AVAILABLE|460|M|67.25,33.73|Z|1421; Silverpine Forest|L|3317|ITEM|3317|N|the Gnolls on Fenris Isle.\n[color=FF0000]NOTE: [/color]It has a low 3% drop rate, but leads to other things to do on the island.\n\nSkip this step if you wish.|RANK|2|IZ|Fenris Isle|S!US|
 A Resting in Pieces|QID|460|M|PLAYER|CC|N|Click on the 'Talking Head' to accept the quest.\n[color=FF0000]NOTE: [/color]Do this as soon as you get it because it leads to other stuff to do on the island.|U|3317|O|
 C Rot Hide Ichor|QID|443|M|65.71,23.93|Z|1421; Silverpine Forest|L|3236 8|ITEM|3236|N|Rot Hide Gnolls.|S|
-T Resting in Pieces|QID|460|M|67.87,24.86|Z|1421; Silverpine Forest|N|Click on the Shallow Grave to turn in the quest.\n[color=FF0000]NOTE: [/color]If you follow the wall around the west side to the back, there is an opening in the wall you can walk through. It's a little out of the way, but there's less fighting involved.|
+T Resting in Pieces|QID|460|M|67.87,24.86|Z|1421; Silverpine Forest|N|Click on the Shallow Grave to turn in the quest.\n[color=FF0000]NOTE: [/color]If you follow the wall around the west side to the back, there is an opening in the wall you can walk through. Once inside, continue east along the wall behind the buildings.|
 A The Hidden Niche|QID|461|PRE|460|M|67.87,24.86|Z|1421; Silverpine Forest|N|From the Shallow Grave.|
-R The Dusty Shelf|ACTIVE|461|M|65.73,24.40;65.60,23.41;65.67,23.89;65.28,23.45;65.09,23.31;65.34,24.81|CC|Z|1421; Silverpine Forest|N|Head inside Fenris Keep and upstairs to the Dusty Shelf.\n[color=FF0000]NOTE: [/color]You can take any path up to the roof.\nYou can find yourself overwhelmed very easily by the number and close proximity of the mobs to each other. Take your time and advance slowly to avoid unwanted attention. These mobs don't run, but there are roamers that can sneak up on you.\nIf you happen to die, go all the way to the roof and respawn up there.|
+R The Dusty Shelf|ACTIVE|461|M|65.73,24.40;65.60,23.41;65.67,23.89;65.28,23.45;65.09,23.31;65.34,24.81|CC|Z|1421; Silverpine Forest|N|Head inside Fenris Keep and upstairs to the Dusty Shelf.\n[color=FF0000]NOTE: [/color]You can take any path up to the roof.\nProceed cautiously or you may get overwhelmed easily by the number and close proximity of the mobs to each other. Take your time and advance slowly to avoid unwanted attention. These mobs don't run, but there are roamers that can sneak up on you.\nIf you happen to die, go all the way to the roof and respawn up there.|C|-Druid,-Rogue|
+R The Dusty Shelf|ACTIVE|461|M|65.73,24.40;65.60,23.41;65.67,23.89;65.28,23.45;65.09,23.31;65.34,24.81|CC|Z|1421; Silverpine Forest|N|Using your stealth ability, head inside Fenris Keep and upstairs to the Dusty Shelf.\n[color=FF0000]NOTE: [/color]You can take any path up to the roof.\nCarefully clear any mobs you cannot sneak past.\nProceed cautiously or you may get overwhelmed  easily by the number and close proximity of the mobs to each other. Take your time and advance slowly to avoid unwanted attention. These mobs don't run, but there are roamers that can sneak up on you.\nIf you happen to die, go all the way to the roof and respawn up there.|C|Druid,Rogue|
 T The Hidden Niche|QID|461|M|65.34,24.81|Z|1421; Silverpine Forest|N|Click on the Dusty Shelf.|
 A Wand to Bethor|QID|491|PRE|461|M|65.34,24.81|Z|1421; Silverpine Forest|N|From the Dusty Shelf.|
-R Fight or Flight|ACTIVE|491|M|65.39,23.23|CC|Z|1421; Silverpine Forest|N|You can either fight your way back out, or walk to the north edge of the roof and jump to the wall. Drop to the ground from here.\n[color=FF0000]NOTE: [/color]Your pet may, or may not follow you down. If you're lucky it doesn't take the stairs down.|
+R Fight or Flight|ACTIVE|491&443|M|65.39,23.23|CC|Z|1421; Silverpine Forest|N|You can either fight your way back out, or walk to the north edge of the roof and jump to the wall. Drop to the ground from here.\n[color=FF0000]NOTE: [/color]Your pet may, or may not follow you down. If you're lucky, it doesn't take the stairs down.|
 C Rot Hide Ichor|QID|443|M|67.25,33.73|Z|1421; Silverpine Forest|L|3236 8|ITEM|3236|N|Rot Hide Gnolls.|T|Rot Hide|US|
 R The Sepulcher|ACTIVE|443|M|46.30,41.55|Z|1421; Silverpine Forest|N|Make your way back to The Sepulcher.\n[color=FF0000]NOTE: [/color]Dealer's choice on how you wish to get there.|
 
 T Rot Hide Ichor|QID|443|M|42.80,40.86|Z|1421; Silverpine Forest|N|To Apothecary Renferrel.|
 A Rot Hide Origins|QID|444|PRE|443|M|42.80,40.86|Z|1421; Silverpine Forest|N|From Apothecary Renferrel.|
-F Undercity|ACTIVE|491^444|M|45.62,42.60|Z|1421; Silverpine Forest|N|Fly to Undercity to turn in quests.|
-T Wand to Bethor|QID|491|M|84.06,17.44|Z|1458; Undercity|N|To Bethor Iceshard; in the Magic Quarter.|
+A Journey to Hillsbrad Foothills|QID|493|M|42.80,40.86|Z|1421; Silverpine Forest|N|From Apothecary Renferrel.|
+A Beren's Peril|QID|516|M|43.98,40.93|Z|1421; Silverpine Forest|N|From Shadow Priest Allister.|
+A The Weaver|QID|480|PRE|479|M|43.98,40.93|Z|1421; Silverpine Forest|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Shadow Priest Allister.\n[color=FF0000]NOTE: [/color]This quest can be a bit of a challenge to solo for some classes\nSkip this quest if you wish.|RANK|2|NA|
+F Undercity|ACTIVE|491^444|M|45.62,42.60|Z|1421; Silverpine Forest|N|Fly to Undercity From the Sepulcher.|
+T Wand to Bethor|QID|491|M|84.06,17.44|Z|1458; Undercity|N|To Bethor Iceshard, in the Magic Quarter (on the platform behind the big skull).|
 T Rot Hide Origins|QID|444|M|84.06,17.44|Z|1458; Undercity|N|To Bethor Iceshard.|
 A Thule Ravenclaw|QID|446|PRE|444|M|84.06,17.44|Z|1458; Undercity|N|From Bethor Iceshard.|
 A A Husband's Revenge|QID|530|PRE|441|M|62.02,42.75|Z|1458; Undercity|N|From Raleigh Andrean in the Trade Quarter.|
-F The Sepulcher|ACTIVE|446|M|63.26,48.54|Z|1458; Undercity|
-T Thule Ravenclaw|QID|446|M|42.80,40.86|Z|1421; Silverpine Forest|N|To Apothecary Renferrel.\n[color=FF0000]NOTE: [/color]Make sure you hold onto the Bethor's Potion because you're going to need it later.|
+F The Sepulcher|ACTIVE|446|M|63.26,48.54|Z|1458; Undercity|N|Fly to The Sepulcher from undercity.|
+T Thule Ravenclaw|QID|446|M|42.80,40.86|Z|1421; Silverpine Forest|N|To Apothecary Renferrel.\n[color=FF0000]NOTE: [/color]Keep the Bethor's Potion he gives you in a safe place; you're going to need it later.|
 A Report to Hadrec|QID|448|PRE|446|M|42.80,40.86|Z|1421; Silverpine Forest|N|From Apothecary Renferrel.|
-A Journey to Hillsbrad Foothills|QID|493|M|42.80,40.86|Z|1421; Silverpine Forest|N|From Apothecary Renferrel.|
 T Report to Hadrec|QID|448|M|43.43,40.86|Z|1421; Silverpine Forest|N|To High Executor Hadrec.|
-A Beren's Peril|QID|516|M|43.98,40.93|Z|1421; Silverpine Forest|N|From Shadow Priest Allister.|
-A The Weaver|QID|480|PRE|479|M|43.98,40.93|Z|1421; Silverpine Forest|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Shadow Priest Allister.\n[color=FF0000]NOTE: [/color]This quest can be a bit of a challenge to solo for some classes.|RANK|2|NA|
 ; --- 2 routes based on whether or not they took 'The Weaver' quest. Coords need to be verified - Hendo72
 ; --- Took the 'The Weaver' quest
 R Ambermill|ACTIVE|480|QO|1|M|55.71,64.46|Z|1421; Silverpine Forest|N|Make your way to Ambermill.|IZ|1421; Silverpine Forest|
-C The Weaver|QID|480|M|63.40,64.28|Z|1421; Silverpine Forest|L|3515|ITEM|3515|N|Ataeric.\n[color=FF0000]NOTE: [/color]You have to get past 2 Conjurers (plus their voidwalkers) and 2 Warders to get to Ataeric. You can aggro the mages one at a time. But, it's not easy. You may find a Dalaran Spellscribe (a non-elite rare spawn) in the room as well.\nMake sure you take out the Conjurer and Voidwalker that path in and out of the building. You'll be using the foyer to fight the mobs inside the room and you don't want them sneaking up on you.\n\nAtaeric won't stand still. He is a Frost mage who likes to keep his distance. If you don't clear the room, you'll end up fighting the entire room at the same time.|
+C The Weaver|QID|480|M|63.40,64.28|Z|1421; Silverpine Forest|L|3515|ITEM|3515|N|Ataeric.\n[color=FF0000]NOTE: [/color]You have to get past 2 Conjurers (plus their voidwalkers) and 2 Warders to get to Ataeric. You can aggro the mages one at a time. But, it's not easy. You may find a Dalaran Spellscribe (a non-elite rare spawn) in the room as well.\nMake sure you take out the Conjurer and Voidwalker that path in and out of the building. You'll be using the foyer to fight the mobs inside the room and you don't want them sneaking up on you.\n\nAtaeric won't stand still. He is a Frost mage who likes to keep his distance. If you don't clear the room, you'll end up fighting the entire room at the same time.\n\nAbandon the quest if you're having trouble.|
 R Beren's Peril|ACTIVE|516&480|M|61.53,64.61;62.88,72.15;60.44,74.46;60.54,73.35|CC|Z|1421; Silverpine Forest|N|Exit the building and follow the road south out of Ambermill. Stick to the mountains on the east side (right) and follow them around the bend.|IZ|1421; Silverpine Forest|
-R Cave Entrance|ACTIVE|516&480|QO|1;2|M|60.58,72.48|CC|Z|1421; Silverpine Forest|N|Make your way to the cave entrance.|IZ|1421; Silverpine Forest|
+R Cave Entrance|ACTIVE|516&480|QO|1;2|M|60.65,73.20|CC|Z|1421; Silverpine Forest|N|Make your way to the cave entrance.|IZ|1421; Silverpine Forest|
 C Beren's Peril|QID|516&480|QO|1;2|Z|1421; Silverpine Forest|N|<coords>Enter the cave and kill Ravenclaw Drudgers and Guardians.|
-R Cave Entrance|ACTIVE|516&480|M|60.58,72.48|CC|Z|1421; Silverpine Forest|N|Make your way back to the cave entrance.|IZ|Beren's Peril|
-R The Greymane Wall|QID|530|ACTIVE|480|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|CC|Z|1421; Silverpine Forest|N|Exit the cave and head back to the road. Follow the road west past the bend and continue west to the next intersection. From here, go south to The Greymane Wall.|IZ|1421; Silverpine Forest|
+R Cave Entrance|ACTIVE|516&480|M|60.65,73.20|CC|Z|1421; Silverpine Forest|N|Make your way back to the cave entrance.|IZ|Beren's Peril|
+R The Greymane Wall|ACTIVE|480&530|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|CC|Z|1421; Silverpine Forest|N|Exit the cave and head back to the road. Follow the road west past the bend and continue west to the next intersection. From here, go south to The Greymane Wall.|IZ|1421; Silverpine Forest|
 C A Husband's Revenge|QID|530|ACTIVE|480|M|46.06,85.64|Z|1421; Silverpine Forest|L|3613|ITEM|3613|N|Valdred Moray.\n[color=FF0000]NOTE: [/color]He paths back and forth in front of the gate.|T|Valdred Moray|
 ; --- Skipped 'The Weaver' quest
-R The Greymane Wall|QID|530|ACTIVE|-480|QO|1|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|CC|Z|1421; Silverpine Forest|N|Follow the road south to the bend. From here, go west to the intersection and then south to The Greymane Wall.|IZ|1421; Silverpine Forest|
+R The Greymane Wall|QID|530|QO|1|ACTIVE|-480|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|CC|Z|1421; Silverpine Forest|N|Follow the road south to the bend. From here, go west to the intersection and then south to The Greymane Wall.|IZ|1421; Silverpine Forest|
 C A Husband's Revenge|QID|530|ACTIVE|-480|M|46.06,85.64|Z|1421; Silverpine Forest|L|3613|ITEM|3613|N|Valdred Moray.\n[color=FF0000]NOTE: [/color]He paths back and forth in front of the gate.|T|Valdred Moray|
-R Beren's Peril|ACTIVE|516&-480|M|59.70,77.90;60.54,73.35|CC|Z|1421; Silverpine Forest|N|Return to the main road and follow the northern hillside east.|IZ|1421; Silverpine Forest|
-R Cave Entrance|ACTIVE|516&-480|QO|1;2|M|60.58,72.48|CC|Z|1421; Silverpine Forest|N|Make your way to the cave entrance.|IZ|1421; Silverpine Forest|
-C Beren's Peril|QID|516&-480|QO|1;2|Z|1421; Silverpine Forest|N|Enter the cave and kill Ravenclaw Drudgers and Guardians.|
-R Cave Entrance|ACTIVE|516&-480|M|60.58,72.48|CC|Z|1421; Silverpine Forest|N|Make your way back to the cave entrance.|IZ|Beren's Peril|
+R Beren's Peril|ACTIVE|516|AVAILABLE|480&494|M|59.70,77.90;60.54,73.35|CC|Z|1421; Silverpine Forest|N|Return to the main road and follow the northern hillside east.|IZ|1421; Silverpine Forest|
+R Cave Entrance|ACTIVE|516|QO|1;2|AVAILABLE|480&494|M|60.65,73.20|CC|Z|1421; Silverpine Forest|N|Make your way to the cave entrance.|IZ|1421; Silverpine Forest|
+C Beren's Peril|QID|516|QO|1;2|AVAILABLE|480&494|M|58.90,70.98|Z|1421; Silverpine Forest|N|Enter the cave and kill Ravenclaw Drudgers and Guardians.NOTE I wouldn't go too deep into the cave.|
+R Cave Entrance|ACTIVE|516|AVAILABLE|480&494|M|60.65,73.20|CC|Z|1421; Silverpine Forest|N|Make your way back to the cave entrance.|IZ|Beren's Peril|
 ; ---
 R Hillsbrad Foothills|ACTIVE|1065|M|67.00,80.28|CC|Z|1421; Silverpine Forest|N|Return to the main road and head east to the Silverpine Forest/Hillsbrad Foothills border.|
 
 ; --- Hillsbrad Foothills
 A Time To Strike|QID|494|M|20.79,47.36|Z|1424; Hillsbrad Foothills|N|From Deathstalker Lesh at Southpoint Tower.|
-R Tarren Mill|QID|494|M|57.65,36.61;55.86,19.60|CC|Z|1424; Hillsbrad Foothills|N|Follow the road to Tarren Mill.|
-f Tarren Mill|QID|494|M|60.15,18.61|Z|1424; Hillsbrad Foothills|N|At Zarise.|
+R Tarren Mill|ACTIVE|1065&494|M|57.65,36.61;59.66,21.22|CC|Z|1424; Hillsbrad Foothills|N|Follow the road to Tarren Mill.|
+f Tarren Mill|ACTIVE|1065&494|M|60.15,18.61|Z|1424; Hillsbrad Foothills|N|At Zarise.|
 T Journey to Tarren Mill|QID|1065|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|To Apothecary Lydon.|
 A Blood of Innocents|QID|1066|PRE|1065|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|From Apothecary Lydon.|
 T Journey to Hillsbrad Foothills|QID|493|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|To Apothecary Lydon.|
@@ -153,25 +157,24 @@ T Time To Strike|QID|494|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Exe
 A Battle of Hillsbrad|QID|527|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|From High Executor Darthalia.|
 A WANTED: Syndicate Personnel|QID|549|M|62.62,20.73|Z|1424; Hillsbrad Foothills|N|From the Wanted post beside the Chapel entrance.|
 A The Rescue|QID|498|M|63.20,20.66|Z|1424; Hillsbrad Foothills|N|From Krusk.|
-C Elixir of Suffering|QID|496|QO|1|M|44.44,40.46|Z|1424; Hillsbrad Foothills|L|3476 10|ITEM|3476|N|Gray Bears.|S|
-C Elixir of Suffering|QID|496|QO|2|M|75.19,35.46|Z|1424; Hillsbrad Foothills|L|3477|ITEM|3477|N|Moss Creepers.|S|
+C Elixir of Suffering|QID|496|M|44.44,40.46|Z|1424; Hillsbrad Foothills|L|3476 10;3477|N|Kill and loot Gray Bears and Moss Creepers.|S|
 R Durnholde Keep|ACTIVE|498|QO|1;2|M|76.08,47.11|Z|1424; Hillsbrad Foothills|N|Make your way to the Durnholde Keep entrance.|
 C WANTED: Syndicate Personnel|QID|549|QO|1;2|M|80.45,44.49|Z|1424; Hillsbrad Foothills|N|Kill Syndicate Rogues and Watchmen.|S|
 C Blood of Innocents|QID|1066|M|80.45,44.49|Z|1424; Hillsbrad Foothills|L|5620 5|ITEM|5620|N|Syndicate Mage.|S|
 C The Rescue|QID|498|M|79.60,41.86;75.40,42.00|CN|Z|1424; Hillsbrad Foothills|L|3467|ITEM|3467|N|Jailer Eston.\n[color=FF0000]NOTE: [/color]He has multiple spawn locations.\n At some point in the fight, he will mind control you into attacking a friendly and reset himself to 100% health.|T|Jailor Eston|
-C The Rescue|QID|498|M|79.46,40.54|Z|1424; Hillsbrad Foothills|L|3499|ITEM|3499|N|Jailor Marlgen.\n[color=FF0000]NOTE: [/color]If you go around back, you single pull the mobs and clear the area. The Watchmen are a lot easier to clear than the Mages.|T|Jailor Marlgen|
-C The Rescue|QID|498|QO|2|M|79.74,39.64|Z|1424; Hillsbrad Foothills|N|Rescue Tog'thar by clicking on the Locked Ball and Chain.|U|3499|NC|
-C The Rescue|QID|498|QO|1|M|77.40,42.81;75.50,38.76;75.18,41.64|CC|Z|1424; Hillsbrad Foothills|N|Rescue Drull by clicking on the Locked Ball and Chain.\n[color=FF0000]NOTE: [/color]Run along the stone wall west of the bridge, drop down to the ground behind the buildings, and follow the wall around to the backdoor.\nHe has a rogue, a mage and a Watchmen guarding him. If you approach by the rear door, you'll only have to pull the Watchmen. As long as the Watchmen doesn't run back inside and you stick to the west wall, you shouldn't aggro the other two.\n\nSometimes Jailor Eston will spawn inside. He can be pulled singly as well.|U|3467|NC|
+C The Rescue|QID|498|M|79.46,40.54|Z|1424; Hillsbrad Foothills|L|3499|ITEM|3499|N|Jailor Marlgen.\n[color=FF0000]NOTE: [/color]If you go around back, you single pull the mobs and clear the area. The Watchmen are a lot easier to clear than the Mages.\n\nIf he's spawned up by the other tower, You can walk along the back and come around to the front of the tower. Much easier than clearing the path.|T|Jailor Marlgen|
+C The Rescue|QID|498|QO|2|M|79.74,39.64|Z|1424; Hillsbrad Foothills|N|Rescue Tog'thar by clicking on the Locked Ball and Chain.NOTE Depending on where the Jailors spawned, you may have to clear the area first.|NC|
+C The Rescue|QID|498|QO|1|M|77.40,42.81;75.50,38.76;75.18,41.64|CC|Z|1424; Hillsbrad Foothills|N|Rescue Drull by clicking on the Locked Ball and Chain.\n[color=FF0000]NOTE: [/color]Run along the back of the building and drop down to the wall below you. Drop down to the ground and follow the wall around to the backdoor of the building.\nHe has a rogue, a mage and a Watchmen guarding him. If you approached by the rear door, you only have to pull the closest Watchmen. As long as the Watchmen doesn't run back inside, and you stick to the west wall, you shouldn't aggro the other two.\n\nSometimes Jailor Eston will spawn inside. He can be pulled singly as well.|NC|
 C Blood of Innocents|QID|1066|M|80.45,44.49|Z|1424; Hillsbrad Foothills|L|5620 5|ITEM|5620|N|Syndicate Mages.|T|Syndicate Shadow Mage|US|
 C WANTED: Syndicate Personnel|QID|549|QO|1;2|M|80.45,44.49|Z|1424; Hillsbrad Foothills|N|Kill Syndicate Rogues and Watchmen.\n[color=FF0000]NOTE: [/color]If you're having trouble finding Rogues, they may share spawn points with Mages inside the buildings.|US|
-R Tarren Mill|ACTIVE|549|M|62.38,28.44|Z|1424; Hillsbrad Foothills|
+R Tarren Mill|ACTIVE|549|M|62.38,28.44|Z|1424; Hillsbrad Foothills|N|Return to Tarren Mill.|
 T WANTED: Syndicate Personnel|QID|549|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Executor Darthalia.|
 T The Rescue|QID|498|M|63.24,20.66|Z|1424; Hillsbrad Foothills|N|To Krusk.|
 T Blood of Innocents|QID|1066|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|To Apothecary Lydon.|
 A Return to Thunder Bluff|QID|1067|PRE|1066|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|From Apothecary Lydon.|
 N Collection Quests|ACTIVE|496^501|Z|1424; Hillsbrad Foothills|N|You are going to finish up your collection (Elixir) quests before you leave the area. No need to carry the quests and their items with you.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
 C Elixir of Pain|QID|501|M|38.80,39.60|Z|1424; Hillsbrad Foothills|L|3496 10|ITEM|3496|N|Mountain Lions.|T|Starving Mountain Lion|
-l Elixir of Suffering|QID|496|QO|1;2|M|63.20,48.20|Z|1424; Hillsbrad Foothills|N|Gray Bears and Moss Creepers.|US|
+C Elixir of Suffering|QID|496|M|63.20,48.20|Z|1424; Hillsbrad Foothills|L|3476 10;3477|N|Kill and loot Gray Bears and Moss Creepers.|US|
 R Tarren Mill|ACTIVE|496|M|61.35,20.04|Z|1424; Hillsbrad Foothills|N|Head back to Tarren Mill.|
 T Elixir of Suffering|QID|496|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|To Apothecary Lydon.|
 A Elixir of Suffering|QID|499|PRE|496|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|From Apothecary Lydon.|
@@ -198,23 +201,23 @@ T Return to Thunder Bluff|QID|1067|M|22.90,21.03|Z|1456; Thunder Bluff|N|To Apot
 A The Flying Machine Airport|QID|1086|PRE|1067|M|22.84,20.93|Z|1456; Thunder Bluff|N|From Apothecary Zamah.|
 
 ; --- The Barrens
-F Ratchet|ACTIVE|1094|M|47.02,49.83|Z|1456; Thunder Bluff|
+F Ratchet|ACTIVE|1094|M|47.02,49.83|Z|1456; Thunder Bluff|N|Fly to Ratchet.|
 T Further Instructions|QID|1094|M|62.98,37.22|Z|1413; The Barrens|N|To Sputtervalve.|
 A Further Instructions|QID|1095|PRE|1094|M|62.98,37.22|Z|1413; The Barrens|N|From Sputtervalve.|
 T Mahren Skyseer|QID|874|M|65.84,43.86|Z|1413; The Barrens|N|To Mahren Skyseer at The Tidus Stair.\n[color=FF0000]NOTE: [/color]You can either swim there, or follow the road. Running along the shoreline will take longer because the shore isn't a straight line and you'll end up swimming at several points along the way.|
 A Isha Awak|QID|873|PRE|874|M|65.84,43.86|Z|1413; The Barrens|N|From Mahren Skyseer.|
-C Isha Awak|QID|873|QO|1|M|65.39,46.91;63.56,53.93|CC|Z|1413; The Barrens|L|5104|ITEM|5104|N|Isha Awak.\nJump into the water and start swimming east. It can be found in the water between the next point and Northwatch Hold.\n[color=FF0000]NOTE: [/color]If you don't want to swim, the targeting button works from the shore. ;)|T|Isha Awak|
+C Isha Awak|QID|873|QO|1|M|65.39,46.91;63.56,53.93|CC|Z|1413; The Barrens|L|5104|ITEM|5104|N|Isha Awak after you clear the area.\nJump into the water and start swimming east. It can be found in the water between the next point and Northwatch Hold.\n[color=FF0000]NOTE: [/color]Isha is lv 27 and may require help from a friend.\n\nIf you don't want to swim, the targeting button works from the shore. ;)|T|Isha Awak|
 T Isha Awak|QID|873|M|65.84,43.86|Z|1413; The Barrens|N|To Mahren Skyseer.|
 N Booty Bay|ACTIVE|6571|QO|2|Z|1442; Stonetalon Mountains|N|Before returning to Stonetalon Mountains, we're taking a side trip to Booty Bay to pick up a quest item.\n[color=FF0000]NOTE: [/color]This is the last time we'll be in Ratchet to make this trip.\n\nManually check this step off to continue.|
 
 ; --- Booty Bay
 b Booty Bay|ACTIVE|6571|QO|2|M|63.70,38.63|Z|1413; The Barrens|N|Take the boat to Booty Bay.|
 C Warsong Supplies|QID|6571|QO|2|M|26.43,73.30|Z|1434; Stranglethorn Vale|L|16745|N|You'll find the crate at the back of the first stack of cargo on the dock.\n[color=FF0000]NOTE: [/color]Do this quick enough and you won't have to wait for the next boat to go back.|
-f Booty Bay|ACTIVE|1095|M|26.87,77.09|Z|1434; Stranglethorn Vale|N|Since you are here go grab the Flight Path, So head up to Gringer who's standing just outside the Inn balcony.|TAXI|-Booty Bay|IZ|1434; Stranglethorn Vale|
+f Booty Bay|ACTIVE|1095|M|26.87,77.09|Z|1434; Stranglethorn Vale|N|Since you are here, go grab the flightpath from Gringer who's standing just off to the side of the balcony of the Inn.|TAXI|-Booty Bay|IZ|1434; Stranglethorn Vale|
 b Ratchet|ACTIVE|1095|M|25.80,73.10|Z|1434; Stranglethorn Vale|N|Take the boat to Ratchet.|IZ|1434; Stranglethorn Vale|
 
 ; --- Stonetalon Mountains
-F Sun Rock Retreat|ACTIVE|1095|M|63.08,37.16|Z|1413; The Barrens|
+F Sun Rock Retreat|ACTIVE|1095|M|63.08,37.16|Z|1413; The Barrens|N|Fly to Sun Rock Retreat from Ratchet.|
 h Sun Rock Retreat|ACTIVE|1095|M|47.46,62.13|Z|1442; Stonetalon Mountains|N|Set your hearthstone to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]You'll want to do this, or you'll have 3 long runs instead of just 2.|
 R Windshear Crag|AVAILABLE|1096|M|53.15,61.61;59.97,71.14|CC|Z|1442; Stonetalon Mountains|N|Follow the road south out of Sun Rock Retreat to Windshear Crag (look for the sign).\n[color=FF0000]NOTE: [/color]If you don't mind a little falling damage, you can get in through the graveyard you pass along the way.|
 T Further Instructions|QID|1095|M|58.99,62.60|Z|1442; Stonetalon Mountains|N|Make your way to Ziz Fizziks' hut and turn in the quest.|
@@ -222,7 +225,7 @@ A Gerenzo Wrenchwhistle|QID|1096|PRE|1095|M|58.99,62.60|Z|1442; Stonetalon Mount
 C Shredding Machines - XT:4|QID|1068|QO|1|M|64.09,44.35;71.35,44.30|CN|Z|1442; Stonetalon Mountains|N|Kill XT:4. It patrols the north side of the river between the two waypoints.|S|
 C Shredding Machines - XT:9|QID|1068|QO|2|M|71.35,55.25;60.20,54.29|CN|Z|1442; Stonetalon Mountains|N|Kill XT:9. It patrols the south side of the river.|S|
 C The Flying Machine Airport|QID|1086|M|66.48,45.40|Z|1442; Stonetalon Mountains|N|Place the Toxic Fogger here.|U|5638|
-C Gerenzo Wrenchwhistle|QID|1096|M|69.26,40.60;64.61,37.96;62.84,40.49|CS|Z|1442; Stonetalon Mountains|L|5736|ITEM|5736|N|Gerenzo.\n[color=FF0000]NOTE: [/color]Make your way to the path leading up to the structure. Once you're there, work your way over to where Gerenzo is.|T|Gerenzo Wrenchwhistle|
+C Gerenzo Wrenchwhistle|QID|1096|M|69.17,40.26;64.61,37.96;62.84,40.49|CC|Z|1442; Stonetalon Mountains|L|5736|ITEM|5736|N|Gerenzo Wrenchwhistle (lv 27 melee).\n[color=FF0000]NOTE: [/color]Make your way to the path leading up to the structure. Once you're there, work your way over to where Gerenzo is. He has a guard with him that cannot be pulled separately.|T|Gerenzo Wrenchwhistle|
 ;L Level 25
 N Shortcut down|ACTIVE|1096|M|64.09,44.35|CC|Z|1442; Stonetalon Mountains|N|Jump into the water and swim to shore.|IZ|Cragpool Lake|
 C Shredding Machines - XT:4|QID|1068|QO|1|M|64.09,44.35;71.35,44.30|CN|Z|1442; Stonetalon Mountains|N|Kill XT:4.\n[color=FF0000]NOTE: [/color]It patrols the north side of the river between the two waypoints.|T|XT:4|US|
@@ -231,49 +234,48 @@ T Gerenzo Wrenchwhistle|QID|1096|M|58.99,62.57|Z|1442; Stonetalon Mountains|N|To
 R Webwinder Path|ACTIVE|6481|QO|1|M|59.79,71.19|Z|1442; Stonetalon Mountains|N|Exit Windshear Crag to the main road.|
 R Boulderslide Ravine|ACTIVE|6481|QO|1|M|66.24,89.37|Z|1442; Stonetalon Mountains|N|Follow the road south.|
 R Boulderslide Cavern|ACTIVE|6481|QO|1|M|61.98,93.16|Z|1442; Stonetalon Mountains|N|Make your way to the cave entrance.|
-C Earthen Arise|QID|6481|M|57.67,89.48|Z|1442; Stonetalon Mountains|N|Kill Goggeroc (Lv 20 Elite) after he spawns when you click on the Resonite Cask.\n[color=FF0000]NOTE: [/color]Make sure you clear the mobs in the area first. They may be grey, but they are extremely annoying and will attack you.|
-R Webwinder Path|ACTIVE|1068|M|61.72,93.13;67.76,86.64|CC|Z|1442; Stonetalon Mountains|N|Exit the cave and make your way back to the road.\n[color=FF0000]NOTE: [/color]The kobolds may be grey, but they will attack you and you can easily aggro enough of them to be a problem.|IZ|Boulderslide Ravine|
+C Earthen Arise|QID|6481|M|57.67,89.48|Z|1442; Stonetalon Mountains|N|Kill Goggeroc (Lv 20 Elite) after he spawns when you click on the Resonite Cask.\n[color=FF0000]NOTE: [/color]As you did earlier, clear a path to the water at the back of the cave.\nMake sure you clear the mobs in the area first because although they are grey, they are extremely annoying and will attack you.|C|-Druid,-Rogue|
+C Earthen Arise|QID|6481|M|57.67,89.48|Z|1442; Stonetalon Mountains|N|Kill Goggeroc (Lv 20 Elite) after he spawns when you click on the Resonite Cask.\n[color=FF0000]NOTE: [/color]As you did earlier, use your Stealth ability to make your way to the water at the back of the cave.\nMake sure you clear the mobs in the area first because although they are grey, they are extremely annoying and will attack you.|C|Druid,Rogue|
+R Webwinder Path|ACTIVE|1068|M|61.72,93.13;67.76,86.64|CC|Z|1442; Stonetalon Mountains|N|Exit the cave and make your way back to the road.\n[color=FF0000]NOTE: [/color]The kobolds may be grey, but they will attack you and you can easily aggro enough of them to be a problem.|IZ|Boulderslide Cavern^Boulderslide Ravine|
 R Malaka'jin|ACTIVE|1068|M|71.82,91.70|Z|1442; Stonetalon Mountains|N|Follow the road south to Malaka'jin to bypass going through Camp Aparaje.|IZ|1442; Stonetalon Mountains|
 R The Barrens|ACTIVE|1068|M|72.95,93.74;83.53,97.88|CC|Z|1442; Stonetalon Mountains|N|Exit Malaka'jin by taking the 'shortcut' along the canyon wall south to The Barrens border to see Seereth Stonebreak.|
 T Shredding Machines|QID|1068|M|35.26,27.88|Z|1413; The Barrens|N|To Seereth Stonebreak.|
-R Sun Rock Retreat|AVAILABLE|6301|M|49.58,60.99|Z|1442; Stonetalon Mountains|N|Make your way back to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]We're saving our hearthstone for later... trust me.|
-A Cycle of Rebirth|QID|6301|M|47.43,58.46|Z|1442; Stonetalon Mountains|N|From Tammra Windfield.|
+R Sun Rock Retreat|AVAILABLE|6301|M|49.58,60.99|Z|1442; Stonetalon Mountains|N|Make your way back to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]We're saving our hearthstone for later... trust me. Unless, you planning on some downtime for the cooldown to lapse.|
+A Cycle of Rebirth|QID|6301|M|47.46,58.38|Z|1442; Stonetalon Mountains|N|From Tammra Windfield.|
 R Mirkfallon Lake|ACTIVE|6301|M|51.54,49.43|Z|1442; Stonetalon Mountains|N|Follow the road north to Mirkfallon Lake.|
-C Cycle of Rebirth|QID|6301|M|48.67,40.07|Z|1442; Stonetalon Mountains|L|16205 10|N|Loot any gaea seeds you find on the ground around the lake.|
+C Cycle of Rebirth|QID|6301|M|48.67,40.07|Z|1442; Stonetalon Mountains|L|16205 10|N|Loot any gaea seeds you find on the ground around the lake.NOTE They have static spawn points.\nTry to avoid fighting; it just prolongs the time it takes to do this.|
 R Sun Rock Retreat|ACTIVE|6301|M|49.58,60.99|Z|1442; Stonetalon Mountains|N|Return to Sun Rock Retreat.|
-T Cycle of Rebirth|QID|6301|M|47.48,58.39|Z|1442; Stonetalon Mountains|N|To Tammra Windfield.|
-A New Life|QID|6381|PRE|6301|M|47.48,58.39|Z|1442; Stonetalon Mountains|N|From Tammra Windfield.|
+T Cycle of Rebirth|QID|6301|M|47.46,58.38|Z|1442; Stonetalon Mountains|N|To Tammra Windfield.|
+A New Life|QID|6381|PRE|6301|M|47.46,58.38|Z|1442; Stonetalon Mountains|N|From Tammra Windfield.|
 A Harpies Threaten|QID|6282|M|47.15,61.10|Z|1442; Stonetalon Mountains|N|From Maggran Earthbinder.|
 T Earthen Arise|QID|6481|M|47.22,64.05|CS|Z|1442; Stonetalon Mountains|N|To Mor'rogal, on top of the hill.|
 * Enchanted Resonite Crystal|PRE|6481|M|PLAYER|CC|N|You can safely destroy it now.|U|16603|O|
 A Elemental War|QID|6393|M|47.37,64.25|Z|1442; Stonetalon Mountains|N|From Tsunaman.|
 R The Charred Vale|ACTIVE|6381^6393^6282|M|44.55,63.01;37.99,68.08|CC|Z|1442; Stonetalon Mountains|N|Head back to the main trail. Follow the torch-marked path south over the mountain to the bottom.\n[color=FF0000]NOTE: [/color]There is a longer route that brings you in through the north entrance. That route requires you to go back north up through Mirkfallon Lake and then west with a curve south into the Charred Vale. That route has less fighting and the mobs are level 23-25 at the top end. Whichever route you choose, you will be covering all 4 corners of the Charred Vale to complete this round of quests. The suggested route gets you there faster.|
-C New Life|QID|6381|QO|1|M|PLAYER|CC|N|Locate a Gaea Dirt Mound and click on it to plant a Gaea seed.|S|NC|
+C New Life|QID|6381|M|PLAYER|CC|N|Locate a Gaea Dirt Mound and click on it to plant a Gaea seed.|S|NC|
 C Elemental War|QID|6393|M|PLAYER|CC|L|16312 10|ITEM|16312|N|Fire Elementals.\n[color=FF0000]NOTE: [/color]They are immune to fire damage (Duh!).|S|
-C Harpies Threaten|QID|6282|QO|1;2;3;4|M|PLAYER|CC|N|Kill Bloodfury Harpies, Ambushers, Slayers and Roguefeathers through all four corners of the Charred Vale.\n[color=FF0000]NOTE: [/color]Don't waste your time with the Bloodfury Storm Witches and Windcallers, unless you have no choice. Try to draw them away from the others. It won't take much to get overwhelmed.|
-C Elemental War|QID|6393|Z|1442; Stonetalon Mountains|L|16312 10|ITEM|16312|N|Fire Elementals.\n[color=FF0000]NOTE: [/color]They are immune to fire damage.|US|
-C New Life|QID|6381|QO|1|Z|1442; Stonetalon Mountains|N|Gaea seed planted.|US|NC|
+C Harpies Threaten|QID|6282|QO|1;2;3;4|M|PLAYER|CC|N|Kill Bloodfury Harpies, Ambushers, Slayers and Roguefeathers through all four corners of the Charred Vale.\n[color=FF0000]NOTE: [/color]Don't waste your time with the Bloodfury Storm Witches and Windcallers, unless you have no choice.\nTry to draw them away from the others. It won't take much to get overwhelmed.|
+C Elemental War|QID|6393|M|PLAYER|CC|L|16312 10|ITEM|16312|N|Fire Elementals.\n[color=FF0000]NOTE: [/color]They are immune to fire damage (Duh!).|US|
+C New Life|QID|6381|M|PLAYER|CC|N|Gaea seed planted.|US|NC|
 R Sun Rock Retreat|ACTIVE|6393^6282|M|37.93,67.93;44.54,63.43|CC|Z|1442; Stonetalon Mountains|N|Run back to Sun Rock Retreat.|
 T Elemental War|QID|6393|M|47.37,64.25|Z|1442; Stonetalon Mountains|N|To Tsunaman.|
 T Harpies Threaten|QID|6282|M|47.20,61.16|Z|1442; Stonetalon Mountains|N|To Maggran Earthbinder.|
 A Bloodfury Bloodline|QID|6283|PRE|6282|M|47.20,61.16|Z|1442; Stonetalon Mountains|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Maggran Earthbinder.|
 A Calling in the Reserves|QID|5881|M|47.20,61.16|Z|1442; Stonetalon Mountains|N|From Maggran Earthbinder.|
 A Cenarius' Legacy|QID|1087|M|45.94,60.42|Z|1442; Stonetalon Mountains|N|From Braelyn Firehand.|
-N Bag space|ACTIVE|6381|N|For this next round of quests, you're going to need at least 5 empty spots minimum just for the items you need to collect.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-T New Life|QID|6381|M|47.42,58.50|Z|1442; Stonetalon Mountains|N|To Tammra Windfield.|
-C Jin'Zil's Forest Magic - Courser Eye|QID|1058|M|39.19,6.82|Z|1442; Stonetalon Mountains|L|5585 30|ITEM|5585|N|Coursers.\n[color=FF0000]NOTE: [/color]You'll find them everywhere north of Mirkfallon Lake.|S|
+N Bag space|ACTIVE|6381|N|For this next round of quests, you're going to need 5 empty spots MINIMUM just for the items you need to collect. Do what you gotta do to make that happen.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+T New Life|QID|6381|M|47.46,58.38|Z|1442; Stonetalon Mountains|N|To Tammra Windfield.|
+C Jin'Zil's Forest Magic|QID|1058|M|39.19,6.82|Z|1442; Stonetalon Mountains|L|5585 30|ITEM|5585|N|Coursers.\n[color=FF0000]NOTE: [/color]You'll find them everywhere north of Mirkfallon Lake.|S|
 R Mirkfallon Lake|ACTIVE|1058^1087|M|51.54,49.43|Z|1442; Stonetalon Mountains|N|Follow the road north to Mirkfallon Lake.|
 R Stonetalon Peak|ACTIVE|1058^1087|M|44.31,17.78|Z|1442; Stonetalon Mountains|N|Continue north out of Mirkfallon Lake until you reach Stonetalon Peak.\n[color=FF0000]NOTE: [/color]Dying now means a 2500+ yd corpse run.|
-N Fey Dragon|ACTIVE|1058^1087|Z|1442; Stonetalon Mountains|N|Be very aware of these guys sneaking up on you as adds. They cast 'Nullify Mana', which will drain a portion of your mana.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|C|Mage,Priest,Warlock|
-C Jin'Zil's Forest Magic - Fey Dragon Scale|QID|1058|M|35.60,11.63|Z|1442; Stonetalon Mountains|L|5583|ITEM|5583|N|Fey Dragons.|S|
-C Jin'Zil's Forest Magic - Stonetalon Sap|QID|1058|M|35.60,11.63|Z|1442; Stonetalon Mountains|L|5582 5|ITEM|5582|N|'Sap Beasts'.|S|
-C Jin'Zil's Forest Magic - Twilight Runner Whisker|QID|1058|M|32.27,8.17|Z|1442; Stonetalon Mountains|L|5584 5|ITEM|5584|N|Twilight Runners.\nThey are in the northern half of Stonetalon Peak.\n[color=FF0000]NOTE: [/color]Be aware that as you are moving around in this area, there is an Alliance outpost northeast of you.|S|
+N Fey Dragon|ACTIVE|1058^1087|Z|1442; Stonetalon Mountains|N|Be very aware of these guys sneaking up on you as adds. They cast 'Nullify Mana', which will drain a portion of your mana.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|C|Mage,Priest,Warlock,Druid|
+C Jin'Zil's Forest Magic|QID|1058|M|35.60,11.63|Z|1442; Stonetalon Mountains|L|5583;5582 5|N|Kill and loot Fey Dragons and 'Sap Beasts'.|S|
+C Jin'Zil's Forest Magic|QID|1058|M|32.27,8.17|Z|1442; Stonetalon Mountains|L|5584 5|ITEM|5584|N|Twilight Runners.\nThey are in the northern half of Stonetalon Peak.\n[color=FF0000]NOTE: [/color]Be aware that as you are moving around in this area, there is an Alliance outpost northeast of you.|S|
 C Cenarius' Legacy|QID|1087|QO|1;2;3|M|35.60,11.63|Z|1442; Stonetalon Mountains|N|Kill Sons of Cenarius, Daughters of Cenarius and Cenarion Botanists.\n[color=FF0000]NOTE: [/color]You'll find them in the woods on either side of the road.|
 ; Level 26
-C Jin'Zil's Forest Magic - Twilight Runner Whisker|QID|1058|M|32.27,8.17|Z|1442; Stonetalon Mountains|L|5584 5|ITEM|5584|N|Twilight Runners.\nThey are in the northern half of Stonetalon Peak.\n[color=FF0000]NOTE: [/color]Be aware that as you are moving around in this area, there is an Alliance outpost northeast of you.|T|Twilight Runner|
-C Jin'Zil's Forest Magic - Stonetalon Sap|QID|1058|M|35.60,11.63|Z|1442; Stonetalon Mountains|L|5582 5|ITEM|5582|N|Sap Beasts.\n[color=FF0000]NOTE: [/color]They are in southern half of Stonetalon Peak. They are also found in the northeast area.\n\nOnly 'Sap Beasts' will drop them; ignore the Corrosive Sap Beasts.|T|Sap Beast|US|
-C Jin'Zil's Forest Magic - Fey Dragon Scale|QID|1058|M|35.60,11.63|Z|1442; Stonetalon Mountains|L|5583|ITEM|5583|N|Fey Dragons.\n[color=FF0000]NOTE: [/color]They are spread out over Stonetalon Peak.|T|Fey Dragon|US|
-C Jin'Zil's Forest Magic - Courser Eye|QID|1058|M|46.36,37.19|Z|1442; Stonetalon Mountains|L|5585 30|ITEM|5585|N|Coursers.\n[color=FF0000]NOTE: [/color]You'll find them everywhere north of Mirkfallon Lake.|US|
+C Jin'Zil's Forest Magic|QID|1058|M|32.27,8.17|Z|1442; Stonetalon Mountains|L|5584 5|ITEM|5584|N|Twilight Runners.\nThey are in the northern half of Stonetalon Peak.\n[color=FF0000]NOTE: [/color]Be aware that as you are moving around in this area, there is an Alliance outpost northeast of you.|T|Twilight Runner|
+C Jin'Zil's Forest Magic|QID|1058|M|35.60,11.63|Z|1442; Stonetalon Mountains|L|5583;5582 5|N|Kill and loot Fey Dragons and 'Sap Beasts'.\n[color=FF0000]NOTE: [/color]Fey Dragons are spread out over Stonetalon Peak.\n'Sap Beasts' are found in the southern half of Stonetalon Peak and in the northeast area.\nIgnore the Corrosive Sap Beasts.|T|Sap Beast|US|
+C Jin'Zil's Forest Magic|QID|1058|M|46.36,37.19|Z|1442; Stonetalon Mountains|L|5585 30|ITEM|5585|N|Coursers.\n[color=FF0000]NOTE: [/color]You'll find them everywhere north of Mirkfallon Lake.|US|
 R Webwinder Path|ACTIVE|1058^1087|M|51.54,49.59|Z|1442; Stonetalon Mountains|N|Follow the road south through Mirkfallon Lake.|
 
 ; --- I realize this is a long run. But, we don't want to be carrying all of these items until we return to the area much later in the guide.
@@ -287,12 +289,12 @@ A Ordanus|QID|1088|PRE|1087|M|45.94,60.42|Z|1442; Stonetalon Mountains|N|From Br
 F Thunder Bluff|ACTIVE|1086|M|45.13,59.84|Z|1442; Stonetalon Mountains|N|Fly to Thunder Bluff to go see Apothecary Zamah.|
 R The Pools of Vision|ACTIVE|1086|M|30.50,30.48|Z|1456; Thunder Bluff|N|Make your way to the cave beneath Spirit Rise.|
 T The Flying Machine Airport|QID|1086|M|23.06,21.07|Z|1456; Thunder Bluff|N|To Apothecary Zamah.|
-= Level 26 Training|AVAILABLE|1195|M|PLAYER|CC|N|Do your level 26 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|26|C|Druid|IZ|1456; Thunder Bluff|
+= Level 26 Training|AVAILABLE|1195|M|PLAYER|CC|N|Do your level 26 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|26|C|-Warlock,-Rogue|IZ|1456; Thunder Bluff|
 A The Sacred Flame|QID|1195|M|54.97,51.41|Z|1456; Thunder Bluff|N|From Zangen Stonehoof.|
 
 ; --- Hillsbrad Foothills
 F Orgrimmar|AVAILABLE|502|ACTIVE|1195|M|47.02,49.83|Z|1456; Thunder Bluff|
-= Level 26 Training|AVAILABLE|502|M|PLAYER|CC|N|Do your level 26 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|26|IZ|1454; Orgrimmar|C|-Druid|
+= Level 26 Training|AVAILABLE|502|M|PLAYER|CC|N|Do your level 26 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|26|IZ|1454; Orgrimmar|C|Warlock,Rogue|
 R Durotar|AVAILABLE|502|ACTIVE|1195|M|45.55,12.06|Z|1411; Durotar|N|Exit Orgrimmar through the south gate.|
 b Tirisfal Glades|AVAILABLE|502|ACTIVE|1195|M|50.88,13.83|Z|1411; Durotar|N|Take the Zepplin to Tirisfal Glade.|
 R Undercity|AVAILABLE|502|ACTIVE|1195|M|66.22,1.74|Z|1458; Undercity|N|Enter Undercity.|
@@ -301,12 +303,12 @@ A Elixir of Pain|QID|502|PRE|501|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|Fro
 A Elixir of Agony|QID|509|PRE|502|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|From Apothecary Lydon.|
 A Dangerous!|QID|567|M|62.55,19.69|Z|1424; Hillsbrad Foothills|N|From the wanted poster hanging beside the Inn's front door.\njust in case you run into one of them while you are doing other things, accept this quest now. It would suck to have to kill them more than once because you didn't have the quest.|
 h Tarren Mill|QID|527|M|62.78,19.03|Z|1424; Hillsbrad Foothills|N|Set your hearth to Tarren Mill with Innkeeper Shay.|
-R Hillsbrad Fields|ACTIVE|502^527|M|33.43,35.03|Z|1424; Hillsbrad Foothills|N|Run to the north end of the area.\n[color=FF0000]NOTE: [/color]You can either take the road, or follow the hillside. But, steer clear of Darrow Hill and the Cave yetis.|
-C Battle of Hillsbrad|QID|527|QO|1;2|Z|1424; Hillsbrad Foothills|N|Kill Hillsbrad Farmers and Farmhands.|S|
-C Dangerous!|QID|567|QO|2|Z|1424; Hillsbrad Foothills|N|Kill Citizen Wilkes.\n[color=FF0000]NOTE: [/color]He patrols the north branch of the main road in Hillsbrad Fields from the Forge up to the last house; stopping briefly at each building as he passes.|S|IZ|Hillsbrad Fields|
+R Hillsbrad Fields|ACTIVE|502^527|M|33.43,35.03|Z|1424; Hillsbrad Foothills|N|Run to the north end of the area.\n[color=FF0000]NOTE: [/color]You can either take the road, or follow the hillside. But, steer clear of Darrow Hill and the Cave Yetis (lv 30+).|
+C Battle of Hillsbrad|QID|527|QO|1;2|M|35.29,40.64|Z|1424; Hillsbrad Foothills|N|Kill Hillsbrad Farmers and Farmhands.|S|
+C Dangerous!|QID|567|QO|2|M|32.60,41.60|Z|1424; Hillsbrad Foothills|N|Kill Citizen Wilkes.\n[color=FF0000]NOTE: [/color]He patrols the north branch of the main road in Hillsbrad Fields from the Forge up to the last house; stopping briefly at each building as he passes.|IZ|Hillsbrad Fields|S|
 T Elixir of Pain|QID|502|M|32.67,35.32|Z|1424; Hillsbrad Foothills|N|To Stanley beside his doghouse at the northern most house in Hillsbrad Fields.\n[color=FF0000]NOTE: [/color]Stanley won't appreciate you giving him the elixir. He becomes enraged and attacks you. The quest completes once you defeat him.|
 C Farmer Ray|QID|527|QO|3|M|32.67,35.62;33.74,33.50|CN|Z|1424; Hillsbrad Foothills|N|Kill Farmer Ray just inside the front door.\n[color=FF0000]NOTE: [/color]Draw him out so you don't aggro the mobs inside with him.\nIf he's not in the house, check the courtyard on the east side of the house. The courtyard location requires you clear the adds first.|T|Farmer Ray|
-C Farmer Getz|QID|527|QO|4|M|35.45,38.00;36.52,39.45;35.29,40.64|CN|Z|1424; Hillsbrad Foothills|N|Kill Farmer Getz.\n[color=FF0000]NOTE: [/color]If he's inside the barn, you'll aggro the 2 mobs that are in there with him.\nIf he's at the house (east of the barn), he'll only have 1 mob with him.\nIf he's in the field, pull what you can to clear the field first.|T|Farmer Getz|
+C Farmer Getz|QID|527|QO|4|M|35.45,38.00;36.52,39.45;35.29,40.64|CN|Z|1424; Hillsbrad Foothills|N|Kill Farmer Getz.\n[color=FF0000]NOTE: [/color]If he's inside the barn, you'll aggro the 2 mobs in there with him.\nIf he's at the house (east of the barn), he'll only have 1 mob with him.\nIf he's in the field, pull what you can to clear the field first.|T|Farmer Getz|
 C Battle of Hillsbrad|QID|527|QO|1;2|M|35.29,40.64|Z|1424; Hillsbrad Foothills|N|Finish killing Hillsbrad Farmers and Farmhands.|US|
 H Tarren Mill|QID|527|M|62.78,19.03|Z|1424; Hillsbrad Foothills|N|Hearth back to Tarren Mill.\n[color=FF0000]NOTE: [/color]You can choose to run back and save your hearth for your next trip here.|
 T Battle of Hillsbrad|QID|527|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Executor Darthalia in Tarren Mill.|
@@ -324,11 +326,13 @@ R Tarren Mill|ACTIVE|528|M|62.78,19.03|Z|1424; Hillsbrad Foothills|N|Return to T
 T Battle of Hillsbrad|QID|528|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Executor Darthalia.|
 A Battle of Hillsbrad|QID|529|PRE|528|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|From High Executor Darthalia.|
 R Hillsbrad Fields|ACTIVE|529|QO|2|M|32.21,48.31|Z|1424; Hillsbrad Foothills|N|Follow the road to the south entrance to Hillsbrad Fields.\n[color=FF0000]NOTE: [/color]You're headed for the Forge.|
-C Battle of Hillsbrad|QID|529|QO|2|M|31.37,45.26||Z|1424; Hillsbrad Foothills|N|Kill Hillsbrad Apprentice Blacksmiths.[color=FF0000]NOTE: [/color]There are 3 inside the forge and 1 outside.|S|
+; Battle of Hillsbrad|QID|529|QO|1;2| is split into 2 steps for better flow while doing the quest.
+; The QO doesn't work if the steps have the same name
+C Battle of Hillsbrad|QID|529|QO|2|M|31.37,45.26|Z|1424; Hillsbrad Foothills|N|Kill Hillsbrad Apprentice Blacksmiths.[color=FF0000]NOTE: [/color]There are 3 inside the forge and 1 outside.|S|
 C Battle of Hillsbrad - Blacksmith Verringtan|QID|529|QO|1|M|31.37,45.26|Z|1424; Hillsbrad Foothills|N|Kill Blacksmith Verringtan inside the Forge.\n[color=FF0000]NOTE: [/color]If you approach from the south entrance, you'll aggro all 4 mobs inside. If you approach from the north entrance, you'll only aggro 3 of them. Kite them around to the rear of the building to avoid aggroing anyone else and to prevent the runners from doing the same. Verringtan will be one of the mobs that attack you.\n\nSometimes you get lucky and he spawns outside by the well. If Verringtan spawned outside, pull him when the Councilman is as far away as possible. Aggroing the Councilman means everyone attacks.|T|Blacksmith Verringtan|
 C Battle of Hillsbrad|QID|529|M|31.99,45.43|Z|1424; Hillsbrad Foothills|L|3564|N|As soon as you clear the forge, run inside and pick up the Shipment of Iron inside the forge.|
 C Battle of Hillsbrad|QID|529|QO|2|M|31.37,45.26|Z|1424; Hillsbrad Foothills|N|Finish killing the Hillsbrad Apprentice Blacksmiths.[color=FF0000]NOTE: [/color]You should be able to pull the one outside by himself.|US|
-N Souvenirs of Death|ACTIVE|546&509|Z|1424; Hillsbrad Foothills|N|You are leaving area again and won't return for quite some time.\nYou can choose to finish this quest now, or skip it and finish when you come back.\n[color=FF0000]NOTE: [/color]To save bag space, you can always stash your quest items in the bank until you come back.\nManually check this step off to continue.|IZ|Hillsbrad Fields|
+N Souvenirs of Death|ACTIVE|546&509|Z|1424; Hillsbrad Foothills|N|You are leaving the area again and won't return for quite some time.\nYou can choose to finish this quest now, or skip it and finish when you come back.\n[color=FF0000]NOTE: [/color]To save bag space, you can always stash your quest items in the bank until you come back.\nManually check this step off to continue.|IZ|Hillsbrad Fields|
 C Souvenirs of Death|QID|546|ACTIVE|509|M|32.14,41.42|Z|1424; Hillsbrad Foothills|L|3692 30|ITEM|3692|N|Hillsbrad human mobs.\n[color=FF0000]NOTE: [/color]Skip this step if you want to move on for now.|IZ|Hillsbrad Fields|US|
 R Tarren Mill|ACTIVE|509|M|62.78,19.03|Z|1424; Hillsbrad Foothills|N|Return to Tarren Mill.\n[color=FF0000]NOTE: [/color]If you saved it, you can use your hearth instead.|
 t Souvenirs of Death|QID|546|M|62.13,19.70|Z|1424; Hillsbrad Foothills|N|To Deathguard Samsa.|IZ|Tarren Mill|
@@ -338,7 +342,7 @@ T Battle of Hillsbrad|QID|529|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To Hig
 A Battle of Hillsbrad|QID|532|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|From High Executor Darthalia.|
 
 ; --- Undercity
-N Too tough|ACTIVE|513|N|This area has gotten a little too tough for your current level.\nWe'll temporarily move on for now and head back to The Barrens.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+N Too tough|ACTIVE|513|Z|1424; Hillsbrad Foothills|N|This area has gotten a little too tough for your current level.\nWe'll temporarily move on for now and head back to The Barrens.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
 F Undercity|ACTIVE|513|M|60.14,18.63|Z|1424; Hillsbrad Foothills|N|Fly to Undercity to see Master Apothecary Faranell.|
 T Elixir of Agony|QID|513|M|48.68,69.25|Z|1458; Undercity|N|To Master Apothecary Faranell, underneath The Apothecarium.|
 
@@ -359,8 +363,8 @@ A Washte Pawne|QID|885|M|PLAYER|CC|N|Right-click on Washte Pawne's Feather to ac
 A The Harvester|QID|897|M|PLAYER|CC|N|Right-click on Harvester's Head to accept the quest.|U|5138|O|
 ; ---
 C Egg Hunt|QID|868|M|42.39,70.25;48.93,69.86|CN|Z|1413; The Barrens|L|5058 12|N|Collect Silithid Eggs from the Silithid Mounds found on both sides of the road in Field of Giants.\n[color=FF0000]NOTE: [/color]You may have to back and forth to get enough.|
-l The Harvester|AVAILABLE|897|Z|1413; The Barrens|L|5138|ITEM|5138|N|Silithid Harvester.\nHave a quick look around and see if you can locate this mob. This is one of Jorn Skyseer's rare quest kills and probably the hardest to find.\n[color=FF0000]NOTE: [/color]Skip this step if you've given up waiting/looking.|T|Silithid Harvester|RARE|
-A Gann's Reclamation|QID|843|M|46.11,81.23|Z|1413; The Barrens|N|From Gann Stonespire.\n[color=FF0000]NOTE: [/color]You may find him sooner walking along on Southern Gold Road. This is the furthest south he travels.|
+l The Harvester|AVAILABLE|897|M|42.60,70.60;48.80,68.80|CN|Z|1413; The Barrens|L|5138|ITEM|5138|N|Silithid Harvester.\nHave a quick look around and see if you can locate this mob on either side of the road.\n[color=FF0000]NOTE: [/color]This is one of Jorn Skyseer's rare quest kills and probably the hardest to find.\n\nSkip this step if you've given up waiting/looking.|T|Silithid Harvester|RARE|
+A Gann's Reclamation|QID|843|M|46.11,81.23|Z|1413; The Barrens|N|From Gann Stonespire.\n[color=FF0000]NOTE: [/color]You should run into him as you walk south down Southern Gold Road.\nIf you don't, turn around and head north again.|
 C Weapons of Choice|QID|893|QO|1|M|41.49,80.24|Z|1413; The Barrens|L|5093|ITEM|5093|N|Razormane Pathfinders/Stalkers.|S|
 C Weapons of Choice|QID|893|QO|2|M|41.49,80.24|Z|1413; The Barrens|L|5092|ITEM|5092|N|Razormane Seers.|S|
 C Weapons of Choice|QID|893|QO|3|M|41.49,80.24|Z|1413; The Barrens|L|5094|ITEM|5094|N|Razormane Warfrenzy.|S|
@@ -368,7 +372,7 @@ C Betrayal from Within|QID|879|QO|1|M|44.71,80.48|Z|1413; The Barrens|L|5074|ITE
 C Betrayal from Within|QID|879|QO|3|M|40.13,80.69|Z|1413; The Barrens|L|5072|ITEM|5072|N|Lok.\n[color=FF0000]NOTE: [/color]He is at the top of the hill at the back of Blackthorn Ridge.|T|Lok Orcbane|
 C Betrayal from Within|QID|879|QO|2|M|43.96,83.44|Z|1413; The Barrens|L|5073|ITEM|5073|N|Nak.\n[color=FF0000]NOTE: [/color]Follow the cliff wall east and you'll run into him.|T|Nak|
 C Weapons of Choice|QID|893|QO|1;2;3|M|41.49,80.24|Z|1413; The Barrens|N|Kill the correct mob to loot the required item.|US|
-l Washte Pawne|AVAILABLE|885|M|44.30,80.00|Z|1413; The Barrens|L|5138|ITEM|5138|N|Washte Pawne.\nBefore leaving the area, have a look around and see if you can locate this mob. This is one of Jorn Skyseer's rare quest kills.\n[color=FF0000]NOTE: [/color]This mob is tameable and therefore, be respectful of Hunters who may be in the area looking for it.\nYou may find it closer to the road and on the other side, as well.\n\nSkip this step if you've given up waiting/looking.|T|Washte Pawne|RARE|
+l Washte Pawne|AVAILABLE|885|M|44.30,80.00|Z|1413; The Barrens|L|5138|ITEM|5138|N|Washte Pawne.\nBefore leaving the area, have a look around and see if you can locate this mob.\n[color=FF0000]NOTE: [/color]This is one of Jorn Skyseer's rare quest kills.\nThis mob is tameable and therefore, be respectful of Hunters who may be in the area looking for it.\nYou may find it closer to the road and on the other side, as well.\n\nSkip this step if you've given up waiting/looking.|T|Washte Pawne|RARE|
 R Bael Modan|ACTIVE|843|QO|1;2;3|M|46.35,85.00|Z|1413; The Barrens|N|Simply, it's southeast of you, across the road.|
 C Gann's Reclamation|QID|843|QO|1;2|Z|1413; The Barrens|N|Kill Bael'dun Excavators and Foremen.|S|
 C Gann's Reclamation|QID|843|QO|3|M|47.84,85.53|Z|1413; The Barrens|L|5006|ITEM|5006|N|Prospector Khazgorm.\n[color=FF0000]NOTE: [/color]He's in the center at the bottom of the dig site.|T|Prospector Khazgorm|
@@ -389,34 +393,34 @@ L Level 28|ACTIVE|879&893|N|Grind until you're within 4.5 bubbles of level 28.|L
 H Camp Taurajo|ACTIVE|879&893|M|45.58,59.04|Z|1413; The Barrens|N|Depending on how close you are, either hearth back to Camp Taurajo, or just run there and save your hearth.|
 T Weapons of Choice|QID|893|M|45.10,57.73|Z|1413; The Barrens|N|To Tatternack Steelforge.|
 A A New Ore Sample|QID|1153|M|45.10,57.73|Z|1413; The Barrens|N|From Tatternack Steelforge.|
-t Lakota'mani|QID|883|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|
-t Owatanka|QID|884|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|
-t Washte Pawne|QID|885|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|
-t The Harvester|QID|897|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|
+t Lakota'mani|QID|883|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|IZ|Camp Taurajo|
+t Owatanka|QID|884|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|IZ|Camp Taurajo|
+t Washte Pawne|QID|885|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|IZ|Camp Taurajo|
+t The Harvester|QID|897|M|44.87,59.09|Z|1413; The Barrens|N|To Jorn Skyseer.|IZ|Camp Taurajo|
 T Betrayal from Within|QID|879|M|44.55,59.23|Z|1413; The Barrens|N|To Mangletooth.|
 A Betrayal from Within|QID|906|PRE|879|M|44.55,59.23|Z|1413; The Barrens|N|From Mangletooth.|
 F Crossroads|ACTIVE|868|M|44.46,59.14|Z|1413; The Barrens|N|Fly to Crossroads to see Korran.|
 T Egg Hunt|QID|868|M|51.07,29.63|Z|1413; The Barrens|N|To Korran.|
 * Silithid Eggs|AVAILABLE|-868|M|PLAYER|CC|N|Destroy any Silithid eggs you have leftover.|U|5058|
 T Betrayal from Within|QID|906|M|51.49,30.81|Z|1413; The Barrens|N|To Thork.|
-F Orgrimmar|AVAILABLE|6441|M|51.50,30.33|Z|1413; The Barrens|N|Fly to Orgrimmar to do your training.|C|-Druid|
-F Thunder Bluff|AVAILABLE|6441|M|51.50,30.33|Z|1413; The Barrens|N|Fly to Thunder Bluff to do your training.|C|Druid|
+F Orgrimmar|AVAILABLE|6441|M|51.50,30.33|Z|1413; The Barrens|N|Fly to Orgrimmar to do your training.|C|Warlock,Rogue|
+F Thunder Bluff|AVAILABLE|6441|M|51.50,30.33|Z|1413; The Barrens|N|Fly to Thunder Bluff to do your training.|C|-Warlock,-Rogue|
 = Level 28 Training|AVAILABLE|6441|M|PLAYER|CC|N|Do your level 28 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|28|IZ|Orgrimmar^Thunder Bluff|
-B Deadly Blunderbuss|ACTIVE|6571|QO|1|L|4369|N|Before leaving, make sure you bring one of these with you.\nIf you have level 105 Engineering, you can make it yourself. Otherwise, a friend or the AH are your only options.\n[color=FF0000]NOTE: [/color]You can wait to get this, but you'll have make a special trip if you don't bring it now.|
+B Deadly Blunderbuss|ACTIVE|6571|QO|1|L|4369|ITEM|4369|N|before leaving. You're going to need it shortly.\nIf you have level 105 Engineering, you can make it yourself. Otherwise, a friend or the AH are your only options.\n[color=FF0000]NOTE: [/color]You can wait to get this, but you'll have make a special trip if you don't bring it now.|
 
 ; --- Ashenvale
 F Splintertree Post|AVAILABLE|6441|M|45.11,63.91|Z|1454; Orgrimmar|N|Fly to Splintertree to see Pixel.|
 A Satyr Horns|QID|6441|M|73.06,61.48|Z|1440; Ashenvale|N|From Pixel.|
-A Warsong Saw Blades|QID|6581|ACTIVE|6571|M|73.06,61.48|Z|1440; Ashenvale|L|16742|N|From Pixel.\n[color=FF0000]NOTE: [/color]You need to do this quest to get your quest item.\nSkip for now if you have to.|
+A Warsong Saw Blades|QID|6581|ACTIVE|6571|M|73.06,61.48|Z|1440; Ashenvale|L|-16742|N|From Pixel.\n[color=FF0000]NOTE: [/color]You need to do this quest to get your quest item.\nSkip for now if you have to.|O|
 T Warsong Saw Blades|QID|6581|M|73.06,61.48|Z|1440; Ashenvale|N|To Pixel.|
 A Stonetalon Standstill|QID|25|M|73.67,60.01|Z|1440; Ashenvale|N|From Mastok Wrilehiss.|
 A Ashenvale Outrunners|QID|6503|M|71.10,68.12|Z|1440; Ashenvale|N|From Kuray'bin.|
 N The Lost Pages|AVAILABLE|6504|Z|1440; Ashenvale|N|This next quest will have you collecting 12 single pages (4 pages per chapter) that drop from 72 different mobs throughout Ashenvale.\nYou may want to free up some bag space for these.\n[color=FF0000]NOTE: [/color]If you find that you are running out of room, try combining the pages to see if you have enough to free up some bag space.\n\nManually check this step off to continue.|
 A The Lost Pages|QID|6504|M|70.01,71.16|Z|1440; Ashenvale|N|From Gurda Ragescar.|
-l The Lost Pages|ACTIVE|6504|QO|1;2;3|M|PLAYER|CC|Z|1440; Ashenvale|N|Collect the 12 Shredder Operating Manual pages.|S!US|
-;U Shredder Operating Manual - Chapter 1|ACTIVE|6504|QO|1|M|PLAYER|CC|L|16642|N|Bind Pages 1-4 into Chapter 1.|U|16645^16646^16647^16648|O|
-;U Shredder Operating Manual - Chapter 2|ACTIVE|6504|QO|2|M|PLAYER|CC|L|16643|N|Bind Pages 5-8 into Chapter 2.|U|16649^16650^16651^16652|O|
-;U Shredder Operating Manual - Chapter 3|ACTIVE|6504|QO|3|M|PLAYER|CC|L|16644|N|Bind Pages 9-12 into Chapter 3.|U|16653^16654^16655^16656|O|
+l The Lost Pages|ACTIVE|6504|QO|1;2;3|M|PLAYER|CC|N|Collect the 12 Shredder Operating Manual pages.|S!US|
+;U Shredder Operating Manual - Chapter 1|ACTIVE|6504|QO|1|M|PLAYER|CC|L|16642|N|Bind Pages 1-4 into Chapter 1.|U|16645&16646&16647&16648|O|
+;U Shredder Operating Manual - Chapter 2|ACTIVE|6504|QO|2|M|PLAYER|CC|L|16643|N|Bind Pages 5-8 into Chapter 2.|U|16649&16650&16651&16652|O|
+;U Shredder Operating Manual - Chapter 3|ACTIVE|6504|QO|3|M|PLAYER|CC|L|16644|N|Bind Pages 9-12 into Chapter 3.|U|16653&16654&16655&16656|O|
 R The Dor'Danil Barrow Den|ACTIVE|6503|QO|1|M|73.05,70.59|Z|1440; Ashenvale|N|Just off the road to the east of you.|
 l Sharptalon's Claw|AVAILABLE|2|PRE|6383^235^742^6382|M|71.65,70.23;77.37,67.56|CN|Z|1440; Ashenvale|L|16305|ITEM|16305|N|Sharptalon, a lv 31 (non-elite) blue hippogryph that paths through this area.\n[color=FF0000]NOTE: [/color]He's part of the 'Ashenvale Hunt' quest with a respawn rate of ~15-20 minutes.\nIf you draw him towards the Forsaken by the tent, they'll help you kill it.|T|Sharptalon|S|
 A Sharptalon's Claw|QID|2|PRE|6383|Z|1440; Ashenvale|N|Right-click the item to activate the quest.|U|16305|O|
@@ -468,6 +472,10 @@ F Zoram'gar Outpost|ACTIVE|824|M|73.18,61.59|Z|1440; Ashenvale|N|Fly to Zoram'ga
 T Je'neu of the Earthen Ring|QID|824|M|11.56,34.29|Z|1440; Ashenvale|N|To Je'neu Sancrea.|
 A Between a Rock and a Thistlefur|QID|216|M|11.90,34.54|Z|1440; Ashenvale|N|From Karang Amakkar.|
 A Troll Charm|QID|6462|M|11.65,34.85|Z|1440; Ashenvale|N|From Mitsuwa.|
+A Vorsha the Lasher|QID|6641|M|12.06,34.64|Z|1440; Ashenvale|ELITE|N|[color=80FF00]Escort Quest:[/color]\nFrom Muglash.\n[color=FF0000]NOTE: [/color]If he's not there, just wait because someone is either already doing the quest, or he has died and awaiting respawn.|LVL|20|NA|
+A Vorsha the Lasher|QID|6641|M|12.06,34.64|Z|1440; Ashenvale|N|[color=CC00FF]QUEST FAILED[/color]\nGo back to Muglash to restart the quest.\n[color=FF0000]NOTE: [/color]If he's not there, just wait because someone is either already doing the quest, or he hasn't respawned yet.|LVL|20|FAIL|
+C Vorsha the Lasher|QID|6641|QO|1|M|9.63,27.61|Z|1440; Ashenvale|N|Escort Muglash to the brazier and right-click it to extinguish the flame to start the attack waves. Protect Muglash as you fight against 2 waves of 3 Nagas and then Vorsha in the final wave.\n[color=FF0000]NOTE: [/color]Make sure you kill the Priestesses first, as they will heal everyone fully.|T|Wrathtail Priestess|
+T Vorsha the Lasher|QID|6641|M|12.22,34.21|Z|1440; Ashenvale|N|To Warsong Runner.|
 R Thistlefur Village|ACTIVE|216|QO|1;2|M|30.87,45.69;33.49,38.23|CC|Z|1440; Ashenvale|N|Make your way to Thistlefur Village.\n[color=FF0000]NOTE: [/color]Choose your own path.|
 C Between a Rock and a Thistlefur|QID|216|QO|1;2|Z|1440; Ashenvale|N|Kill Thistlefur Avengers and Shaman.\nKill them as you run into them, but you'll have plenty of time to work on this.|S|
 R Thistlefur Hold|ACTIVE|6462|QO|1|M|37.42,32.35;38.46,30.63|CC|Z|1440; Ashenvale|N|Make your way through the gate.|
@@ -554,15 +562,15 @@ C Battle of Hillsbrad|QID|532|QO|1|M|29.65,41.70|Z|1424; Hillsbrad Foothills|N|K
 C Battle of Hillsbrad|QID|532|QO|3|M|29.73,41.75|Z|1424; Hillsbrad Foothills|N|Destroy the Hillsbrad Proclamation on the railing.|NC|
 C Battle of Hillsbrad|QID|532|QO|4|M|29.53,41.55|Z|1424; Hillsbrad Foothills|N|Destroy the Hillsbrad Town Registry on the floor by the book shelf in the corner.|NC|
 C Battle of Hillsbrad|QID|532|QO|2|Z|1424; Hillsbrad Foothills|N|Finish killing Hillsbrad Councilmen.|T|Hillsbrad Councilman|US|
-C Dangerous!|QID|567|QO|2|Z|1424; Hillsbrad Foothills|N|Kill Citizen Wilkes. He patrols the north branch of the main road in Hillsbrad Fields from the Forge up to the last house; stopping briefly at each building as he passes.\n[color=FF0000]NOTE: [/color]Being that this the last time you will be here, go find him.|T|Citizen Wilkes|US|
+C Dangerous!|QID|567|QO|2|M|32.60,41.60|Z|1424; Hillsbrad Foothills|N|Kill Citizen Wilkes. He patrols the north branch of the main road in Hillsbrad Fields from the Forge up to the last house; stopping briefly at each building as he passes.\n[color=FF0000]NOTE: [/color]Being that this the last time you will be here, go find him.|T|Citizen Wilkes|US|
 H Tarren Mill|ACTIVE|532|M|62.78,19.03|Z|1424; Hillsbrad Foothills|N|Hearth back to Tarren Mill.\n[color=FF0000]NOTE: [/color]You can choose to run back and save your hearth for your next trip here.|
 T Battle of Hillsbrad|QID|532|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Executor Darthalia.|
 A Battle of Hillsbrad|QID|539|PRE|532|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|From High Executor Darthalia.|
 R Azurelode Mine|ACTIVE|567|QO|3|M|27.50,59.30|Z|1424; Hillsbrad Foothills|N|Run to the upper entrance of Azurelode Mine.\n[color=FF0000]NOTE: [/color]You may want to clear the path by solo pulling the Sentries. They hit pretty hard.|
-C Battle of Hillsbrad|QID|539|QO|2|Z|1424; Hillsbrad Foothills|N|Kill Hillsbrad Miners.\n[color=FF0000]NOTE: [/color]This shouldn't take long, as they're everywhere.|S|
+C Battle of Hillsbrad|QID|539|QO|2|M|31.22,55.76|Z|1424; Hillsbrad Foothills|N|Kill Hillsbrad Miners.\n[color=FF0000]NOTE: [/color]This shouldn't take long, as they're everywhere.|S|
 C Dangerous!|QID|567|QO|3|M|27.27,58.63;28.61,52.80;29.77,54.13;29.78,55.63;29.94,54.58|CC|Z|1424; Hillsbrad Foothills|N|Work your way inside the mine and after clearing any potential adds, kill Miner Hackett.\n[color=FF0000]NOTE: [/color]He is level 29 and has multiple spawn spots. If he is not at this location, he's either dead, or he's down where Foreman Bonds is located. If you look over the ledge, you should see him below you.|T|Miner Hackett|
 C Battle of Hillsbrad|QID|539|QO|1|M|31.22,55.76|Z|1424; Hillsbrad Foothills|N|After clearing any potential adds, kill Foreman Bonds.\n[color=FF0000]NOTE: [/color]When he is almost dead, two lv 29 guards will spawn that take turns interrupting any spellcasting.\nFocus on killing Foreman Bonds. Once he's dead. You can resurrect outside the mine and go back in if you have to.|
-C Battle of Hillsbrad|QID|539|QO|2|Z|1424; Hillsbrad Foothills|N|Finish killing Hillsbrad Miners.|US|
+C Battle of Hillsbrad|QID|539|QO|2|M|31.22,55.76|Z|1424; Hillsbrad Foothills|N|Finish killing Hillsbrad Miners.|US|
 C Souvenirs of Death|QID|546|M|26.76,60.06|Z|1424; Hillsbrad Foothills|L|3692 30|ITEM|3692|N|any Hillsbrad mob.|US|
 R Western Strand|ACTIVE|515|QO|1|M|25.33,64.21|Z|1424; Hillsbrad Foothills|N|Using the lower entrance, exit Azurelode Mine and head south towards the shoreline.|
 C Elixir of Agony|QID|515|M|46.23,65.83|Z|1424; Hillsbrad Foothills|L|3510 5|ITEM|3510|N|Murlocs along the coast.\n[color=FF0000]NOTE: [/color]Muckdwellers are a better choice over Coastrunners (range attack) and avoid the huts as you tend to aggro 2-3 at a time.\nIf you prefer, you can do this in the water as you swim east.\n\nAvoid letting the Coastrunners get to far away from you when they run, they will aggro another Murloc and range attack you.|C|Warlock|S|
@@ -571,7 +579,7 @@ C Elixir of Agony|QID|515|M|46.23,65.83|Z|1424; Hillsbrad Foothills|L|3510 5|ITE
 R Eastern Strand|ACTIVE|515|QO|2|M|53.19,64.57|Z|1424; Hillsbrad Foothills|N|You have a couple choices at this point. You can either run north to the road and go around that way, or you can swim across at the southernmost point of the shoreline to maintain your distance from Southshore.\n[color=FF0000]NOTE: [/color]Southshore is Alliance controlled. So, unless you enjoy running from PvP guards, I'd keep your distance.|
 C Elixir of Agony|QID|515|M|65.58,84.28|Z|1424; Hillsbrad Foothills|L|3509 5|ITEM|3509|N|Nagas.|
 H Tarren Mill|ACTIVE|515|M|62.78,19.03|Z|1424; Hillsbrad Foothills|N|Hearth back to Tarren Mill.\n[color=FF0000]NOTE: [/color]Skip this step if your hearth is on cooldown.|
-R Tarren Mill|QID|515|M|62.81,41.59;63.31,29.84|CC|Z|1424; Hillsbrad Foothills|N|Return to Tarren Mill.\nDepending on which end of Eastern Strand you are at, you can either follow the road north of you, or weave your way to the river and follow the EAST bank north. The Southshore guards will leave you alone as long as you don't go in the water.\n[color=FF0000]NOTE: [/color]IF YOU GO IN THE WATER, YOU WILL DIE!!!|
+R Tarren Mill|ACTIVE|515|M|62.81,41.59;63.31,29.84|CC|Z|1424; Hillsbrad Foothills|N|Return to Tarren Mill.\nDepending on which end of Eastern Strand you're at, you can either follow the road north of you, or weave your way to the river and follow the EAST bank north. The Southshore guards will leave you alone as long as you don't go in the water.\n[color=FF0000]NOTE: [/color]IF YOU GO IN THE WATER, YOU WILL DIE!!!|
 T Elixir of Agony|QID|515|M|61.44,19.06|Z|1424; Hillsbrad Foothills|N|To Apothecary Lydon.\n[color=FF0000]NOTE: [/color]Do not accept the follow up. It's an Elite quest and not really worth the effort.|
 T Dangerous!|QID|567|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Executor Darthalia.|
 T Battle of Hillsbrad|QID|539|M|62.29,20.28|Z|1424; Hillsbrad Foothills|N|To High Executor Darthalia.\n[color=FF0000]NOTE: [/color]Do not accept the follow up. It's an Elite quest and not really worth the effort.|

--- a/WoWPro_Leveling/Vanilla/Horde/31_40_Hendo_HordeChapter2.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/31_40_Hendo_HordeChapter2.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-31-40-Hendo-HordeChapter2', 'Leveling', 'Thousand Needles', 'Hendo72', 'Horde',1)
+local guide = WoWPro:RegisterGuide('ClassicHorde3140', 'Leveling', 'Thousand Needles', 'WoWPro Team', 'Horde',1)
 WoWPro:GuideName(guide, 'Horde Chapter 2')
 WoWPro:GuideLevels(guide,30, 40)
-WoWPro:GuideNextGuide(guide, 'Classic-40-50-Hendo-HordeChapter3')
+WoWPro:GuideNextGuide(guide, 'ClassicHorde4050')
 WoWPro:GuideSteps(guide, function()
 return [[
 
@@ -523,7 +523,7 @@ T Goblin Sponsorship|QID|1183|M|80.18,75.88|N|To Pozzik.|
 A The Eighteenth Pilot|QID|1186|PRE|1183|M|80.18,75.88|N|From Pozzik.|
 T The Eighteenth Pilot|QID|1186|M|80.31,76.06|N|To Razzeric.\n[color=FF0000]NOTE: [/color]Do not get the follow-up quest.|
 ; --- The Barrens
-H Orgrimmar|ACTIVE|569|M|54.11,68.39|Z|1454; Orgrimmar|N|Hearth to Orgrimmar to do training, etc. before heading back to STV.|
+H Orgrimmar|ACTIVE|569|PRE|1186|M|54.11,68.39|Z|1454; Orgrimmar|N|Hearth to Orgrimmar to do training, etc. before heading back to STV.|
 F Thunder Bluff|ACTIVE|569|M|45.50,63.84|Z|1454; Orgrimmar|C|Druid|
 F Orgrimmar|ACTIVE|569|M|47.02,49.83|Z|1456; Thunder Bluff|C|Druid|
 ; --- STV
@@ -724,7 +724,8 @@ T Stinky's Escape|QID|1270|M|62.37,37.62|Z|1413; The Barrens|N|To Mebok Mizzyrix
 ; Stranglethorn Vale
 N Bank|ACTIVE|572^605^196|M|62.67,37.44|Z|1413; The Barrens|N|As you are now headed back to STV, make sure you grab all of your quest items from your bank before leaving.|IZ|392|
 b Booty Bay|ACTIVE|572^605^196|M|63.70,38.63|Z|1413; The Barrens|N|Take the boat to Booty Bay.|IZ|-1434|
-F Grom'gol Base Camp|ACTIVE|572^605^196|M|26.87,77.10|Z|1434; Stranglethorn Vale|N|Fly to Grom'gol Base Camp.|
+A Skullsplitter Tusks|QID|209|PRE|189|M|27.00,77.13|Z|1434; Stranglethorn Vale|N|From Kebok.|
+F Grom'gol Base Camp|ACTIVE|209|M|26.87,77.10|Z|1434; Stranglethorn Vale|N|Fly to Grom'gol Base Camp.|
 
 ; Saving for use in Chap3 - Hendo72
 ;A Excelsior|QID|628|PRE|577|M|28.29,77.59|Z|1434; Stranglethorn Vale|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Drizzlik.|

--- a/WoWPro_Leveling/Vanilla/Horde/41_50_Hendo_HordeChapter3.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/41_50_Hendo_HordeChapter3.lua
@@ -1,35 +1,34 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-local guide = WoWPro:RegisterGuide('Classic-40-50-Hendo-HordeChapter3', 'Leveling', 'Stranglethorn Vale', 'Hendo72', 'Horde',1)
+local guide = WoWPro:RegisterGuide('ClassicHorde4050', 'Leveling', 'Stranglethorn Vale', 'WoWPro Team', 'Horde',1)
 WoWPro:GuideName(guide, 'Horde Chapter 3')
 WoWPro:GuideLevels(guide,40, 50)
-WoWPro:GuideNextGuide(guide, 'Classic-51-53-Ungoro-Crater')
+WoWPro:GuideNextGuide(guide, 'ClassicUngoro5153')
 WoWPro:GuideSteps(guide, function()
 return [[
 
 R Southern Savage Coast|ACTIVE|605^572^196|M|32.62,35.53|Z|1434; Stranglethorn Vale|N|Exit Grom'gol Base to the south side and swim across to the opposite shore.|
-C Mok'thardin's Enchantment|QID|572|M|33.63,37.87|Z|1434; Stranglethorn Vale|L|3863 10|N|Kill Jungle Stalkers to collect the feathers.|S|
-K Raptor Mastery|ACTIVE|196|QO|1|M|33.63,37.87|Z|1434; Stranglethorn Vale|N|Kill Jungle Stalkers.|
-C Mok'thardin's Enchantment|QID|572|M|33.63,37.87|Z|1434; Stranglethorn Vale|L|3863 10|N|Kill Jungle Stalkers to collect the feathers.|US|
-C Singing Blue Shards|ACTIVE|605|M|33.63,37.87|Z|1434; Stranglethorn Vale|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|US|
-R Venture Co. Base Camp|ACTIVE|600|QO|1|M|44.82,25.69|Z|1434; Stranglethorn Vale|N|Head to the main road and follow it south across the bridge over the river.|
-C Venture Company Mining|QID|600|M|41.7,42.9|N|Kill goblins around for their crystals.|
-R Grom'gol Base Camp|ACTIVE|572|M|32.16,28.76|Z|1434; Stranglethorn Vale|
+C Mok'thardin's Enchantment|QID|572|M|33.63,37.87|Z|1434; Stranglethorn Vale|L|3863 10|ITEM|3863|N|Jungle Stalkers.|S|
+C Raptor Mastery|QID|196|M|33.63,37.87|Z|1434; Stranglethorn Vale|N|Kill Jungle Stalkers.|
+C Mok'thardin's Enchantment|QID|572|M|33.63,37.87|Z|1434; Stranglethorn Vale|L|3863 10|ITEM|3863|N|Jungle Stalkers.|US|
+C Singing Blue Shards|QID|605|M|33.63,37.87|Z|1434; Stranglethorn Vale|L|3918 10|ITEM|3918|N|Crystal Spine Basilisks.|
+R Grom'gol Base Camp|ACTIVE|572|M|32.16,28.76|Z|1434; Stranglethorn Vale|N|Return to Grom'gol.|
 T Mok'thardin's Enchantment|QID|572|M|32.12,29.25|Z|1434; Stranglethorn Vale|N|To Far Seer Mok'thardin.|
 A Mok'thardin's Enchantment|QID|571|PRE|572|M|32.12,29.25|Z|1434; Stranglethorn Vale|N|From Far Seer Mok'thardin.|
 A Split Bone Necklace|QID|598|PRE|572|M|32.27,27.71|Z|1434; Stranglethorn Vale|N|From Kin'weelay.|
-R The Vile Reef|ACTIVE|1107|QO|1|M|28.45,23.19|Z|1434; Stranglethorn Vale|N|Make your way to The Vile Reef.|
-C Encrusted Tail Fins|QID|1107|M|26.62,25.56|Z|1434; Stranglethorn Vale|L|5796 10|N|Kill Saltscale Murlocs to loot the Encrusted Tail Fins.\nThe best way to do this is to kite them to the surface so you don't drown by accident.\n This quest is not easy and can be time consuming.\n[color=FF0000]NOTE: [/color]Melee classes, focus on Warriors and Foragers. The others are range attack and will require you to fight underwater.|
-R Bal'lal Ruins|ACTIVE|584|QO|1;2|M|29.12,18.28|CC|Z|1434; Stranglethorn Vale|N|Make your way to the Bal'lal Ruins.|
+R The Vile Reef|ACTIVE|1107|QO|1|M|28.45,23.19|Z|1434; Stranglethorn Vale|N|Make your way out to The Vile Reef.|
+C Encrusted Tail Fins|QID|1107|M|26.62,25.56|Z|1434; Stranglethorn Vale|L|5796 10|ITEM|5796|N|Saltscale Murlocs.\n[color=FF0000]NOTE: [/color]The best way to do this is to kite them to the surface so you don't drown by accident.\nThis quest is not easy and can be time consuming.\nMelee classes, focus on Warriors and Foragers. The others are range attack and will require you to fight underwater.|
+C Split Bone Necklace|QID|598|M|24.72,11.49|Z|1434; Stranglethorn Vale|L|3916 25|ITEM|3916|N|any Skullsplitter mob.|S|
+R Bal'lal Ruins|ACTIVE|584|QO|1;2|M|29.12,18.28|Z|1434; Stranglethorn Vale|N|Make your way to the Bal'lal Ruins.|
 R Ruins of Zul'Kunda|ACTIVE|584|QO|1;2|M|30.03,13.07;27.93,11.33|CC|Z|1434; Stranglethorn Vale|N|Follow the cliff north to the Zul'Kunda entrance.\n[color=FF0000]NOTE: [/color]Pulling the guards at the entrance will not be possible as all of them are range attack. You can go around them by climbing the hill on the left side and coming down between the wall and the building.|
-K Nezzliok|ACTIVE|584|QO|2|M|23.26,9.77|Z|1434; Stranglethorn Vale|N|Work your way through the center of the Ruins to the ramp on the other side.\nSticking to the tall wall, clear the mobs as you walk up the ramp. You should be able to pull most of them solo, or a set of 2.\nAt the top the ramp, jump on top the wall and, staying on the outside edge, run to the opposite corner. Begin pulling the mobs around him until he is the only one left or he joins the fight.|
-K Gan'zulah|ACTIVE|584|QO|1|M|23.26,8.72|Z|1434; Stranglethorn Vale|N|Using the same process as you did with Nezzliok, pull the mobs closest to the wall until Gan'zulah is alone or joins the fight.|
-R Nesingwary's Expedition|ACTIVE|196|M|34.91,11.00|Z|1434; Stranglethorn Vale|N|Work your way out of the Ruins the same way you came in.\n[color=FF0000]NOTE: [/color]You can avoid some of the fight by dropping down to the lower ledge of the wall and walking around to where the bottom of the ramp is.\n Once you are out of the Ruins, make your way to the Nesingwary's Expedition.|
+C Bloodscalp Clan Heads|QID|584|QO|2|M|23.26,9.77|Z|1434; Stranglethorn Vale|N|Kill Nezzliok.\n[color=FF0000]NOTE: [/color]Work your way through the center of the Ruins to the ramp on the other side.\nSticking to the tall wall, clear the mobs as you walk up the ramp. You should be able to pull most of them solo, or a set of 2.\nAt the top the ramp, jump on top the wall and, staying on the outside edge, run to the opposite corner. Begin pulling the mobs around him until he is the only one left or he joins the fight.|
+C Bloodscalp Clan Heads|QID|584|QO|1|M|23.26,8.72|Z|1434; Stranglethorn Vale|N|Kill Gan'zulah.\n[color=FF0000]NOTE: [/color]Using the same process as you did with Nezzliok, pull the mobs closest to the wall until Gan'zulah is alone or joins the fight.|
+R Nesingwary's Expedition|ACTIVE|196|M|34.91,11.00|Z|1434; Stranglethorn Vale|N|Work your way out of the Ruins the same way you came in.\n[color=FF0000]NOTE: [/color]You can avoid some of the fighting by dropping down to the lower ledge of the wall and walking around to where the bottom of the ramp is.\nOnce you are out of the Ruins, make your way to Nesingwary's Expedition.|
 T Raptor Mastery|QID|196|M|35.66,10.81|Z|1434; Stranglethorn Vale|N|To Hemet Nesingwary.|
 A Raptor Mastery|QID|197|PRE|196|M|35.66,10.81|Z|1434; Stranglethorn Vale|N|From Hemet Nesingwary.|
-C Bhag'thera|QID|193|M|47.35,28.40;49.65,23.63;48.58,19.59|CN|Z|1434; Stranglethorn Vale|L|3876|ITEM|3876|N|Bhag'thera. You'll find Bhag'thera in 1 of 3 locations. When you find him, kill him to loot his fang.\n[color=FF0000]NOTE: [/color]As you are moving between the spots, be sure to give the elite Ogres around the entrance to Mosh'Ogg a VERY wide berth.|
+C Bhag'thera|QID|193|M|47.35,28.40;49.65,23.63;48.58,19.59|CN|Z|1434; Stranglethorn Vale|L|3876|ITEM|3876|N|Bhag'thera in 1 of 3 locations.\n[color=FF0000]NOTE: [/color]As you are moving between the spots, be sure to give the elite Ogres around the entrance to Mosh'Ogg a VERY wide berth.|
+C Skullsplitter Tusks|QID|209|M|46.11,44.90|Z|1434; Stranglethorn Vale|L|1524 18|ITEM|1524|N|any Skullsplitter in either of the Ruins to the south of you.\n[color=FF0000]NOTE: [/color]Avoid the groups of 3 that travel the roads around the area.|
 
 ]]
-
 end)

--- a/WoWPro_Leveling/Vanilla/Horde/51_53_UnGoro_Crater.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/51_53_UnGoro_Crater.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide('classic-young-ungoro', 'Leveling', "Un'Goro Crater", 'Jame', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicUngoro5153', 'Leveling', "Un'Goro Crater", 'WoWPro Team', 'Horde', 1)
 WoWPro:GuideName(guide, "Un'Goro Crater (51-53)")
 WoWPro:GuideLevels(guide, 51, 53, 52)
-WoWPro:GuideNextGuide(guide, 'classic-young-burning-steppes')
+WoWPro:GuideNextGuide(guide, 'ClassicHordeBurningSteppes')
 WoWPro:GuideSteps(guide, function()
 return [[
 

--- a/WoWPro_Leveling/Vanilla/Horde/53_54_Burning_Steppes.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/53_54_Burning_Steppes.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide('classic-young-burning-steppes', 'Leveling', 'Burning Steppes', 'Jame', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicHordeBurningSteppes5354', 'Leveling', 'Burning Steppes', 'WoWPro Team', 'Horde', 1)
 WoWPro:GuideName(guide, 'Burning Steppes (53-54)')
 WoWPro:GuideLevels(guide, 53, 54, 53.5)
-WoWPro:GuideNextGuide(guide, 'classic-young-felwood')
+WoWPro:GuideNextGuide(guide, 'ClassicHordeFelwood5455')
 WoWPro:GuideSteps(guide, function()
 return [[
 

--- a/WoWPro_Leveling/Vanilla/Horde/54_55_Winterspring.lua
+++ b/WoWPro_Leveling/Vanilla/Horde/54_55_Winterspring.lua
@@ -1,8 +1,8 @@
 
-local guide = WoWPro:RegisterGuide('classic-young-winterspring', 'Leveling', 'Winterspring', 'Jame', 'Horde', 1)
+local guide = WoWPro:RegisterGuide('ClassicHordeWinterspring5455', 'Leveling', 'Winterspring', 'WoWPro Team', 'Horde', 1)
 WoWPro:GuideName(guide, 'Winterspring (54-55)')
 WoWPro:GuideLevels(guide, 54, 55, 54.75)
-WoWPro:GuideNextGuide(guide, 'classic-young-western-plaguelands56')
+WoWPro:GuideNextGuide(guide, 'ClassicHordeWesternPlaguelands56')
 WoWPro:GuideSteps(guide, function()
 return [[
 

--- a/WoWPro_Leveling/WoWPro_Leveling.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling.lua
@@ -41,10 +41,10 @@ WoWPro.Leveling.ClassicStartGuides = {
     Gnome = 'ClassicDunMorogh0112',
     Human = 'ClassicElwynn0112',
     NightElf = "ClassicTeldrassil0112",
-    Orc = 'Classic-01-12-Hendo-Durotar',
-    Scourge = 'Classic-01-12-Hendo-TirisfalGlades',
-    Tauren = 'Classic-01-12-Hendo-Mulgore',
-    Troll = 'Classic-01-12-Hendo-Durotar'
+    Orc = 'ClassicDurotar0112',
+    Scourge = 'ClassicTirisfalGlades0112',
+    Tauren = 'ClassicMulgore0112',
+    Troll = 'ClassicDurotar0112'
 }
 WoWPro.Leveling.ClassicBCStartGuides = {
     BloodElf = "BC-BloodElf",


### PR DESCRIPTION
- missing hyphen in guide registry
- decided to update horde naming scheme to reflect the one used for Alliance.