### PR TITLE
Use IsInGroup for group-sync checks and fix group note gating

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -922,7 +922,7 @@ end
 
 function WoWPro:SendGroupInfo()
 	--if WoWProCharDB.GroupSync then
-	if _G.GetNumSubgroupMembers(_G.LE_PARTY_CATEGORY_HOME) > 0 then
+	if _G.IsInGroup(_G.LE_PARTY_CATEGORY_HOME) then
 		local _, myclass = _G.UnitClass("player")
 		local _, myrace = _G.UnitRace("player")
 		local gender = _G.UnitSex("player")

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1477,7 +1477,7 @@ if step then
             end}
         )
     end
-    if QID and WoWPro.QuestLog[QID] and WoWPro.QuestLog[QID].index and _G.GetNumGroupMembers() > 0 then
+    if QID and WoWPro.QuestLog[QID] and WoWPro.QuestLog[QID].index and _G.IsInGroup() then
         tinsert(dropdown,
             {text = "Share Quest", func = function()
                 _G.QuestLogPushQuest(WoWPro.QuestLog[QID].index)
@@ -2529,14 +2529,14 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 end
             end
             -- A/N Group Steps --
-            if (WoWPro.group[guideIndex] and (_G.GetNumGroupMembers() == 0) and stepAction == "A") then
+            if (WoWPro.group[guideIndex] and (not _G.IsInGroup()) and stepAction == "A") then
                 local why = "You are not in a group."
                 WoWPro.why[guideIndex] = why
                 WoWPro:dbp(why)
                 skip = true
                 break
             end
-            if (WoWPro.group[guideIndex] and (_G.GetNumGroupMembers() >= 0) and stepAction == "N") then
+            if (WoWPro.group[guideIndex] and _G.IsInGroup() and stepAction == "N") then
                 local why = "You are in a group, note not needed."
                 WoWPro.why[guideIndex] = why
                 WoWPro:dbp(why)

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -410,7 +410,7 @@ WoWPro.RegisterEventHandler("UPDATE_BINDINGS", WoWPro.PLAYER_REGEN_ENABLED)
 local successfulRequest = _G.C_ChatInfo.RegisterAddonMessagePrefix("WoWPro")
 
 WoWPro.RegisterEventHandler("GROUP_ROSTER_UPDATE", function(event, ...)
-	if _G.GetNumSubgroupMembers(_G.LE_PARTY_CATEGORY_HOME) == 0 then
+	if not _G.IsInGroup(_G.LE_PARTY_CATEGORY_HOME) then
 		WoWPro.GroupSync = false
 	end
 	if successfulRequest then
@@ -440,7 +440,7 @@ WoWPro.GroupVersionMismatchOnce = {}
 
 WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 	local _, prefix, text, _, sender = event, ...
-	if successfulRequest and prefix == "WoWPro" and _G.GetNumSubgroupMembers(_G.LE_PARTY_CATEGORY_HOME) > 0 then
+	if successfulRequest and prefix == "WoWPro" and _G.IsInGroup(_G.LE_PARTY_CATEGORY_HOME) then
 		local synctype, message = string.split(" ", text, 2)
 		local gname = string.split("-", sender, 2)
 		if gname ~= _G.UnitName("Player") then


### PR DESCRIPTION
- Replaced legacy group member count checks with IsInGroup for clearer, category-aware group detection.
- Updated group-sync/event gating logic to use home-category checks in WoWPro_Events.lua:413 and WoWPro_Events.lua:443.
- Updated addon group info send guard in WoWPro.lua:925.
- Updated quest share and group-step gating in WoWPro_Broker.lua:1480, WoWPro_Broker.lua:2532, and WoWPro_Broker.lua:2539. 
- Fixed logic bug where the N-step group check was always true due to a >= 0 condition. No functional changes outside group membership detection and related gating.