### PR TITLE
Fix WoWPro tooltip layering and sizing in guide rows

### DIFF
--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -1164,7 +1164,7 @@ function WoWPro:CreateDialogBox(name, w, h)
     frame:SetBackdropColor(0.05, 0.05, 0.05, 1)
     frame:SetHeight(h)
     frame:SetWidth(w)
-    frame:SetFrameStrata("TOOLTIP")
+    frame:SetFrameStrata("FULLSCREEN_DIALOG")
     frame:Hide()
 
     local titletext = frame:CreateFontString()

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -58,7 +58,7 @@ function WoWPro:CreateAction(parent, anchor)
     action.frame = frame
     action:SetAllPoints()
 
-    local tooltip = _G.CreateFrame("Frame", nil, frame, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
+    local tooltip = _G.CreateFrame("Frame", nil, _G.UIParent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     tooltip:SetBackdrop( {
         bgFile = [[Interface\CHARACTERFRAME\UI-Party-Background]],
         edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],
@@ -69,7 +69,10 @@ function WoWPro:CreateAction(parent, anchor)
     tooltip:SetHeight(125)
     tooltip:SetWidth(64)
     tooltip:SetAlpha(1)
-    tooltip:SetFrameStrata("TOOLTIP")
+    tooltip:SetFrameStrata("FULLSCREEN_DIALOG")
+    tooltip:SetFrameLevel(1000)
+    tooltip:SetToplevel(true)
+    tooltip:SetClampedToScreen(true)
     tooltip:Hide()
 
     local tooltiptext = tooltip:CreateFontString(nil, nil, "GameFontNormal")
@@ -83,6 +86,12 @@ function WoWPro:CreateAction(parent, anchor)
     tooltip.text = tooltiptext
 
     frame:SetScript("OnEnter", function()
+        local textWidth = tooltiptext:GetStringWidth() + 20
+        if textWidth < 80 then textWidth = 80 end
+        if textWidth > 260 then textWidth = 260 end
+        tooltip:SetWidth(textWidth)
+        tooltiptext:SetWidth(textWidth - 20)
+
         tooltip:SetPoint("BOTTOMLEFT", frame, "TOPRIGHT", 0, 0)
         tooltiptext:SetHeight(125)
         tooltiptext:SetHeight(tooltiptext:GetStringHeight())
@@ -574,8 +583,10 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
     local row = _G.CreateFrame("Frame", nil, parent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     local tooltip = WoWPro.GuideRowTooltip
     local tooltiptext = tooltip.tooltiptext
-    tooltip:SetParent(parent)
-    tooltip:SetFrameLevel(row:GetFrameLevel() + 1)
+    tooltip:SetParent(_G.UIParent)
+    tooltip:SetFrameStrata("FULLSCREEN_DIALOG")
+    tooltip:SetFrameLevel(1000)
+    tooltip:SetToplevel(true)
     row:SetPoint("LEFT", 12, 0)
     row:SetHeight(rowHeight or 25)
 

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -69,9 +69,8 @@ function WoWPro:CreateAction(parent, anchor)
     tooltip:SetHeight(125)
     tooltip:SetWidth(64)
     tooltip:SetAlpha(1)
-    tooltip:SetFrameStrata("FULLSCREEN_DIALOG")
-    tooltip:SetFrameLevel(1000)
-    tooltip:SetToplevel(true)
+    tooltip:SetFrameStrata("DIALOG")
+    tooltip:SetFrameLevel(100)
     tooltip:SetClampedToScreen(true)
     tooltip:Hide()
 
@@ -80,22 +79,21 @@ function WoWPro:CreateAction(parent, anchor)
     tooltiptext:SetPoint("RIGHT", -10, 0)
     tooltiptext:SetJustifyH("LEFT")
     tooltiptext:SetJustifyV("TOP")
-    tooltiptext:SetWidth(50)
+    tooltiptext:SetWidth(160)
     tooltiptext:SetAlpha(1)
     tooltiptext:SetText("")
     tooltip.text = tooltiptext
 
     frame:SetScript("OnEnter", function()
-        local textWidth = tooltiptext:GetStringWidth() + 20
-        if textWidth < 80 then textWidth = 80 end
-        if textWidth > 260 then textWidth = 260 end
-        tooltip:SetWidth(textWidth)
-        tooltiptext:SetWidth(textWidth - 20)
+        local width = tooltiptext:GetStringWidth() + 20
+        if width < 80 then width = 80 end
+        if width > 260 then width = 260 end
+        tooltiptext:SetWidth(width - 20)
+        tooltip:SetWidth(width)
 
         tooltip:SetPoint("BOTTOMLEFT", frame, "TOPRIGHT", 0, 0)
-        tooltiptext:SetHeight(125)
         tooltiptext:SetHeight(tooltiptext:GetStringHeight())
-        tooltip:SetHeight(tooltiptext:GetStringHeight()+20)
+        tooltip:SetHeight(tooltiptext:GetStringHeight() + 20)
         tooltip:Show()
     end)
     frame:SetScript("OnLeave", function()
@@ -562,7 +560,7 @@ do
     tooltip:SetBackdropColor(0, 0, 0, 0.7)
     tooltip:SetHeight(125)
     tooltip:SetWidth(512)
-    tooltip:SetFrameStrata("FULLSCREEN_DIALOG")
+    tooltip:SetFrameStrata("DIALOG")
     tooltip:SetFrameLevel(100)
 
     tooltip:Hide()
@@ -584,9 +582,8 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
     local tooltip = WoWPro.GuideRowTooltip
     local tooltiptext = tooltip.tooltiptext
     tooltip:SetParent(_G.UIParent)
-    tooltip:SetFrameStrata("FULLSCREEN_DIALOG")
-    tooltip:SetFrameLevel(1000)
-    tooltip:SetToplevel(true)
+    tooltip:SetFrameStrata("DIALOG")
+    tooltip:SetFrameLevel(100)
     row:SetPoint("LEFT", 12, 0)
     row:SetHeight(rowHeight or 25)
 

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -637,7 +637,7 @@ function WoWPro:CreateErrorLog(title)
     ErrorLog = _G.CreateFrame("Frame", "WoWProErrorLog", _G.UIParent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     ErrorLog:Hide()
     ErrorLog:SetPoint("CENTER", "UIParent", "CENTER")
-    ErrorLog:SetFrameStrata("TOOLTIP")
+    ErrorLog:SetFrameStrata("FULLSCREEN_DIALOG")
     ErrorLog:SetHeight(512)
     ErrorLog:SetWidth(768)
     ErrorLog:SetBackdrop({


### PR DESCRIPTION
- Keep action/row tooltips above guide header text by using dialog strata and frame level.

- Prevent icon tooltip text truncation by auto-sizing width from content with min/max bounds.

- Clamp tooltip to screen to avoid off-screen clipping near edges.

- Preserve existing hover behavior while improving readability and visual priority.