### PR TITLE
Modernize Options Panel

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -378,7 +378,7 @@ function WoWPro:OnInitialize()
     WoWProDB.global.RecklessCombat = true
     WoWProDB.global.Achievements = WoWProDB.global.Achievements or {}
     WoWProDB.global.NpcFauxQuests = WoWProDB.global.NpcFauxQuests or {}
-    WoWProDB.global.QuestEngineDelay = WoWProDB.global.QuestEngineDelay or 0.25
+    WoWProDB.global.QuestEngineDelay = WoWProDB.global.QuestEngineDelay or 0.5
     WoWProCharDB.disabledAddons = WoWProCharDB.disabledAddons or {}
     if WoWProCharDB.NoTomTom == nil then
         WoWProCharDB.NoTomTom = false

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -44,670 +44,652 @@ local function createDisplayConfig()
         name = L["Guide Display"],
         desc = L["Options that alter the way the guide frame looks"],
         args = {
-            desc = {
-                order = 0,
-                type = "description",
-                name = L["On this page you can edit the way the guide frame looks."],
-            },
-            blank1 = {
+            displayPanel = {
                 order = 1,
-                type = "description",
-                name = " ",
-            },
-            padding = {
-                order = 25,
-                type = "range",
-                name = L["Padding"],
-                desc = L["The padding determines how much blank space is left between the guide text and the border of the guide frame."],
-                min = 0, max = 20, step = 1,
-                get = function(info) return WoWProDB.profile.pad end,
-                set = function(info,val) WoWProDB.profile.pad = val
-                    WoWPro.PaddingSet(); WoWPro.RowSizeSet() end,
-                width = "double"
-            },
-            spacing = {
-                order = 26,
-                type = "range",
-                name = L["Spacing"],
-                desc = L["Spacing determines how much blank space is left between lines in the guide text. "],
-                min = 0, max = 10, step = 1,
-                get = function(info) return WoWProDB.profile.space end,
-                set = function(info,val) WoWProDB.profile.space = val
-                    WoWPro.RowSizeSet() end,
-                width = "double"
-            },
-            hide = {
-                order = 6,
-                type = "toggle",
-                name = L["Enable Instance Hide"],
-                desc = L["Enables/Disables hiding the active module when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
-                get = function(info) return WoWProCharDB.AutoHideInsideInstances ; end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoHideInsideInstances == true then WoWProCharDB.AutoHideInsideInstances=false; else WoWProCharDB.AutoHideInsideInstances=true; end
-                   end
-            },
-            notify = {
-                order = 6.5,
-                type = "toggle",
-                name = L["Enable Instance Notify"],
-                desc = L["Enables/Disables notifying when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
-                get = function(info) return WoWProCharDB.AutoHideInsideInstancesNotify ; end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoHideInsideInstancesNotify == true then WoWProCharDB.AutoHideInsideInstancesNotify=false; else WoWProCharDB.AutoHideInsideInstancesNotify=true; end
-                    end
-            },
-            combathide = {
-                order = 7,
-                type = "toggle",
-                name = L["Enable Combat Hide"],
-                desc = L["Enables/Disables hiding the active module when you are in combat."],
-                get = function(info) return WoWProCharDB.AutoHideInCombat ; end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoHideInCombat == true then WoWProCharDB.AutoHideInCombat=false; else WoWProCharDB.AutoHideInCombat=true; end
-                    end
-            },
-            noteshow = {
-                order = 8,
-                type = "toggle",
-                name = L["Mouseover Notes"],
-                desc = L["Show notes on mouseover instead of always displaying them."],
-                get = function(info) return WoWProDB.profile.mousenotes end,
-                set = function(info,val) WoWProDB.profile.mousenotes = val
-                    WoWPro.RowSizeSet() end
-            },
-            minimap = {
-                order = 9,
-                type = "toggle",
-                name = L["Minimap Button"],
-                desc = L["Show/hide WoW-Pro mini map button."],
-                get = function(info) return not WoWProDB.profile.minimap.hide end,
-                set = function(info,val) WoWProDB.profile.minimap.hide = not val
-                     WoWPro.MinimapSet() end
-            },
-            track = {
-                order = 10,
-                type = "toggle",
-                name = L["Quest Tracking"],
-                desc = L["Allows tracking of quests in the guide frame"],
-                get = function(info) return WoWProDB.profile.track end,
-                set = function(info,val) WoWProDB.profile.track = val
-                    WoWPro:UpdateGuide("Config: Quest Tracking") end
-            },
-            showcoords = {
-                order = 11,
-                type = "toggle",
-                name = L["Show Coordinates"],
-                desc = L["Shows the coordinates in the note text."],
-                get = function(info) return WoWProDB.profile.showcoords end,
-                set = function(info,val) WoWProDB.profile.showcoords = val
-                    WoWPro:UpdateGuide("Config: Show Coordinates") end
-            },
-            autoload = {
-                order = 12,
-                type = "toggle",
-                name = L["Auto-Load Guide"],
-                desc = L["Will automatically load the next guide when you complete one."],
-                get = function(info) return WoWProDB.profile.autoload end,
-                set = function(info,val) WoWProDB.profile.autoload = val end
-            },
-            guidescroll = {
-                order = 21,
-                type = "toggle",
-                name = L["Scroll Mode"],
-                desc = L["Displays full, scrollable guide in guide frame, instead of need-to-know info."],
-                get = function(info) return WoWProDB.profile.guidescroll end,
-                set = function(info,val) WoWProDB.profile.guidescroll = val
-                    WoWPro:TitlebarSet()
-                    WoWPro:UpdateGuide("Config: Scroll Mode") end,
-            },
-            guideprogress = {
-                order = 21.5,
-                type = "toggle",
-                name = L["Guide Progress"],
-                desc = L["If enabled, will show the progress of the guide as a count rather than %."],
-                get = function(info) return WoWProDB.profile.guideprogress end,
-                set = function(info, val)
-                    WoWProDB.profile.guideprogress = val
-                    WoWPro:TitlebarSet()
-                    WoWPro:UpdateGuide("Config: Guide Progress")
-                end,
-            },
-            progressbar = {
-                order = 21.7,
-                type = "toggle",
-                name = L["Display Quest Progress Bar"],
-                desc = L["If enabled, will show a progrerss bar for % based quests"],
-                get = function(info) return WoWProDB.profile.progressbar end,
-                set = function(info, val)
-                    WoWProDB.profile.progressbar = val
-                    WoWPro:UpdateGuide("Config: Display Quest Progress")
-                end,
-            },
-            checksoundfile = {
-                order = 23,
-                type = "select",
-                name = L["Step Completed Sound"],
-                desc = L["Sound played when a guide step is completed"],
-                values = function() local values = {}
-                    for k,v in pairs(soundfiles) do
-                        values[v] = k
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.checksoundfile end,
-                set = function(info,val) WoWProDB.profile.checksoundfile = val
-                    _G.PlaySoundFile(val) end,
-                disabled = function(...) return not WoWProDB.profile.checksound end,
-            },
-            checksound = {
-                order = 23,
-                type = "toggle",
-                name = L["Enable Sound"],
-                desc = L["Plays a check-off sound when a guide step is completed."],
-                get = function(info) return WoWProDB.profile.checksound end,
-                set = function(info,val) WoWProDB.profile.checksound = val end
-            },
-            lefty = {
-                order = 22,
-                type = "toggle",
-                name = L["Left Handed"],
-                desc = L["When enabled:\n- Target and Use buttons move to the right side of the window\n\nAuto-protect:\n- Automatically enables or disables to keep the buttons on-screen\n\nWhen disabled:\n- Buttons stay on the left side of the window"],
-                get = function(info) return WoWProDB.profile.leftside end,
-                set = function(info,val) WoWProDB.profile.leftside = val
-                    -- Reposition buttons when left-handed mode changes
-                    if WoWPro.rows then
-                        for _, row in ipairs(WoWPro.rows) do
-                            if row.itembutton then
-                                row.itembutton:ClearAllPoints()
-                                if val then
-                                    row.itembutton:SetPoint("TOPLEFT", row, "TOPRIGHT", 10, -7)
-                                else
-                                    row.itembutton:SetPoint("TOPRIGHT", row, "TOPLEFT", -10, -7)
+                type = "group",
+                name = L["Guide Display"],
+                inline = true,
+                args = {
+                    intro = {
+                        order = 1,
+                        type = "description",
+                        name = L["On this page you can edit the way the guide frame looks."],
+                        width = "full",
+                    },
+                    behavior = {
+                        order = 10,
+                        type = "group",
+                        name = "Behavior",
+                        inline = true,
+                        args = {
+                            hide = {
+                                order = 1,
+                                type = "toggle",
+                                name = L["Enable Instance Hide"],
+                                desc = L["Enables/Disables hiding the active module when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
+                                width = "double",
+                                get = function(info) return WoWProCharDB.AutoHideInsideInstances ; end,
+                                set = function(info,val)
+                                    if WoWProCharDB.AutoHideInsideInstances == true then WoWProCharDB.AutoHideInsideInstances=false; else WoWProCharDB.AutoHideInsideInstances=true; end
                                 end
-                            end
-                            if row.targetbutton then
-                                row.targetbutton:ClearAllPoints()
-                                if row.targetbutton.Position then
-                                    row.targetbutton:Position(true)
-                                else
-                                    -- Only offset if itembutton is shown
-                                    if row.itembutton and row.itembutton:IsShown() then
-                                        if val then
-                                            row.targetbutton:SetPoint("TOPLEFT", row, "TOPRIGHT", 46, -7)
-                                        else
-                                            row.targetbutton:SetPoint("TOPRIGHT", row, "TOPLEFT", -46, -7)
-                                        end
-                                    else
-                                        if val then
-                                            row.targetbutton:SetPoint("TOPLEFT", row, "TOPRIGHT", 10, -7)
-                                        else
-                                            row.targetbutton:SetPoint("TOPRIGHT", row, "TOPLEFT", -10, -7)
+                            },
+                            notify = {
+                                order = 2,
+                                type = "toggle",
+                                name = L["Enable Instance Notify"],
+                                desc = L["Enables/Disables notifying when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
+                                width = "double",
+                                get = function(info) return WoWProCharDB.AutoHideInsideInstancesNotify ; end,
+                                set = function(info,val)
+                                    if WoWProCharDB.AutoHideInsideInstancesNotify == true then WoWProCharDB.AutoHideInsideInstancesNotify=false; else WoWProCharDB.AutoHideInsideInstancesNotify=true; end
+                                end
+                            },
+                            combathide = {
+                                order = 3,
+                                type = "toggle",
+                                name = L["Enable Combat Hide"],
+                                desc = L["Enables/Disables hiding the active module when you are in combat."],
+                                width = "double",
+                                get = function(info) return WoWProCharDB.AutoHideInCombat ; end,
+                                set = function(info,val)
+                                    if WoWProCharDB.AutoHideInCombat == true then WoWProCharDB.AutoHideInCombat=false; else WoWProCharDB.AutoHideInCombat=true; end
+                                end
+                            },
+                            noteshow = {
+                                order = 4,
+                                type = "toggle",
+                                name = L["Mouseover Notes"],
+                                desc = L["Show notes on mouseover instead of always displaying them."],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.mousenotes end,
+                                set = function(info,val) WoWProDB.profile.mousenotes = val
+                                    WoWPro.RowSizeSet() end
+                            },
+                            track = {
+                                order = 6,
+                                type = "toggle",
+                                name = L["Quest Tracking"],
+                                desc = L["Allows tracking of quests in the guide frame"],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.track end,
+                                set = function(info,val) WoWProDB.profile.track = val
+                                    WoWPro:UpdateGuide("Config: Quest Tracking") end
+                            },
+                            showcoords = {
+                                order = 7,
+                                type = "toggle",
+                                name = L["Show Coordinates"],
+                                desc = L["Shows the coordinates in the note text."],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.showcoords end,
+                                set = function(info,val) WoWProDB.profile.showcoords = val
+                                    WoWPro:UpdateGuide("Config: Show Coordinates") end
+                            },
+                            autoload = {
+                                order = 8,
+                                type = "toggle",
+                                name = L["Auto-Load Guide"],
+                                desc = L["Will automatically load the next guide when you complete one."],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.autoload end,
+                                set = function(info,val) WoWProDB.profile.autoload = val end
+                            },
+                            guidescroll = {
+                                order = 9,
+                                type = "toggle",
+                                name = L["Scroll Mode"],
+                                desc = L["Displays full, scrollable guide in guide frame, instead of need-to-know info."],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.guidescroll end,
+                                set = function(info,val) WoWProDB.profile.guidescroll = val
+                                    WoWPro:TitlebarSet()
+                                    WoWPro:UpdateGuide("Config: Scroll Mode") end,
+                            },
+                            guideprogress = {
+                                order = 10,
+                                type = "toggle",
+                                name = L["Guide Progress"],
+                                desc = L["If enabled, will show the progress of the guide as a count rather than %."],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.guideprogress end,
+                                set = function(info, val)
+                                    WoWProDB.profile.guideprogress = val
+                                    WoWPro:TitlebarSet()
+                                    WoWPro:UpdateGuide("Config: Guide Progress")
+                                end,
+                            },
+                            progressbar = {
+                                order = 11,
+                                type = "toggle",
+                                name = L["Display Quest Progress Bar"],
+                                desc = L["If enabled, will show a progrerss bar for % based quests"],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.progressbar end,
+                                set = function(info, val)
+                                    WoWProDB.profile.progressbar = val
+                                    WoWPro:UpdateGuide("Config: Display Quest Progress")
+                                end,
+                            },
+                            lefty = {
+                                order = 14,
+                                type = "toggle",
+                                name = L["Left Handed"],
+                                desc = L["When enabled:\n- Target and Use buttons move to the right side of the window\n\nAuto-protect:\n- Automatically enables or disables to keep the buttons on-screen\n\nWhen disabled:\n- Buttons stay on the left side of the window"],
+                                width = "double",
+                                get = function(info) return WoWProDB.profile.leftside end,
+                                set = function(info,val) WoWProDB.profile.leftside = val
+                                    if WoWPro.rows then
+                                        for _, row in ipairs(WoWPro.rows) do
+                                            if row.itembutton then
+                                                row.itembutton:ClearAllPoints()
+                                                if val then
+                                                    row.itembutton:SetPoint("TOPLEFT", row, "TOPRIGHT", 10, -7)
+                                                else
+                                                    row.itembutton:SetPoint("TOPRIGHT", row, "TOPLEFT", -10, -7)
+                                                end
+                                            end
+                                            if row.targetbutton then
+                                                row.targetbutton:ClearAllPoints()
+                                                if row.targetbutton.Position then
+                                                    row.targetbutton:Position(true)
+                                                else
+                                                    if row.itembutton and row.itembutton:IsShown() then
+                                                        if val then
+                                                            row.targetbutton:SetPoint("TOPLEFT", row, "TOPRIGHT", 46, -7)
+                                                        else
+                                                            row.targetbutton:SetPoint("TOPRIGHT", row, "TOPLEFT", -46, -7)
+                                                        end
+                                                    else
+                                                        if val then
+                                                            row.targetbutton:SetPoint("TOPLEFT", row, "TOPRIGHT", 10, -7)
+                                                        else
+                                                            row.targetbutton:SetPoint("TOPRIGHT", row, "TOPLEFT", -10, -7)
+                                                        end
+                                                    end
+                                                end
+                                            end
                                         end
                                     end
                                 end
-                            end
-                        end
-                    end
-                end
-            },
-            anchorheading = {
-                order = 30,
-                type = "header",
-                name = L["Window Expansion Anchor"],
-            },
-            drag = {
-                order = 30.1,
-                type = "toggle",
-                name = L["Enable Drag"],
-                desc = L["When enabled: Click on the button bar to move the window. Drag to reposition it on your screen.\nWhen disabled: Window is locked in place."],
-                get = function(info) return WoWProDB.profile.drag end,
-                set = function(info,val) WoWProDB.profile.drag = val
-                    WoWPro.DragSet() end
-            },
-            expansionAnchor = {
-                order = 30.3,
-                type = "select",
-                name = " ",
-                desc = L["Choose which corner the window expands from; content grows away from that corner and stays on-screen."],
-                values = {
-                    ["TOPLEFT"] = "Top Left",
-                    ["TOPRIGHT"] = "Top Right",
-                    ["BOTTOMLEFT"] = "Bottom Left",
-                    ["BOTTOMRIGHT"] = "Bottom Right",
+                            },
+                        },
+                    },
+                    windowLayout = {
+                        order = 20,
+                        type = "group",
+                        name = "Window Layout",
+                        inline = true,
+                        args = {
+                            padding = {
+                                order = 1,
+                                type = "range",
+                                name = L["Padding"],
+                                desc = L["The padding determines how much blank space is left between the guide text and the border of the guide frame."],
+                                min = 0, max = 20, step = 1,
+                                get = function(info) return WoWProDB.profile.pad end,
+                                set = function(info,val) WoWProDB.profile.pad = val
+                                    WoWPro.PaddingSet(); WoWPro.RowSizeSet() end,
+                                width = "full"
+                            },
+                            spacing = {
+                                order = 2,
+                                type = "range",
+                                name = L["Spacing"],
+                                desc = L["Spacing determines how much blank space is left between lines in the guide text. "],
+                                min = 0, max = 10, step = 1,
+                                get = function(info) return WoWProDB.profile.space end,
+                                set = function(info,val) WoWProDB.profile.space = val
+                                    WoWPro.RowSizeSet() end,
+                                width = "full"
+                            },
+                            drag = {
+                                order = 3,
+                                type = "toggle",
+                                name = L["Enable Drag"],
+                                desc = L["When enabled: Click on the button bar to move the window. Drag to reposition it on your screen.\nWhen disabled: Window is locked in place."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.drag end,
+                                set = function(info,val) WoWProDB.profile.drag = val
+                                    WoWPro.DragSet() end
+                            },
+                            expansionAnchor = {
+                                order = 4,
+                                type = "select",
+                                name = L["Window Expansion Anchor"],
+                                desc = L["Choose which corner the window expands from; content grows away from that corner and stays on-screen."],
+                                width = "full",
+                                values = {
+                                    ["TOPLEFT"] = "Top Left",
+                                    ["TOPRIGHT"] = "Top Right",
+                                    ["BOTTOMLEFT"] = "Bottom Left",
+                                    ["BOTTOMRIGHT"] = "Bottom Right",
+                                },
+                                get = function(info) return WoWProDB.profile.expansionAnchor or "TOPLEFT" end,
+                                set = function(info, val)
+                                    WoWProDB.profile.expansionAnchor = val
+                                    WoWProDB.profile.leftside = (val == "TOPLEFT" or val == "BOTTOMLEFT")
+                                    WoWPro:UpdateResizeHandle()
+                                end,
+                            },
+                            resize = {
+                                order = 5,
+                                type = "toggle",
+                                name = L["Resize Handle"],
+                                desc = L["Shows a resize handle at the corner opposite your anchor point.\n\nWhen enabled:\n- Drag the handle to manually resize the window\n- Window respects screen boundaries\n- Auto-resize is disabled\n\nWhen disabled:\n- Hides the handle and locks the current window size"],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.resize end,
+                                set = function(info,val) WoWProDB.profile.resize = val
+                                    if val then WoWProDB.profile.autoresize = false end
+                                    if not val then
+                                        WoWPro.AnchorStore("ResizeLocked")
+                                    end
+                                    WoWPro.ResizeSet(); WoWPro.RowSizeSet() end
+                            },
+                            autoresize = {
+                                order = 6,
+                                type = "toggle",
+                                name = L["Auto Resize"],
+                                desc = L["Guide will automatically resize to the set number of steps. \nManual resize recommended for advanced users only. \nHides drag handle."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.autoresize end,
+                                set = function(info,val) WoWProDB.profile.autoresize = val
+                                    if val then WoWProDB.profile.resize = false
+                                    else
+                                        WoWPro.AnchorStore("AutoResizeDisabled")
+                                    end
+                                    WoWPro.ResizeSet(); WoWPro.RowSizeSet() end
+                            },
+                            numsteps = {
+                                order = 7,
+                                type = "range",
+                                name = L["Auto Resize: Number of Steps"],
+                                desc = L["Sets how many steps to show and auto-resizes the window to fit them. Only applies when Auto Resize is enabled. Sticky steps are not counted."],
+                                min = 1, max = 15, step = 1,
+                                get = function(info) return WoWProDB.profile.numsteps end,
+                                set = function(info,val) WoWProDB.profile.numsteps = val
+                                    WoWPro.RowSizeSet()
+                                    WoWPro:UpdateGuide("Config:numsteps") end,
+                                width = "full"
+                            },
+                            minresizeh = {
+                                order = 8,
+                                type = "range",
+                                name = L["Min Resize - Width"],
+                                desc = L["Minimum horizontal pixel size the guide window can be set to."],
+                                min = 250, max = 1000, step = 10,
+                                get = function(info) return WoWProDB.profile.hminresize end,
+                                set = function(info,val) WoWProDB.profile.hminresize = val
+                                    WoWPro:ResizeSet(); WoWPro.RowSizeSet() end,
+                                width = "full"
+                            },
+                            minresizev = {
+                                order = 9,
+                                type = "range",
+                                name = L["Min Resize - Height"],
+                                desc = L["Minimum height (pixels) the guide window can be set to."],
+                                min = 50, max = 1000, step = 10,
+                                get = function(info) return WoWProDB.profile.vminresize end,
+                                set = function(info,val) WoWProDB.profile.vminresize = val
+                                    WoWPro:ResizeSet(); WoWPro.RowSizeSet() end,
+                                width = "full"
+                            },
+                        },
+                    },
+                    bars = {
+                        order = 30,
+                        type = "group",
+                        name = L["Title Bar & Button Bar"],
+                        inline = true,
+                        args = {
+                            titlebar = {
+                                order = 1,
+                                type = "toggle",
+                                name = L["Enable Title Bar"],
+                                desc = L["Enables/disables the title bar attached to the guide window."],
+                                get = function(info) return WoWProDB.profile.titlebar end,
+                                set = function(info,val) WoWProDB.profile.titlebar = val
+                                    WoWPro.TitlebarSet(); WoWPro.PaddingSet(); WoWPro.RowSizeSet() end,
+                                width = "double"
+                            },
+                            titlecolor = {
+                                order = 2,
+                                type = "color",
+                                name = L["Title Bar Color"],
+                                desc = L["Background color for the title bar."],
+                                hasAlpha = true,
+                                get = function(info) return WoWProDB.profile.titlecolor[1], WoWProDB.profile.titlecolor[2], WoWProDB.profile.titlecolor[3] ,WoWProDB.profile.titlecolor[4] end,
+                                set = function(info,r,g,b,a)
+                                    WoWProDB.profile.titlecolor = {r,g,b,a}
+                                    WoWPro.TitlebarSet() end
+                            },
+                            buttonbar = {
+                                order = 3,
+                                type = "toggle",
+                                name = L["Enable Button Bar"],
+                                desc = L["Enables/disables the button bar attached to the guide window."],
+                                get = function(info) return WoWProDB.profile.buttonbar ~= false end,
+                                set = function(info,val)
+                                    WoWProDB.profile.buttonbar = val
+                                    WoWPro:TitlebarShow()
+                                end,
+                                width = "double"
+                            },
+                        },
+                    },
+                    backgrounds = {
+                        order = 40,
+                        type = "group",
+                        name = L["Backgrounds"],
+                        inline = true,
+                        args = {
+                            bgtexture = {
+                                order = 1,
+                                type = "select",
+                                name = L["Guide Window Background"],
+                                desc = L["Texture used for the guide window background."],
+                                values = function() local values = {}
+                                    local list = LSM:List("background")
+                                    local hashtable = LSM:HashTable("background")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    return values end,
+                                get = function(info)
+                                    return WoWProDB.profile.bgtexture end,
+                                set = function(info,val) WoWProDB.profile.bgtexture = val
+                                    WoWPro.BackgroundSet() end,
+                                width = "double"
+                            },
+                            bgcolor = {
+                                order = 2,
+                                type = "color",
+                                name = L["Guide Window Color"],
+                                desc = L["Background color for the guide window"],
+                                hasAlpha = true,
+                                get = function(info) return WoWProDB.profile.bgcolor[1], WoWProDB.profile.bgcolor[2], WoWProDB.profile.bgcolor[3] ,WoWProDB.profile.bgcolor[4] end,
+                                set = function(info,r,g,b,a)
+                                    WoWProDB.profile.bgcolor = {r,g,b,a}
+                                    WoWPro.BackgroundSet() end
+                            },
+                            bordertexture = {
+                                order = 3,
+                                type = "select",
+                                name = L["Border Texture"],
+                                desc = L["Texture used for the guide window border."],
+                                values = function() local values = {}
+                                    local list = LSM:List("border")
+                                    local hashtable = LSM:HashTable("border")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    return values end,
+                                get = function(info)
+                                    return WoWProDB.profile.bordertexture end,
+                                set = function(info,val) WoWProDB.profile.bordertexture = val
+                                    WoWPro.border = true
+                                    WoWPro.BackgroundSet() end,
+                                width = "double"
+                            },
+                            border = {
+                                order = 4,
+                                type = "toggle",
+                                name = L["Enable Border"],
+                                desc = L["Enables/disables the border around the guide window."],
+                                get = function(info) return WoWProDB.profile.border end,
+                                set = function(info,val) WoWProDB.profile.border = val
+                                    WoWPro.BackgroundSet() end
+                            },
+                            stickytexture = {
+                                order = 5,
+                                type = "select",
+                                name = L["Sticky Background"],
+                                desc = L["Texture used for sticky step background."],
+                                values = function() local values = {}
+                                    local list = LSM:List("background")
+                                    local hashtable = LSM:HashTable("background")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    return values end,
+                                get = function(info)
+                                    return WoWProDB.profile.stickytexture end,
+                                set = function(info,val) WoWProDB.profile.stickytexture = val
+                                    WoWPro.BackgroundSet(); WoWPro.RowColorSet() end,
+                                width = "double"
+                            },
+                            stickycolor = {
+                                order = 6,
+                                type = "color",
+                                name = L["Sticky Step Color"],
+                                desc = L["Background color for the sticky step frames."],
+                                hasAlpha = true,
+                                get = function(info) return WoWProDB.profile.stickycolor[1], WoWProDB.profile.stickycolor[2], WoWProDB.profile.stickycolor[3] ,WoWProDB.profile.stickycolor[4] end,
+                                set = function(info,r,g,b,a)
+                                    WoWProDB.profile.stickycolor = {r,g,b,a}
+                                    WoWPro.BackgroundSet(); WoWPro.RowColorSet() end
+                            },
+                        },
+                    },
+                    textFormatting = {
+                        order = 50,
+                        type = "group",
+                        name = L["Text Formatting"],
+                        inline = true,
+                        args = {
+                            stepfont = {
+                                order = 1,
+                                type = 'select',
+                                dialogControl = 'LSM30_Font',
+                                name = L["Step Font"],
+                                desc = L["Font used for the main step text."],
+                                values = LSM:HashTable("font"),
+                                get = function(info) local values = {}
+                                    local list = LSM:List("font")
+                                    local hashtable = LSM:HashTable("font")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    local hash = values[WoWProDB.profile.stepfont]
+                                    return hash end,
+                                set = function(info,val)
+                                    local hashtable = LSM:HashTable("font")
+                                    WoWProDB.profile.stepfont = hashtable[val]
+                                    WoWPro.RowFontSet() end
+                            },
+                            steptextsize = {
+                                order = 2,
+                                type = "range",
+                                name = L["Step Text Size"],
+                                desc = L["Size of the main step text."],
+                                min = 1, max = 30, step = 1,
+                                get = function(info) return WoWProDB.profile.steptextsize end,
+                                set = function(info,val) WoWProDB.profile.steptextsize = val
+                                    WoWPro.RowFontSet()
+                                    WoWPro.RowSizeSet() end
+                            },
+                            steptextcolor = {
+                                order = 3,
+                                type = "color",
+                                name = L["Step Text Color"],
+                                desc = L["Color of the main step text."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.steptextcolor[1], WoWProDB.profile.steptextcolor[2], WoWProDB.profile.steptextcolor[3] end,
+                                set = function(info,r,g,b)
+                                    WoWProDB.profile.steptextcolor = {r,g,b}
+                                    WoWPro.RowFontSet() end
+                            },
+                            notefont = {
+                                order = 4,
+                                type = 'select',
+                                dialogControl = 'LSM30_Font',
+                                name = L["Note Font"],
+                                desc = L["Font used for the note text."],
+                                values = LSM:HashTable("font"),
+                                get = function(info) local values = {}
+                                    local list = LSM:List("font")
+                                    local hashtable = LSM:HashTable("font")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    local hash = values[WoWProDB.profile.notefont]
+                                    return hash end,
+                                set = function(info,val)
+                                    local hashtable = LSM:HashTable("font")
+                                    WoWProDB.profile.notefont = hashtable[val]
+                                    WoWPro.RowFontSet() end
+                            },
+                            notetextsize = {
+                                order = 5,
+                                type = "range",
+                                name = L["Note Text Size"],
+                                desc = L["Size of the note text."],
+                                min = 1, max = 30, step = 1,
+                                get = function(info) return WoWProDB.profile.notetextsize end,
+                                set = function(info,val) WoWProDB.profile.notetextsize = val
+                                    WoWPro.RowFontSet()
+                                    WoWPro.RowSizeSet() end
+                            },
+                            notetextcolor = {
+                                order = 6,
+                                type = "color",
+                                name = L["Note Text Color"],
+                                desc = L["Color of the note text."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.notetextcolor[1], WoWProDB.profile.notetextcolor[2], WoWProDB.profile.notetextcolor[3] end,
+                                set = function(info,r,g,b)
+                                    WoWProDB.profile.notetextcolor = {r,g,b}
+                                    WoWPro.RowFontSet() end
+                            },
+                            trackfont = {
+                                order = 7,
+                                type = "select",
+                                dialogControl = 'LSM30_Font',
+                                name = L["Tracker Font"],
+                                desc = L["Font used for the tracking text."],
+                                values = LSM:HashTable("font"),
+                                get = function(info) local values = {}
+                                    local list = LSM:List("font")
+                                    local hashtable = LSM:HashTable("font")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    local hash = values[WoWProDB.profile.trackfont]
+                                    return hash end,
+                                set = function(info,val)
+                                    local hashtable = LSM:HashTable("font")
+                                    WoWProDB.profile.trackfont = hashtable[val]
+                                    WoWPro.RowFontSet() end
+                            },
+                            tracktextsize = {
+                                order = 8,
+                                type = "range",
+                                name = L["Tracker Text Size"],
+                                desc = L["Size of the tracking text."],
+                                min = 1, max = 30, step = 1,
+                                get = function(info) return WoWProDB.profile.tracktextsize end,
+                                set = function(info,val) WoWProDB.profile.tracktextsize = val
+                                    WoWPro.RowFontSet()
+                                    WoWPro.RowSizeSet() end
+                            },
+                            tracktextcolor = {
+                                order = 9,
+                                type = "color",
+                                name = L["Tracker Text Color"],
+                                desc = L["Color of the tracking text."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.tracktextcolor[1], WoWProDB.profile.tracktextcolor[2], WoWProDB.profile.tracktextcolor[3] end,
+                                set = function(info,r,g,b)
+                                    WoWProDB.profile.tracktextcolor = {r,g,b}
+                                    WoWPro.RowFontSet() end
+                            },
+                            titlefont = {
+                                order = 10,
+                                type = "select",
+                                dialogControl = 'LSM30_Font',
+                                name = L["Title Bar Font"],
+                                desc = L["Font used on the title bar."],
+                                values = LSM:HashTable("font"),
+                                get = function(info) local values = {}
+                                    local list = LSM:List("font")
+                                    local hashtable = LSM:HashTable("font")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    local hash = values[WoWProDB.profile.titlefont]
+                                    return hash end,
+                                set = function(info,val)
+                                    local hashtable = LSM:HashTable("font")
+                                    WoWProDB.profile.titlefont = hashtable[val]
+                                    WoWPro:TitlebarSet() end
+                            },
+                            titletextsize = {
+                                order = 11,
+                                type = "range",
+                                name = L["Title Bar Text Size"],
+                                desc = L["Size of the title bar text."],
+                                min = 1, max = 30, step = 1,
+                                get = function(info) return WoWProDB.profile.titletextsize end,
+                                set = function(info,val) WoWProDB.profile.titletextsize = val
+                                    WoWPro:TitlebarSet() end
+                            },
+                            titletextcolor = {
+                                order = 12,
+                                type = "color",
+                                name = L["Title Bar Text Color"],
+                                desc = L["Color of the title bar text."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.titletextcolor[1], WoWProDB.profile.titletextcolor[2], WoWProDB.profile.titletextcolor[3] end,
+                                set = function(info,r,g,b)
+                                    WoWProDB.profile.titletextcolor = {r,g,b}
+                                    WoWPro:TitlebarSet() end
+                            },
+                            stickytitlefont = {
+                                order = 13,
+                                type = "select",
+                                dialogControl = 'LSM30_Font',
+                                name = L["'As you go:' Font"],
+                                desc = L["Font used on the top of the sticky frame."],
+                                values = LSM:HashTable("font"),
+                                get = function(info) local values = {}
+                                    local list = LSM:List("font")
+                                    local hashtable = LSM:HashTable("font")
+                                    for i,handle in ipairs(list) do
+                                        values[hashtable[handle]] = handle
+                                    end
+                                    local hash = values[WoWProDB.profile.stickytitlefont]
+                                    return hash end,
+                                set = function(info,val)
+                                    local hashtable = LSM:HashTable("font")
+                                    WoWProDB.profile.stickytitlefont = hashtable[val]
+                                    WoWPro.RowFontSet()
+                                    WoWPro.RowSizeSet() end
+                            },
+                            stickytitletextsize = {
+                                order = 14,
+                                type = "range",
+                                name = L["'As you go:' Text Size"],
+                                desc = L["Size of the text on the top of the sticky frame."],
+                                min = 1, max = 30, step = 1,
+                                get = function(info) return WoWProDB.profile.stickytitletextsize end,
+                                set = function(info,val) WoWProDB.profile.stickytitletextsize = val
+                                    WoWPro.RowFontSet()
+                                    WoWPro.RowSizeSet() end
+                            },
+                            stickytitletextcolor = {
+                                order = 15,
+                                type = "color",
+                                name = L["'As you go:' Text Color"],
+                                desc = L["Color of the text on the top of the sticky frame."],
+                                width = "full",
+                                get = function(info) return WoWProDB.profile.stickytitletextcolor[1], WoWProDB.profile.stickytitletextcolor[2], WoWProDB.profile.stickytitletextcolor[3] end,
+                                set = function(info,r,g,b)
+                                    WoWProDB.profile.stickytitletextcolor = {r,g,b}
+                                    WoWPro.RowFontSet() end
+                            },
+                        },
+                    },
                 },
-                get = function(info) return WoWProDB.profile.expansionAnchor or "TOPLEFT" end,
-                set = function(info, val)
-                    WoWProDB.profile.expansionAnchor = val
-                    WoWProDB.profile.leftside = (val == "TOPLEFT" or val == "BOTTOMLEFT")
-                    WoWPro:UpdateResizeHandle()
-                end,
             },
-            resizeheading = {
-                order = 31,
-                type = "header",
-                name = L["Resize Settings"],
-            },
-            resize = {
-                order = 32,
-                type = "toggle",
-                name = L["Resize Handle"],
-                desc = L["Shows a resize handle at the corner opposite your anchor point.\n\nWhen enabled:\n- Drag the handle to manually resize the window\n- Window respects screen boundaries\n- Auto-resize is disabled\n\nWhen disabled:\n- Hides the handle and locks the current window size"],
-                get = function(info) return WoWProDB.profile.resize end,
-                set = function(info,val) WoWProDB.profile.resize = val
-                    if val then WoWProDB.profile.autoresize = false end
-                    -- When disabling resize (locking), save the current size
-                    if not val then
-                        WoWPro.AnchorStore("ResizeLocked")
-                    end
-                    WoWPro.ResizeSet(); WoWPro.RowSizeSet() end
-            },
-            autoresize = {
-                order = 33,
-                type = "toggle",
-                name = L["Auto Resize"],
-                desc = L["Guide will automatically resize to the set number of steps. \nManual resize recommended for advanced users only. \nHides drag handle."],
-                get = function(info) return WoWProDB.profile.autoresize end,
-                set = function(info,val) WoWProDB.profile.autoresize = val
-                    if val then WoWProDB.profile.resize = false
-                    else
-                        -- When disabling auto-resize (switching to manual), save the current auto-resized size
-                        WoWPro.AnchorStore("AutoResizeDisabled")
-                    end
-                    WoWPro.ResizeSet(); WoWPro.RowSizeSet() end
-            },
-            numsteps = {
-                order = 34,
-                type = "range",
-                name = L["Auto Resize: Number of Steps"],
-                desc = L["Sets how many steps to show and auto-resizes the window to fit them. Only applies when Auto Resize is enabled. Sticky steps are not counted."],
-                min = 1, max = 15, step = 1,
-                get = function(info) return WoWProDB.profile.numsteps end,
-                set = function(info,val) WoWProDB.profile.numsteps = val
-                    WoWPro.RowSizeSet()
-                    WoWPro:UpdateGuide("Config:numsteps") end,
-                width = "double"
-            },
-            minresizeh = {
-                order = 35,
-                type = "range",
-                name = L["Min Resize - Width"],
-                desc = L["Minimum horizontal pixel size the guide window can be set to."],
-                min = 250, max = 1000, step = 10,
-                get = function(info) return WoWProDB.profile.hminresize end,
-                set = function(info,val) WoWProDB.profile.hminresize = val
-                    WoWPro:ResizeSet(); WoWPro.RowSizeSet() end,
-                width = "double"
-            },
-            minresizev = {
-                order = 36,
-                type = "range",
-                name = L["Min Resize - Height"],
-                desc = L["Minimum height (pixels) the guide window can be set to."],
-                min = 50, max = 1000, step = 10,
-                get = function(info) return WoWProDB.profile.vminresize end,
-                set = function(info,val) WoWProDB.profile.vminresize = val
-                    WoWPro:ResizeSet(); WoWPro.RowSizeSet() end,
-                width = "double"
-            },
-            blank4 = {
-                order = 40,
-                type = "description",
-                name = " ",
-            },
-            titleheading = {
-                order = 41,
-                type = "header",
-                name = L["Title Bar & Button Bar"],
-            },
-            titlebar = {
-                order = 42,
-                type = "toggle",
-                name = L["Enable Title Bar"],
-                desc = L["Enables/disables the title bar attached to the guide window."],
-                get = function(info) return WoWProDB.profile.titlebar end,
-                set = function(info,val) WoWProDB.profile.titlebar = val
-                    WoWPro.TitlebarSet(); WoWPro.PaddingSet(); WoWPro.RowSizeSet() end,
-                width = "double"
-            },
-            titlecolor = {
-                order = 43,
-                type = "color",
-                name = L["Title Bar Color"],
-                desc = L["Background color for the title bar."],
-                hasAlpha = true,
-                get = function(info) return WoWProDB.profile.titlecolor[1], WoWProDB.profile.titlecolor[2], WoWProDB.profile.titlecolor[3] ,WoWProDB.profile.titlecolor[4] end,
-                set = function(info,r,g,b,a)
-                    WoWProDB.profile.titlecolor = {r,g,b,a}
-                    WoWPro.TitlebarSet() end
-            },
-            buttonbar = {
-                order = 44,
-                type = "toggle",
-                name = L["Enable Button Bar"],
-                desc = L["Enables/disables the button bar attached to the guide window."],
-                get = function(info) return WoWProDB.profile.buttonbar ~= false end,
-                set = function(info,val)
-                    WoWProDB.profile.buttonbar = val
-                    WoWPro:TitlebarShow()
-                end,
-                width = "double"
-            },
-            blank5 = {
-                order = 50,
-                type = "description",
-                name = " ",
-            },
-            bgheading = {
-                order = 51,
-                type = "header",
-                name = L["Backgrounds"],
-            },
-            bgtexture = {
-                order = 52,
-                type = "select",
-                name = L["Guide Window Background"],
-                desc = L["Texture used for the guide window background."],
-                values = function() local values = {}
-                    local list = LSM:List("background")
-                    local hashtable = LSM:HashTable("background")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.bgtexture end,
-                set = function(info,val) WoWProDB.profile.bgtexture = val
-                    WoWPro.BackgroundSet() end,
-                    width = "double"
-            },
-            bgcolor = {
-                order = 53,
-                type = "color",
-                name = L["Guide Window Color"],
-                desc = L["Background color for the guide window"],
-                hasAlpha = true,
-                get = function(info) return WoWProDB.profile.bgcolor[1], WoWProDB.profile.bgcolor[2], WoWProDB.profile.bgcolor[3] ,WoWProDB.profile.bgcolor[4] end,
-                set = function(info,r,g,b,a)
-                    WoWProDB.profile.bgcolor = {r,g,b,a}
-                    WoWPro.BackgroundSet() end
-            },
-            bordertexture = {
-                order = 54,
-                type = "select",
-                name = L["Border Texture"],
-                desc = L["Texture used for the guide window border."],
-                values = function() local values = {}
-                    local list = LSM:List("border")
-                    local hashtable = LSM:HashTable("border")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.bordertexture end,
-                set = function(info,val) WoWProDB.profile.bordertexture = val
-                    WoWPro.border = true
-                    WoWPro.BackgroundSet() end,
-                    width = "double"
-            },
-            border = {
-                order = 55,
-                type = "toggle",
-                name = L["Enable Border"],
-                desc = L["Enables/disables the border around the guide window."],
-                get = function(info) return WoWProDB.profile.border end,
-                set = function(info,val) WoWProDB.profile.border = val
-                    WoWPro.BackgroundSet() end
-            },
-            stickytexture = {
-                order = 56,
-                type = "select",
-                name = L["Sticky Background"],
-                desc = L["Texture used for sticky step background."],
-                values = function() local values = {}
-                    local list = LSM:List("background")
-                    local hashtable = LSM:HashTable("background")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.stickytexture end,
-                set = function(info,val) WoWProDB.profile.stickytexture = val
-                    WoWPro.BackgroundSet(); WoWPro.RowColorSet() end,
-                    width = "double"
-            },
-            stickycolor = {
-                order = 57,
-                type = "color",
-                name = L["Sticky Step Color"],
-                desc = L["Background color for the sticky step frames."],
-                hasAlpha = true,
-                get = function(info) return WoWProDB.profile.stickycolor[1], WoWProDB.profile.stickycolor[2], WoWProDB.profile.stickycolor[3] ,WoWProDB.profile.stickycolor[4] end,
-                set = function(info,r,g,b,a)
-                    WoWProDB.profile.stickycolor = {r,g,b,a}
-                    WoWPro.BackgroundSet(); WoWPro.RowColorSet() end
-            },
-            blank6 = {
-                order = 60,
-                type = "description",
-                name = " ",
-            },
-            textheading = {
-                order = 61,
-                type = "header",
-                name = L["Text Formatting"],
-            },
-            stepfont = {
-                order = 62,
-                type = 'select',
-                dialogControl = 'LSM30_Font',
-                name = L["Step Font"],
-                desc = L["Font used for the main step text."],
-                values = LSM:HashTable("font"),
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.stepfont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.stepfont = hashtable[val]
-                    WoWPro.RowFontSet() end
-            },
-            steptextsize = {
-                order = 63,
-                type = "range",
-                name = L["Step Text Size"],
-                desc = L["Size of the main step text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.steptextsize end,
-                set = function(info,val) WoWProDB.profile.steptextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            steptextcolor = {
-                order = 64,
-                type = "color",
-                name = L["Step Text Color"],
-                desc = L["Color of the main step text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.steptextcolor[1], WoWProDB.profile.steptextcolor[2], WoWProDB.profile.steptextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.steptextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-            notefont = {
-                order = 65,
-                type = 'select',
-                dialogControl = 'LSM30_Font',
-                name = L["Note Font"],
-                desc = L["Font used for the note text."],
-                values = LSM:HashTable("font"),
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.notefont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.notefont = hashtable[val]
-                    WoWPro.RowFontSet() end
-            },
-            notetextsize = {
-                order = 66,
-                type = "range",
-                name = L["Note Text Size"],
-                desc = L["Size of the note text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.notetextsize end,
-                set = function(info,val) WoWProDB.profile.notetextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            notetextcolor = {
-                order = 67,
-                type = "color",
-                name = L["Note Text Color"],
-                desc = L["Color of the note text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.notetextcolor[1], WoWProDB.profile.notetextcolor[2], WoWProDB.profile.notetextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.notetextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-            trackfont = {
-                order = 68,
-                type = "select",
-                dialogControl = 'LSM30_Font',
-                name = L["Tracker Font"],
-                desc = L["Font used for the tracking text."],
-                values = LSM:HashTable("font"), -- pull in your font list from LSM
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.trackfont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.trackfont = hashtable[val]
-                    WoWPro.RowFontSet() end
-            },
-            tracktextsize = {
-                order = 69,
-                type = "range",
-                name = L["Tracker Text Size"],
-                desc = L["Size of the tracking text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.tracktextsize end,
-                set = function(info,val) WoWProDB.profile.tracktextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            tracktextcolor = {
-                order = 70,
-                type = "color",
-                name = L["Tracker Text Color"],
-                desc = L["Color of the tracking text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.tracktextcolor[1], WoWProDB.profile.tracktextcolor[2], WoWProDB.profile.tracktextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.tracktextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-            titlefont = {
-                order = 71,
-                type = "select",
-                dialogControl = 'LSM30_Font',
-                name = L["Title Bar Font"],
-                desc = L["Font used on the title bar."],
-                values = LSM:HashTable("font"), -- pull in your font list from LSM
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.titlefont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.titlefont = hashtable[val]
-                    WoWPro:TitlebarSet() end
-            },
-            titletextsize = {
-                order = 72,
-                type = "range",
-                name = L["Title Bar Text Size"],
-                desc = L["Size of the title bar text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.titletextsize end,
-                set = function(info,val) WoWProDB.profile.titletextsize = val
-                    WoWPro:TitlebarSet() end
-            },
-            titletextcolor = {
-                order = 73,
-                type = "color",
-                name = L["Title Bar Text Color"],
-                desc = L["Color of the title bar text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.titletextcolor[1], WoWProDB.profile.titletextcolor[2], WoWProDB.profile.titletextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.titletextcolor = {r,g,b}
-                    WoWPro:TitlebarSet() end
-            },
-            stickytitlefont = {
-                order = 74,
-                type = "select",
-                dialogControl = 'LSM30_Font',
-                name = L["'As you go:' Font"],
-                desc = L["Font used on the top of the sticky frame."],
-                values = LSM:HashTable("font"), -- pull in your font list from LSM
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.stickytitlefont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.stickytitlefont = hashtable[val]
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            stickytitletextsize = {
-                order = 75,
-                type = "range",
-                name = L["'As you go:' Text Size"],
-                desc = L["Size of the text on the top of the sticky frame."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.stickytitletextsize end,
-                set = function(info,val) WoWProDB.profile.stickytitletextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            stickytitletextcolor = {
-                order = 76,
-                type = "color",
-                name = L["'As you go:' Text Color"],
-                desc = L["Color of the text on the top of the sticky frame."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.stickytitletextcolor[1], WoWProDB.profile.stickytitletextcolor[2], WoWProDB.profile.stickytitletextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.stickytitletextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            }
         }
     }
 end
@@ -717,290 +699,532 @@ local function createMainConfig()
         name = L["Main"],
         type = "group",
         args = {
-            version = {
-                order = 11,
-                type = "description",
-                name = L["Version"]..": "..WoWPro.Version,
-            },
-            header = {
-                order = 10,
-                type = "header",
-                name = L["Addon Version Installed"],
-            },
-            header1 = {
-                order = 13,
-                type = "header",
-                name = "Addon Enable and Debugging",
-            },
-            enable = {
-                order = 14,
-                type = "toggle",
-                name = L["Enable Addon"],
-                desc = L["Enables/Disables showing the WoW-Pro guide addons."],
-                get = function(info) return WoWProCharDB.Enabled end,
-                set = function(info,val)
-                        if WoWProCharDB.Enabled then
-                            WoWProCharDB.Enabled = false
-                            WoWPro:Disable()
-                        else
-                            WoWProCharDB.Enabled = true
-                            WoWPro:Enable()
-                        end
-                    end
-            },
-            enableDebug = {
-                order = 15,
-                type = "toggle",
-                name = L["Enable Debug"],
-                desc = L["Enables/Disables debug logging"],
-                get = function(info) return WoWPro.DebugLevel > 0 end,
-                set = function(info,val)
-                        if WoWPro.DebugLevel > 0 then
-                            WoWPro.DebugLevel = 0
-                        else
-                            WoWPro.DebugLevel = 1
-                        end
-                        WoWProCharDB.DebugLevel = WoWPro.DebugLevel
-                    end
-            },
-            header2 = {
-                order = 16,
-                type = "header",
-                name = "Automation",
-            },
-            autoSelect = {
-                order = 17,
-                type = "toggle",
-                name = L["Auto Select"],
-                desc = L["Enables/Disables automatically selecting quests/flights from NPCs"],
-                get = function(info) return WoWProCharDB.AutoSelect end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoSelect == true then
-                            WoWProCharDB.AutoSelect = false
-                        else
-                            WoWProCharDB.AutoSelect = true
-                        end
-                    end
-            },
-            autoAccept = {
-                order = 18,
-                type = "toggle",
-                name = L["Auto Accept"],
-                desc = L["Enables/Disables automatically accepting quests from NPCs"],
-                get = function(info) return WoWProCharDB.AutoAccept end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoAccept == true then
-                            WoWProCharDB.AutoAccept = false
-                        else
-                            WoWProCharDB.AutoAccept = true
-                        end
-                    end
-            },
-            autoTurnin = {
-                order = 19,
-                type = "toggle",
-                name = L["Auto Turnin"],
-                desc = L["Enables/Disables automatically turning in quests to NPCs"],
-                get = function(info) return WoWProCharDB.AutoTurnin end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoTurnin == true then
-                            WoWProCharDB.AutoTurnin = false
-                        else
-                            WoWProCharDB.AutoTurnin = true
-                        end
-                    end
-            },
-            automationNote = {
+            status = {
                 order = 20,
-                type = "description",
-                name = L["NOTE: Quest automation does not work in instances or in combat"],
-                hidden = function() return not WoWPro.MIDNIGHT end,
+                type = "group",
+                name = "Main Options and Debugging",
+                inline = true,
+                args = {
+                    enable = {
+                        order = 2,
+                        type = "toggle",
+                        name = L["Enable Addon"],
+                        desc = L["Enables/Disables showing the WoW-Pro guide addons."],
+                        get = function(info) return WoWProCharDB.Enabled end,
+                        set = function(info,val)
+                            if WoWProCharDB.Enabled then
+                                WoWProCharDB.Enabled = false
+                                WoWPro:Disable()
+                            else
+                                WoWProCharDB.Enabled = true
+                                WoWPro:Enable()
+                            end
+                        end,
+                    },
+                    enableDebug = {
+                        order = 3,
+                        type = "toggle",
+                        name = L["Enable Debug"],
+                        desc = L["Enables/Disables debug logging"],
+                        get = function(info) return WoWPro.DebugLevel > 0 end,
+                        set = function(info,val)
+                            if WoWPro.DebugLevel > 0 then
+                                WoWPro.DebugLevel = 0
+                            else
+                                WoWPro.DebugLevel = 1
+                            end
+                            WoWProCharDB.DebugLevel = WoWPro.DebugLevel
+                        end,
+                    },
+                    minimap = {
+                        order = 4,
+                        type = "toggle",
+                        name = L["Minimap Button"],
+                        desc = L["Show/hide WoW-Pro mini map button."],
+                        get = function(info) return not WoWProDB.profile.minimap.hide end,
+                        set = function(info,val) WoWProDB.profile.minimap.hide = not val
+                            WoWPro.MinimapSet() end
+                    },
+                    checksound = {
+                        order = 5,
+                        type = "toggle",
+                        name = L["Enable Sound"],
+                        desc = L["Plays a check-off sound when a guide step is completed."],
+                        get = function(info) return WoWProDB.profile.checksound end,
+                        set = function(info,val) WoWProDB.profile.checksound = val end
+                    },
+                    checksoundfile = {
+                        order = 6,
+                        type = "select",
+                        name = L["Step Completed Sound"],
+                        desc = L["Sound played when a guide step is completed"],
+                        values = function() local values = {}
+                            for k,v in pairs(soundfiles) do
+                                values[v] = k
+                            end
+                            return values end,
+                        get = function(info)
+                            return WoWProDB.profile.checksoundfile end,
+                        set = function(info,val) WoWProDB.profile.checksoundfile = val
+                            _G.PlaySoundFile(val) end,
+                        disabled = function(...) return not WoWProDB.profile.checksound end,
+                        width = "double"
+                    },
+                },
             },
-            header3 = {
-                order = 21,
-                type = "header",
+            automation = {
+                order = 30,
+                type = "group",
+                name = "Automation",
+                inline = true,
+                args = {
+                    autoSelect = {
+                        order = 1,
+                        type = "toggle",
+                        name = L["Auto Select"],
+                        desc = L["Enables/Disables automatically selecting quests/flights from NPCs"],
+                        get = function(info) return WoWProCharDB.AutoSelect end,
+                        set = function(info,val)
+                            if WoWProCharDB.AutoSelect == true then
+                                WoWProCharDB.AutoSelect = false
+                            else
+                                WoWProCharDB.AutoSelect = true
+                            end
+                        end,
+                    },
+                    autoAccept = {
+                        order = 2,
+                        type = "toggle",
+                        name = L["Auto Accept"],
+                        desc = L["Enables/Disables automatically accepting quests from NPCs"],
+                        get = function(info) return WoWProCharDB.AutoAccept end,
+                        set = function(info,val)
+                            if WoWProCharDB.AutoAccept == true then
+                                WoWProCharDB.AutoAccept = false
+                            else
+                                WoWProCharDB.AutoAccept = true
+                            end
+                        end,
+                    },
+                    autoTurnin = {
+                        order = 3,
+                        type = "toggle",
+                        name = L["Auto Turnin"],
+                        desc = L["Enables/Disables automatically turning in quests to NPCs"],
+                        get = function(info) return WoWProCharDB.AutoTurnin end,
+                        set = function(info,val)
+                            if WoWProCharDB.AutoTurnin == true then
+                                WoWProCharDB.AutoTurnin = false
+                            else
+                                WoWProCharDB.AutoTurnin = true
+                            end
+                        end,
+                    },
+                    automationNote = {
+                        order = 4,
+                        type = "description",
+                        name = L["NOTE: Quest automation does not work in instances or in combat"],
+                        hidden = function() return not WoWPro.MIDNIGHT end,
+                        width = "full",
+                    },
+                },
+            },
+            modifiers = {
+                order = 40,
+                type = "group",
                 name = "Guide Modifiers",
+                inline = true,
+                args = {
+                    petBattles = {
+                        order = 1,
+                        type = "toggle",
+                        name = L["Enable Pet Battles"],
+                        desc = L["Enables/Disables automatic pet battle team selection in some guides"],
+                        get = function(info) return WoWProCharDB.EnablePetBattles end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnablePetBattles then
+                                WoWProCharDB.EnablePetBattles = false
+                            else
+                                WoWProCharDB.EnablePetBattles = true
+                            end
+                        end,
+                    },
+                    doRares = {
+                        order = 2,
+                        type = "toggle",
+                        name = L["Enable Rares"],
+                        desc = L["Enables/Disables killing optional Rares in guides."],
+                        get = function(info) return WoWProCharDB.EnableRares end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableRares then
+                                WoWProCharDB.EnableRares = false
+                            else
+                                WoWProCharDB.EnableRares = true
+                            end
+                        end,
+                    },
+                    doTreasures = {
+                        order = 3,
+                        type = "toggle",
+                        name = L["Enable Treasures"],
+                        desc = L["Enables/Disables treasure hunting steps in guides."],
+                        get = function(info) return WoWProCharDB.EnableTreasures end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableTreasures then
+                                WoWProCharDB.EnableTreasures = false
+                            else
+                                WoWProCharDB.EnableTreasures = true
+                            end
+                        end,
+                    },
+                    warbandcompleted = {
+                        order = 4,
+                        type = "toggle",
+                        name = L["Use Warband Quest Completion"],
+                        desc = L["Treat quests completed by another character in your Warband as completed for step filtering."],
+                        hidden = function() return not WoWPro.RETAIL end,
+                        get = function(info) return WoWProDB.profile.useWarbandCompletion end,
+                        set = function(info,val)
+                            WoWProDB.profile.useWarbandCompletion = val
+                            WoWProCharDB.completedQIDsWarband = {}
+                            WoWPro:UpdateGuide("Config: Use Warband Quest Completion")
+                        end,
+                        width = "full",
+                    },
+                    doDungeons = {
+                        order = 5,
+                        type = "toggle",
+                        name = L["Skip Dungeon Quests"],
+                        desc = L["Skips dungeon-specific quests outside Dungeon guides."],
+                        get = function(info) return WoWProCharDB.EnableDungeons end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableDungeons then
+                                WoWProCharDB.EnableDungeons = false
+                            else
+                                WoWProCharDB.EnableDungeons = true
+                            end
+                        end,
+                        width = "double",
+                    },
+                    doFlight = {
+                        order = 6,
+                        type = "toggle",
+                        name = L["Skip Flights"],
+                        desc = L["Skips most flight steps when you have flying in that zone."],
+                        get = function(info) return WoWProCharDB.EnableFlight end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableFlight then
+                                WoWProCharDB.EnableFlight = false
+                            else
+                                WoWProCharDB.EnableFlight = true
+                            end
+                        end,
+                    },
+                },
             },
-            petBattles = {
-                order = 22,
-                type = "toggle",
-                name = L["Enable Pet Battles"],
-                desc = L["Enables/Disables automatic pet battle team selection in some guides"],
-                get = function(info) return WoWProCharDB.EnablePetBattles end,
-                set = function(info,val)
-                        if WoWProCharDB.EnablePetBattles then
-                            WoWProCharDB.EnablePetBattles = false
-                        else
-                            WoWProCharDB.EnablePetBattles = true
-                        end
-                    end
-            },
-            doRares = {
-                order = 23,
-                type = "toggle",
-                name = L["Enable Rares"],
-                desc = L["Enables/Disables killing optional Rares in guides."],
-                get = function(info) return WoWProCharDB.EnableRares end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableRares then
-                            WoWProCharDB.EnableRares = false
-                        else
-                            WoWProCharDB.EnableRares = true
-                        end
-                    end
-            },
-            doTreasures = {
-                order = 24,
-                type = "toggle",
-                name = L["Enable Treasures"],
-                desc = L["Enables/Disables treasure hunting steps in guides."],
-                get = function(info) return WoWProCharDB.EnableTreasures end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableTreasures then
-                            WoWProCharDB.EnableTreasures = false
-                        else
-                            WoWProCharDB.EnableTreasures = true
-                        end
-                    end
-            },
-             warbandcompleted = {
-                order = 24.5,
-                type = "toggle",
-                name = L["Use Warband Quest Completion"],
-                desc = L["Treat quests completed by another character in your Warband as completed for step filtering."],
-                hidden = function() return not WoWPro.RETAIL end,
-                get = function(info) return WoWProDB.profile.useWarbandCompletion end,
-                set = function(info,val)
-                    WoWProDB.profile.useWarbandCompletion = val
-                    WoWProCharDB.completedQIDsWarband = {}
-                    WoWPro:UpdateGuide("Config: Use Warband Quest Completion")
-                end
-            },
-            doDungeons = {
-                order = 25,
-                type = "toggle",
-                name = L["Skip Dungeon Quests"],
-                desc = L["Skips dungeon-specific quests outside Dungeon guides."],
-                get = function(info) return WoWProCharDB.EnableDungeons end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableDungeons then
-                            WoWProCharDB.EnableDungeons = false
-                        else
-                            WoWProCharDB.EnableDungeons = true
-                        end
-                    end,
-                width = "double"
-            },
-            doFlight = {
-                order = 26,
-                type = "toggle",
-                name = L["Skip Flights"],
-                desc = L["Skips most flight steps when you have flying in that zone."],
-                get = function(info) return WoWProCharDB.EnableFlight end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableFlight then
-                            WoWProCharDB.EnableFlight = false
-                        else
-                            WoWProCharDB.EnableFlight = true
-                        end
-                    end
-            },
-            header4 = {
+            tools = {
                 order = 50,
-                type = "header",
+                type = "group",
                 name = "Master Addon Tools",
-            },
-            resetGuide = {
-                order = 51,
-                type = "execute",
-                name = L["Reset WoWPro Addons"],
-                desc = L["If a WoWPro addon is behaving oddly, this wipes all saved state across all characters."],
-                image = "Interface\\Addons\\WoWPro\\Textures\\inv_misc_enggizmos_27",
-                func =  function (info)
+                inline = true,
+                args = {
+                    resetGuide = {
+                        order = 1,
+                        type = "execute",
+                        name = L["Reset WoWPro Addons"],
+                        desc = L["If a WoWPro addon is behaving oddly, this wipes all saved state across all characters."],
+                        image = "Interface\\Addons\\WoWPro\\Textures\\inv_misc_enggizmos_27",
+                        func = function(info)
                             WoWPro:RESET()
                             _G.PlaySound(1026) -- Rabitt death
-                        end
+                        end,
+                    },
+                    resetLog = {
+                        order = 2,
+                        type = "execute",
+                        name = L["Clear the log"],
+                        desc = L["Wow-Pro's Debug Log"],
+                        image = "Interface\\RaidFrame\\ReadyCheck-NotReady",
+                        func = function(info) WoWPro:LogClear("UI") end,
+                    },
+                    showLog = {
+                        order = 3,
+                        type = "execute",
+                        name = L["Show the log"],
+                        desc = L["Wow-Pro's Secret Debug Log"],
+                        image = "Interface\\RaidFrame\\ReadyCheck-Ready",
+                        func = function(info) WoWPro:LogShow() end,
+                    },
+                },
             },
-            resetLog = {
-                order = 52,
-                type = "execute",
-                name = L["Clear the log"],
-                desc = L["Wow-Pro's Debug Log"],
-                image = "Interface\\RaidFrame\\ReadyCheck-NotReady",
-                func =  function (info) WoWPro:LogClear("UI"); end
-            },
-            showLog = {
-                order = 53,
-                type = "execute",
-                name = L["Show the log"],
-                desc = L["Wow-Pro's Secret Debug Log"],
-                image = "Interface\\RaidFrame\\ReadyCheck-Ready",
-                func =  function (info) WoWPro:LogShow(); end
-            },
-            blank10 = {
-                order = 90,
-                type = "description",
-                name = " ",
-            },
-            aboutheader = {
-                order = 1,
-                type = "header",
-                name = "About WoW-Pro",
-            },
-            blank11 = {
-                order = 2,
-                type = "description",
-                name = " ",
-            },
-            about10 = {
-                order = 3,
-                type = "description",
-                fontSize = "medium",
-                name = "WoW-Pro is a addon collection by gamers, for gamers. The collection includes hundreds of free guides covering every facet of World of Warcraft."
-            },
-            blank12 = {
-                order = 4,
-                type = "description",
-                name = " ",
-            },
-            about14 = {
-                order = 5,
-                type = "description",
-                fontSize = "medium",
-                name =
-                    "Over the years WoW-Pro has grown into a huge, active community of gamers. "
-            },
-            blank18 = {
-                order = 6,
-                type = "description",
-                name = " ",
-            },
-            about15 = {
-                order = 7,
-                type = "description",
-                fontSize = "medium",
-                name =
-                    "The WoW-Pro addon has brought many of the guides we've built as a community into the game, "..
-                    "and built on them since WotLK to the Classic(s) and Dragonflight.\n\nDrop by on Discord and say hello!"
-            },
-            blank19 = {
-                order = 8,
-                type = "description",
-                name = "",
-                image = "Interface/AddOns/WoWPro/Textures/Discord",
-                imageWidth = 32,
-                imageHeight = 32,
-                width = "half"
-            },
-            about16 = {
-                order = 9,
-                type = "input",
-                name = "Discord",
-                get = function () return "https://discord.gg/aarduK7"; end,
-                set = function () return "https://discord.gg/aarduK7"; end,
-                icon = "Interface\\AddOns\\WoWPro\\Textures\\Discord",
-            }
         }
+    }
+end
+
+local function createAboutConfig()
+    return {
+        name = "About",
+        type = "group",
+        args = {
+            overview = {
+                order = 10,
+                type = "group",
+                name = "About WoW-Pro",
+                inline = true,
+                args = {
+                    intro1 = {
+                        order = 1,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "WoW-Pro is an addon collection by gamers, for gamers. It provides guided questing, leveling help, automation helpers, and progression tools across modern and classic-era content."
+                    },
+                    intro2 = {
+                        order = 2,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "The project has grown through years of community contributions. Guides and systems continue to evolve from old expansions through current retail content."
+                    },
+                    intro3 = {
+                        order = 3,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "If you are new, start with the Main and Guide Display tabs. If you are troubleshooting, use the built-in log tools and command shortcuts listed below."
+                    },
+                },
+            },
+            quickStart = {
+                order = 20,
+                type = "group",
+                name = "Quick Start",
+                inline = true,
+                args = {
+                    qs1 = {
+                        order = 1,
+                        type = "description",
+                        width = "full",
+                        name = "1) Open the guide list and pick a guide for your character level or campaign."
+                    },
+                    qs2 = {
+                        order = 2,
+                        type = "description",
+                        width = "full",
+                        name = "2) In Main, choose automation settings like Auto Accept, Auto Turnin, and Auto Select."
+                    },
+                    qs3 = {
+                        order = 3,
+                        type = "description",
+                        width = "full",
+                        name = "3) In Guide Display, tune sizing, text, and background style to match your UI."
+                    },
+                    qs4 = {
+                        order = 4,
+                        type = "description",
+                        width = "full",
+                        name = "4) If progress appears off, use Main > Master Addon Tools to reset state or inspect logs."
+                    },
+                },
+            },
+            links = {
+                order = 30,
+                type = "group",
+                name = "Community and Links",
+                inline = true,
+                args = {
+                    discordIcon = {
+                        order = 1,
+                        type = "description",
+                        name = "",
+                        image = "Interface/AddOns/WoWPro/Textures/Discord",
+                        imageWidth = 24,
+                        imageHeight = 24,
+                        width = 0.15
+                    },
+                    discord = {
+                        order = 2,
+                        type = "input",
+                        name = "Discord",
+                        get = function() return "https://discord.gg/aarduK7" end,
+                        set = function() return "https://discord.gg/aarduK7" end,
+                        icon = "Interface\\AddOns\\WoWPro\\Textures\\Discord",
+                        width = "double"
+                    },
+                    github = {
+                        order = 3,
+                        type = "input",
+                        name = "GitHub",
+                        get = function() return "https://github.com/AeroScripts/WoW-Pro-Guides" end,
+                        set = function() return "https://github.com/AeroScripts/WoW-Pro-Guides" end,
+                        width = "double"
+                    },
+                },
+            },
+            commands = {
+                order = 40,
+                type = "group",
+                name = "Useful Commands",
+                inline = true,
+                args = {
+                    cmdIntro = {
+                        order = 1,
+                        type = "description",
+                        width = "full",
+                        name = "Use /wp or /wow-pro with the following commands:"
+                    },
+                    cmd1 = {
+                        order = 2,
+                        type = "description",
+                        width = "full",
+                        name = "- where: print current map position and area details"
+                    },
+                    cmd2 = {
+                        order = 3,
+                        type = "description",
+                        width = "full",
+                        name = "- reset: clear WoW-Pro saved runtime state"
+                    },
+                    cmd3 = {
+                        order = 4,
+                        type = "description",
+                        width = "full",
+                        name = "- clear-log / log: clear or show the debug log"
+                    },
+                    cmd4 = {
+                        order = 5,
+                        type = "description",
+                        width = "full",
+                        name = "- guide-bug / trade-bug: create focused bug reports"
+                    },
+                    cmd5 = {
+                        order = 6,
+                        type = "description",
+                        width = "full",
+                        name = "- devcoords / devzone / devmode: developer mapping helpers"
+                    },
+                    cmd6 = {
+                        order = 7,
+                        type = "description",
+                        width = "full",
+                        name = "- flightids [dest]: inspect flight node IDs for your current map"
+                    },
+                },
+            },
+            status = {
+                order = 50,
+                type = "group",
+                name = "Runtime Status",
+                inline = true,
+                args = {
+                    addonVersion = {
+                        order = 1,
+                        type = "description",
+                        width = "full",
+                        name = function()
+                            return ("Addon Version: %s"):format(tostring(WoWPro.Version or "Unknown"))
+                        end,
+                    },
+                    wowVersion = {
+                        order = 2,
+                        type = "description",
+                        width = "full",
+                        name = function()
+                            local v, b, d, t = _G.GetBuildInfo()
+                            return ("WoW Client: %s (Build %s, TOC %s)"):format(tostring(v or "?"), tostring(b or "?"), tostring(t or "?"))
+                        end,
+                    },
+                    profileName = {
+                        order = 3,
+                        type = "description",
+                        width = "full",
+                        name = function()
+                            local profile = "Unknown"
+                            if WoWProDB and WoWProDB.GetCurrentProfile then
+                                profile = WoWProDB:GetCurrentProfile() or "Unknown"
+                            end
+                            return ("Active Profile: %s"):format(tostring(profile))
+                        end,
+                    },
+                    currentGuide = {
+                        order = 4,
+                        type = "description",
+                        width = "full",
+                        name = function()
+                            local gid = WoWProDB and WoWProDB.char and WoWProDB.char.currentguide or nil
+                            return ("Current Guide: %s"):format(tostring(gid or "None"))
+                        end,
+                    },
+                },
+            },
+            help = {
+                order = 60,
+                type = "group",
+                name = "Troubleshooting Checklist",
+                inline = true,
+                args = {
+                    h1 = {
+                        order = 1,
+                        type = "description",
+                        width = "full",
+                        name = "- If steps do not advance, open Main and check automation toggles plus guide rank settings."
+                    },
+                    h2 = {
+                        order = 2,
+                        type = "description",
+                        width = "full",
+                        name = "- Use /wp log to inspect debug entries and /wp clear-log before reproducing issues."
+                    },
+                    h3 = {
+                        order = 3,
+                        type = "description",
+                        width = "full",
+                        name = "- Use /wp reset if saved state becomes inconsistent after major patches."
+                    },
+                    h4 = {
+                        order = 4,
+                        type = "description",
+                        width = "full",
+                        name = "- If needed, share logs and guide ID in Discord for faster support."
+                    },
+                },
+            },
+        },
+    }
+end
+
+local function createHTMLConfig()
+    return {
+        name = "HTML",
+        type = "group",
+        args = {
+            htmlPanel = {
+                order = 10,
+                type = "group",
+                name = "Simple HTML",
+                inline = true,
+                args = {
+                    htmlNote = {
+                        order = 1,
+                        type = "description",
+                        width = "full",
+                        fontSize = "medium",
+                        name = "Simple HTML sample text for reference.",
+                    },
+                    htmlSample = {
+                        order = 2,
+                        type = "input",
+                        multiline = 12,
+                        width = "full",
+                        name = "Markup",
+                        get = function()
+                            return "<h1>WoW-Pro</h1>\n<p>This is a simple HTML-style sample tab.</p>\n<ul>\n  <li>Main</li>\n  <li>Guide Display</li>\n  <li>Profiles</li>\n</ul>"
+                        end,
+                        set = function() end,
+                    },
+                },
+            },
+        },
     }
 end
 
@@ -1009,164 +1233,162 @@ local function createExpertOptions()
         name = L["Expert"],
         type = "group",
         args = {
-            header = {
-                order = 1,
-                type = "header",
-                name = L["Quest Engine Delay"],
-            },
-            spacer1 = {
-                order = 1.1,
-                type = "description",
-                name = " ",
-                width = "full"
-            },
-            QuestEngineDelay = {
-                order = 2,
-                type = "range",
-                name = L["The amount of time to wait for the WoW client to update it's state."],
-                min = 0.1, max = 0.75, step = .05,
-                get = function(info) return WoWProDB.global.QuestEngineDelay end,
-                set = function(info,val) WoWProDB.global.QuestEngineDelay = val end,
-                width = "full"
-            },
-            spacer2 = {
-                order = 3,
-                type = "description",
-                name = " ",
-                width = "full"
-            },
-            spacer3 = {
-                order = 3.1,
-                type = "description",
-                name = " ",
-                width = "full"
-            },
-            header2 = {
-                order = 3.2,
-                type = "header",
-                name = L["Stay away from the below settings unless you are a developer"],
-            },
-            blank = {
-                order = 4,
-                type = "description",
-                name = " ",
-            },
-            debugClasses = {
-                order = 5,
-                type = "toggle",
-                name = L["Debug Classes"],
-                desc = L["Enables/Disables loading of all class guides"],
-                get = function(info) return (WoWPro.DebugLevel > 0) and WoWPro.DebugClasses end,
-                set = function(info,val)
-                        if WoWPro.DebugClasses then
-                            WoWPro.DebugClasses = false
-                        else
-                            WoWPro.DebugClasses = (WoWPro.DebugLevel > 0)
-                        end
-                        WoWProCharDB.DebugClasses = WoWPro.DebugClasses
-                    end,
-                    width = "double"
-            },
-            EnableGrailQuestline = {
-                order = 6,
-                type = "toggle",
-                name = L["Grail Quest Lines"],
-                desc = L["Enables/Disables Grail Quest Line Integration"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestline end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestline then
-                            WoWProCharDB.EnableGrailQuestline = false
-                        else
-                            WoWProCharDB.EnableGrailQuestline = true
-                        end
-                    end,
-                    width = "double"
-            },
-            EnableGrailCheckPrereq = {
-                order = 7,
-                type = "toggle",
-                name = L["Grail Check PRE"],
-                desc = L["Enables/Disables Grail Quest Prerequistite Quest Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailCheckPrereq end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailCheckPrereq then
-                            WoWProCharDB.EnableGrailCheckPrereq = false
-                        else
-                            WoWProCharDB.EnableGrailCheckPrereq = true
-                        end
-                    end,
-                    width = "double"
-            },
-            EnableGrailBreadcrumbs = {
-                order = 8,
-                type = "toggle",
-                name = L["Grail Check LEAD"],
-                desc = L["Enables/Disables Grail Quest Breadcrumb Quest Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailBreadcrumbs end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailBreadcrumbs then
-                            WoWProCharDB.EnableGrailBreadcrumbs = false
-                        else
-                            WoWProCharDB.EnableGrailBreadcrumbs = true
-                        end
-                    end,
-                    width = "double"
-            },
-            EnableGrailQuestName = {
-                order = 9,
-                type = "toggle",
-                name = L["Grail Quest Name Check"],
-                desc = L["Enables/Disables Grail Quest Quest Name Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestName end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestName then
-                            WoWProCharDB.EnableGrailQuestName = false
-                        else
-                            WoWProCharDB.EnableGrailQuestName = true
-                        end
-                    end,
-                    width = "double"
-            },
-            EnableGrailQuestLevel = {
+            engine = {
                 order = 10,
-                type = "toggle",
-                name = L["Grail Quest Level Check"],
-                desc = L["Enables/Disables Grail Quest Quest Level Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestLevel end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestLevel then
-                            WoWProCharDB.EnableGrailQuestLevel = false
-                        else
-                            WoWProCharDB.EnableGrailQuestLevel = true
-                        end
-                    end,
-                    width = "double"
+                type = "group",
+                name = L["Quest Engine Delay"],
+                inline = true,
+                args = {
+                    engineHelp = {
+                        order = 1,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "Adjust the delay used while waiting for WoW API state updates. Increase this if steps complete too early; decrease it if updates feel sluggish.",
+                    },
+                    QuestEngineDelay = {
+                        order = 2,
+                        type = "range",
+                        name = L["The amount of time to wait for the WoW client to update it's state."],
+                        desc = "Default is 0.5 seconds.",
+                        min = 0.1, max = 0.75, step = .05,
+                        get = function(info) return WoWProDB.global.QuestEngineDelay end,
+                        set = function(info,val) WoWProDB.global.QuestEngineDelay = val end,
+                        width = "full"
+                    },
+                },
             },
-            EnableGrailQuestObsolete = {
-                order = 11,
-                type = "toggle",
-                name = L["Grail Obsolete Quest Check"],
-                desc = L["Enables/Disables Grail Quest Quest Obsolete Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestObsolete end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestObsolete then
-                            WoWProCharDB.EnableGrailQuestObsolete = false
-                        else
-                            WoWProCharDB.EnableGrailQuestObsolete = true
-                        end
-                    end,
-                width = "double"
-            },
-            checkGuides = {
-                order = 13,
-                type = "execute",
-                name = L["Guide Errors Checker"],
-                image = "Interface\\RaidFrame\\ReadyCheck-Waiting",
-                func =  function (info)
-                            WoWPro:LogClear("CheckGuides");
-                            WoWPro:LoadAllGuides()
+            developer = {
+                order = 20,
+                type = "group",
+                name = "Developer Tools",
+                inline = true,
+                args = {
+                    warning = {
+                        order = 1,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = L["Stay away from the below settings unless you are a developer"],
+                    },
+                    debugClasses = {
+                        order = 5,
+                        type = "toggle",
+                        name = L["Debug Classes"],
+                        desc = L["Enables/Disables loading of all class guides"],
+                        get = function(info) return (WoWPro.DebugLevel > 0) and WoWPro.DebugClasses end,
+                        set = function(info,val)
+                            if WoWPro.DebugClasses then
+                                WoWPro.DebugClasses = false
+                            else
+                                WoWPro.DebugClasses = (WoWPro.DebugLevel > 0)
+                            end
+                            WoWProCharDB.DebugClasses = WoWPro.DebugClasses
                         end,
                         width = "double"
+                    },
+                    EnableGrailQuestline = {
+                        order = 6,
+                        type = "toggle",
+                        name = L["Grail Quest Lines"],
+                        desc = L["Enables/Disables Grail Quest Line Integration"],
+                        get = function(info) return WoWProCharDB.EnableGrailQuestline end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestline then
+                                WoWProCharDB.EnableGrailQuestline = false
+                            else
+                                WoWProCharDB.EnableGrailQuestline = true
+                            end
+                        end,
+                        width = "double"
+                    },
+                    EnableGrailCheckPrereq = {
+                        order = 7,
+                        type = "toggle",
+                        name = L["Grail Check PRE"],
+                        desc = L["Enables/Disables Grail Quest Prerequistite Quest Checking"],
+                        get = function(info) return WoWProCharDB.EnableGrailCheckPrereq end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableGrailCheckPrereq then
+                                WoWProCharDB.EnableGrailCheckPrereq = false
+                            else
+                                WoWProCharDB.EnableGrailCheckPrereq = true
+                            end
+                        end,
+                        width = "double"
+                    },
+                    EnableGrailBreadcrumbs = {
+                        order = 8,
+                        type = "toggle",
+                        name = L["Grail Check LEAD"],
+                        desc = L["Enables/Disables Grail Quest Breadcrumb Quest Checking"],
+                        get = function(info) return WoWProCharDB.EnableGrailBreadcrumbs end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableGrailBreadcrumbs then
+                                WoWProCharDB.EnableGrailBreadcrumbs = false
+                            else
+                                WoWProCharDB.EnableGrailBreadcrumbs = true
+                            end
+                        end,
+                        width = "double"
+                    },
+                    EnableGrailQuestName = {
+                        order = 9,
+                        type = "toggle",
+                        name = L["Grail Quest Name Check"],
+                        desc = L["Enables/Disables Grail Quest Quest Name Checking"],
+                        get = function(info) return WoWProCharDB.EnableGrailQuestName end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestName then
+                                WoWProCharDB.EnableGrailQuestName = false
+                            else
+                                WoWProCharDB.EnableGrailQuestName = true
+                            end
+                        end,
+                        width = "double"
+                    },
+                    EnableGrailQuestLevel = {
+                        order = 10,
+                        type = "toggle",
+                        name = L["Grail Quest Level Check"],
+                        desc = L["Enables/Disables Grail Quest Quest Level Checking"],
+                        get = function(info) return WoWProCharDB.EnableGrailQuestLevel end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestLevel then
+                                WoWProCharDB.EnableGrailQuestLevel = false
+                            else
+                                WoWProCharDB.EnableGrailQuestLevel = true
+                            end
+                        end,
+                        width = "double"
+                    },
+                    EnableGrailQuestObsolete = {
+                        order = 11,
+                        type = "toggle",
+                        name = L["Grail Obsolete Quest Check"],
+                        desc = L["Enables/Disables Grail Quest Quest Obsolete Checking"],
+                        get = function(info) return WoWProCharDB.EnableGrailQuestObsolete end,
+                        set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestObsolete then
+                                WoWProCharDB.EnableGrailQuestObsolete = false
+                            else
+                                WoWProCharDB.EnableGrailQuestObsolete = true
+                            end
+                        end,
+                        width = "double"
+                    },
+                    checkGuides = {
+                        order = 13,
+                        type = "execute",
+                        name = L["Guide Errors Checker"],
+                        image = "Interface\\RaidFrame\\ReadyCheck-Waiting",
+                        func =  function (info)
+                            WoWPro:LogClear("CheckGuides")
+                            WoWPro:LoadAllGuides()
+                        end,
+                        width = "full"
+                    },
+                },
             },
         },
     }
@@ -1181,26 +1403,26 @@ local function createRankConfig()
             type = "group",
             order = 50,
             args = {
-                header = {
+                header2 = {
                     order = 10,
                     type = "header",
-                    name = L["Addon Version Installed"],
+                    name = L["Rank Settings"],
                 },
-                version = {
+                rankHelp = {
                     order = 11,
                     type = "description",
-                    name = L["Version"]..": "..WoWPro.Version,
-                },
-                header2 = {
-                    order = 13,
-                    type = "header",
-                    name = L["Rank Settings"],
+                    fontSize = "medium",
+                    width = "full",
+                    name = "Ranks control how many optional steps are included in guides.\n" ..
+                        "1 = shortest route (core progression only), 2 = balanced route, 3 = fullest route (most optional content).\n\n" ..
+                        "Priority for this character is: Toon Rank first, then Global Rank as fallback.",
                 },
                 grank = {
                     order = 25,
                     type = "range",
                     name = L["Global Rank (Difficulty/Completeness)"],
-                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    desc = "Default rank for all characters and guides unless overridden.\n\n" ..
+                        "Use 1 for speed leveling, 2 for normal play, or 3 for completion-focused runs.",
                     min = 1, max = 3, step = 1,
                     get = function(info) return WoWProDB.profile.rank end,
                     set = function(info,val) WoWProDB.profile.rank = val
@@ -1214,7 +1436,8 @@ local function createRankConfig()
                     order = 26,
                     type = "range",
                     name = L["Toon Rank (Difficulty/Completeness)"],
-                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    desc = "Character-specific override for this toon.\n\n" ..
+                        "If set, this value is used instead of Global Rank for this character.",
                     min = 1, max = 3, step = 1,
                     get = function(info) return WoWProCharDB.Rank[1] end,
                     set = function(info,val) WoWProCharDB.Rank[1] = val
@@ -1231,26 +1454,25 @@ local function createRankConfig()
     for name, module in WoWPro:IterateModules() do
         ranks.args[name.."Rank"] = {name=L[name], type="group", order = slot,
             args = {
-                header = {
+                header2 = {
                     order = 10,
                     type = "header",
-                    name = L[name.." Addon Version Installed"],
+                    name = L["Rank Settings"],
                 },
-                version = {
+                rankHelp = {
                     order = 11,
                     type = "description",
-                    name = L[name .. " Version"]..": "..tostring(module.Version).."\n\n",
-                },
-                header2 = {
-                    order = 13,
-                    type = "header",
-                    name = L["Rank Settings"],
+                    fontSize = "medium",
+                    width = "full",
+                    name = "This rank controls how complete " .. tostring(L[name] or name) .. " guides should be in this profile.\n" ..
+                        "1 = shortest route, 2 = balanced route, 3 = fullest route with more optional steps.",
                 },
                 mrank = {
                     order = 25,
                     type = "range",
                     name = L[name.." Rank (Difficulty/Completeness)"],
-                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    desc = "Profile-level rank for this module's guide type.\n\n" ..
+                        "Use this when you want different strictness for " .. tostring(L[name] or name) .. " than your default rank.",
                     min = 1, max = 3, step = 1,
                     get = function(info) return WoWProDB.profile[name.."rank"] end,
                     set = function(info,val) WoWProDB.profile[name.."rank"] = val
@@ -1272,14 +1494,30 @@ local function createActionConfig()
         name = L["Actions"],
         type = "group",
         args = {
-                header = {
-                    order = 10,
-                    type = "header",
-                    name = L["Step Action Description"],
+            legend = {
+                order = 10,
+                type = "group",
+                name = L["Step Action Description"],
+                inline = true,
+                args = {
+                    intro = {
+                        order = 10,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "Action letters appear in each step and indicate what kind of step it is. Use this legend to quickly decode guide rows.",
+                    },
+                    spacer = {
+                        order = 11,
+                        type = "description",
+                        width = "full",
+                        name = " ",
+                    },
+                },
             }
         }
     }
-    WoWPro.InsertActionDescriptions(actions.args, 20)
+    WoWPro.InsertActionDescriptions(actions.args.legend.args, 20)
     return actions
 end
 
@@ -1351,26 +1589,51 @@ end
 
 
 function WoWPro.CreateConfig()
+    local profileConfig = _G.LibStub("AceDBOptions-3.0"):GetOptionsTable(WoWProDB)
+
+    -- Layout pass: make Profiles less cramped by stacking key controls.
+    if profileConfig and profileConfig.args then
+        profileConfig.args.desc.width = "full"
+        profileConfig.args.descreset.width = "full"
+        profileConfig.args.choosedesc.width = "full"
+        profileConfig.args.copydesc.width = "full"
+        profileConfig.args.deldesc.width = "full"
+
+        profileConfig.args.reset.width = "double"
+        profileConfig.args.current.width = "full"
+
+        profileConfig.args.new.width = "full"
+        profileConfig.args.choose.width = "full"
+        profileConfig.args.copyfrom.width = "full"
+        profileConfig.args.delete.width = "full"
+
+        profileConfig.args.desc.name = "\n" .. profileConfig.args.desc.name
+    end
+
     local topConfig = {
         name = "Options",
         type = "group",
         childGroups = "tab",
         args = {
+            aboutConfig = createAboutConfig(),
+            htmlConfig = createHTMLConfig(),
             mainConfig = createMainConfig(),
             displayConfig = createDisplayConfig(),
-            profileConfig = _G.LibStub("AceDBOptions-3.0"):GetOptionsTable(WoWProDB),
+            profileConfig = profileConfig,
             rankConfig = createRankConfig(),
             actionConfig = createActionConfig(),
             expertConfig = createExpertOptions()
         }
     }
     --  (default = 100, 0=first, -1=last)
+    topConfig.args.aboutConfig.order=-1
     topConfig.args.mainConfig.order=0
     topConfig.args.displayConfig.order=10
     topConfig.args.profileConfig.order=13
     topConfig.args.rankConfig.order=14
     topConfig.args.actionConfig.order=15
-    topConfig.args.expertConfig.order=-1
+    topConfig.args.htmlConfig.order=98
+    topConfig.args.expertConfig.order=99
 
 
     config:RegisterOptionsTable("WoWPro", topConfig)

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -1055,8 +1055,8 @@ local function createAboutConfig()
                         order = 3,
                         type = "input",
                         name = "GitHub",
-                        get = function() return "https://github.com/AeroScripts/WoW-Pro-Guides" end,
-                        set = function() return "https://github.com/AeroScripts/WoW-Pro-Guides" end,
+                        get = function() return "https://github.com/Ludovicus-Maior/WoW-Pro-Guides" end,
+                        set = function() return "https://github.com/Ludovicus-Maior/WoW-Pro-Guides" end,
                         width = "double"
                     },
                 },

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -1130,7 +1130,7 @@ local function createAboutConfig()
                         type = "description",
                         width = "full",
                         name = function()
-                            local v, b, d, t = _G.GetBuildInfo()
+                            local v, b, _, t = _G.GetBuildInfo()
                             return ("WoW Client: %s (Build %s, TOC %s)"):format(tostring(v or "?"), tostring(b or "?"), tostring(t or "?"))
                         end,
                     },

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -972,58 +972,53 @@ local function createAboutConfig()
                 name = "About WoW-Pro",
                 inline = true,
                 args = {
-                    intro1 = {
+                    introTitle = {
                         order = 1,
+                        type = "description",
+                        fontSize = "large",
+                        width = "full",
+                        name = "What WoW-Pro Does"
+                    },
+                    intro1 = {
+                        order = 2,
                         type = "description",
                         fontSize = "medium",
                         width = "full",
-                        name = "WoW-Pro is an addon collection by gamers, for gamers. It provides guided questing, leveling help, automation helpers, and progression tools across modern and classic-era content."
+                        name = "WoW-Pro is a community-built addon collection that helps with questing, leveling, and guide-driven progression."
                     },
                     intro2 = {
-                        order = 2,
-                        type = "description",
-                        fontSize = "medium",
-                        width = "full",
-                        name = "The project has grown through years of community contributions. Guides and systems continue to evolve from old expansions through current retail content."
-                    },
-                    intro3 = {
                         order = 3,
                         type = "description",
                         fontSize = "medium",
                         width = "full",
-                        name = "If you are new, start with the Main and Guide Display tabs. If you are troubleshooting, use the built-in log tools and command shortcuts listed below."
+                        name = "It has grown through years of player contributions, covering content from legacy expansions through current Retail."
                     },
-                },
-            },
-            quickStart = {
-                order = 20,
-                type = "group",
-                name = "Quick Start",
-                inline = true,
-                args = {
-                    qs1 = {
-                        order = 1,
-                        type = "description",
-                        width = "full",
-                        name = "1) Open the guide list and pick a guide for your character level or campaign."
-                    },
-                    qs2 = {
-                        order = 2,
-                        type = "description",
-                        width = "full",
-                        name = "2) In Main, choose automation settings like Auto Accept, Auto Turnin, and Auto Select."
-                    },
-                    qs3 = {
-                        order = 3,
-                        type = "description",
-                        width = "full",
-                        name = "3) In Guide Display, tune sizing, text, and background style to match your UI."
-                    },
-                    qs4 = {
+                    introSpacer = {
                         order = 4,
                         type = "description",
                         width = "full",
-                        name = "4) If progress appears off, use Main > Master Addon Tools to reset state or inspect logs."
+                        name = " "
+                    },
+                    introStartTitle = {
+                        order = 5,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "Where To Start"
+                    },
+                    intro3 = {
+                        order = 6,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "New here: begin with Main and Guide Display to set automation, layout, and text style."
+                    },
+                    intro4 = {
+                        order = 7,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "Troubleshooting: use the built-in log tools and command shortcuts listed below."
                     },
                 },
             },
@@ -1033,31 +1028,43 @@ local function createAboutConfig()
                 name = "Community and Links",
                 inline = true,
                 args = {
-                    discordIcon = {
+                    linksTitle = {
                         order = 1,
                         type = "description",
-                        name = "",
-                        image = "Interface/AddOns/WoWPro/Textures/Discord",
-                        imageWidth = 24,
-                        imageHeight = 24,
-                        width = 0.15
+                        fontSize = "large",
+                        width = "full",
+                        name = "Stay Connected"
+                    },
+                    linksIntro = {
+                        order = 2,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "Use these links for announcements, support, and development updates."
                     },
                     discord = {
-                        order = 2,
+                        order = 3,
                         type = "input",
-                        name = "Discord",
+                        name = "Discord Invite",
                         get = function() return "https://discord.gg/aarduK7" end,
                         set = function() return "https://discord.gg/aarduK7" end,
                         icon = "Interface\\AddOns\\WoWPro\\Textures\\Discord",
-                        width = "double"
+                        width = "full"
                     },
                     github = {
-                        order = 3,
+                        order = 4,
                         type = "input",
-                        name = "GitHub",
+                        name = "Source Repository",
                         get = function() return "https://github.com/Ludovicus-Maior/WoW-Pro-Guides" end,
                         set = function() return "https://github.com/Ludovicus-Maior/WoW-Pro-Guides" end,
-                        width = "double"
+                        width = "full"
+                    },
+                    linksNote = {
+                        order = 5,
+                        type = "description",
+                        fontSize = "medium",
+                        width = "full",
+                        name = "Tip: Include your guide name or ID and a short log snippet when asking for help in Discord."
                     },
                 },
             },
@@ -1157,8 +1164,148 @@ local function createAboutConfig()
                     },
                 },
             },
-            help = {
-                order = 60,
+        },
+    }
+end
+
+local function createHelpConfig()
+    return {
+        name = "Help",
+        type = "group",
+        args = {
+            gettingStarted = {
+                order = 10,
+                type = "group",
+                name = "Getting Started",
+                inline = true,
+                args = {
+                    intro = {
+                        order = 1,
+                        type = "description",
+                        width = "full",
+                        name = "Use these steps to get running with WoW-Pro as a player, then use the Recorder to build or edit your own guide.",
+                    },
+                    wowproHeader = {
+                        order = 2,
+                        type = "header",
+                        name = "Starting WoW-Pro",
+                    },
+                    wowpro1 = {
+                        order = 3,
+                        type = "description",
+                        width = "full",
+                        name = "1) Open Guide List and choose a guide that matches your level, campaign, or expansion path.",
+                    },
+                    wowpro2 = {
+                        order = 4,
+                        type = "description",
+                        width = "full",
+                        name = "2) Open Main and set your automation preferences, especially Auto Accept, Auto Turn-in, and Auto Select, before you start questing.",
+                    },
+                    wowpro3 = {
+                        order = 5,
+                        type = "description",
+                        width = "full",
+                        name = "3) Open Guide Display and adjust frame size, number of rows, text scale, and background so the guide fits your UI cleanly.",
+                    },
+                    wowpro4 = {
+                        order = 6,
+                        type = "description",
+                        width = "full",
+                        name = "4) Start playing. WoW-Pro will load the selected guide into the main frame and advance steps as quests and objectives update.",
+                    },
+                    wowpro5 = {
+                        order = 7,
+                        type = "description",
+                        width = "full",
+                        name = "5) If a guide looks stuck or out of sync, use /wp reset to clear guide state and /wp log to inspect the debug log before reporting the issue.",
+                    },
+                    recorderHeader = {
+                        order = 8,
+                        type = "header",
+                        name = "Starting With The Recorder",
+                    },
+                    recorder1 = {
+                        order = 9,
+                        type = "description",
+                        width = "full",
+                        name = "1) Enable WoWPro_Recorder in the AddOns list, then reload the UI if needed. When it is active, a recorder toolbar appears above the main WoW-Pro frame.",
+                    },
+                    recorder2 = {
+                        order = 10,
+                        type = "description",
+                        width = "full",
+                        name = "2) Click New on the recorder toolbar to create a guide. Choose the guide type first, then fill in the guide fields such as Guide ID, zone, author, faction, and level range.",
+                    },
+                    recorder3 = {
+                        order = 11,
+                        type = "description",
+                        width = "full",
+                        name = "3) Finish the New Guide dialog to register the guide. WoW-Pro will load that guide immediately so you can begin editing or recording steps into it.",
+                    },
+                    recorder4 = {
+                        order = 12,
+                        type = "description",
+                        width = "full",
+                        name = "4) Click Record to capture questing progress while you play. Click Stop any time you want to pause before moving, testing, or editing steps manually.",
+                    },
+                    recorder5 = {
+                        order = 13,
+                        type = "description",
+                        width = "full",
+                        name = "5) Use Open to load an existing guide for editing. Use Save to write the current recorder version to your saved guides so it can be reopened later.",
+                    },
+                    recorder6 = {
+                        order = 14,
+                        type = "description",
+                        width = "full",
+                        name = "6) In Advanced mode, use Add to insert a step after the selected step, or use buttons such as Run, Flight, Portal, Note, and Delete to refine the route.",
+                    },
+                    recorder7 = {
+                        order = 15,
+                        type = "description",
+                        width = "full",
+                        name = "7) Use /wpr to toggle Basic or Advanced recorder mode. Use /wpr help to list recorder slash commands, and /wpr qdebug on or off if you need extra quest API logging while testing.",
+                    },
+                    recorder8 = {
+                        order = 16,
+                        type = "description",
+                        width = "full",
+                        name = "8) After saving, reopen the guide with Open and run through a few steps to verify quest IDs, notes, and automatic completion behave the way you expect.",
+                    },
+                    exportHeader = {
+                        order = 17,
+                        type = "header",
+                        name = "Exporting And Sharing",
+                    },
+                    export1 = {
+                        order = 18,
+                        type = "description",
+                        width = "full",
+                        name = "1) Click Save after recording or editing. The recorder opens a large text box containing the full Lua guide definition for the currently loaded guide.",
+                    },
+                    export2 = {
+                        order = 19,
+                        type = "description",
+                        width = "full",
+                        name = "2) Copy that text and paste it into a guide file if you want to move the guide into the addon source, share it with another author, or submit it for review.",
+                    },
+                    export3 = {
+                        order = 20,
+                        type = "description",
+                        width = "full",
+                        name = "3) The recorder also keeps a saved copy in WoWPro_RecorderDB, so you can reload the guide later with Open even if you have not moved it into a permanent guide file yet.",
+                    },
+                    export4 = {
+                        order = 21,
+                        type = "description",
+                        width = "full",
+                        name = "4) For out-of-game backup or sharing, look in your WoW SavedVariables for WoWPro_Recorder.lua under WTF/Account/<account>/SavedVariables. That file stores the recorder guides saved on this installation.",
+                    },
+                },
+            },
+            troubleshooting = {
+                order = 20,
                 type = "group",
                 name = "Troubleshooting Checklist",
                 inline = true,
@@ -1186,41 +1333,6 @@ local function createAboutConfig()
                         type = "description",
                         width = "full",
                         name = "- If needed, share logs and guide ID in Discord for faster support."
-                    },
-                },
-            },
-        },
-    }
-end
-
-local function createHTMLConfig()
-    return {
-        name = "HTML",
-        type = "group",
-        args = {
-            htmlPanel = {
-                order = 10,
-                type = "group",
-                name = "Simple HTML",
-                inline = true,
-                args = {
-                    htmlNote = {
-                        order = 1,
-                        type = "description",
-                        width = "full",
-                        fontSize = "medium",
-                        name = "Simple HTML sample text for reference.",
-                    },
-                    htmlSample = {
-                        order = 2,
-                        type = "input",
-                        multiline = 12,
-                        width = "full",
-                        name = "Markup",
-                        get = function()
-                            return "<h1>WoW-Pro</h1>\n<p>This is a simple HTML-style sample tab.</p>\n<ul>\n  <li>Main</li>\n  <li>Guide Display</li>\n  <li>Profiles</li>\n</ul>"
-                        end,
-                        set = function() end,
                     },
                 },
             },
@@ -1616,7 +1728,7 @@ function WoWPro.CreateConfig()
         childGroups = "tab",
         args = {
             aboutConfig = createAboutConfig(),
-            htmlConfig = createHTMLConfig(),
+            helpConfig = createHelpConfig(),
             mainConfig = createMainConfig(),
             displayConfig = createDisplayConfig(),
             profileConfig = profileConfig,
@@ -1632,7 +1744,7 @@ function WoWPro.CreateConfig()
     topConfig.args.profileConfig.order=13
     topConfig.args.rankConfig.order=14
     topConfig.args.actionConfig.order=15
-    topConfig.args.htmlConfig.order=98
+    topConfig.args.helpConfig.order=98
     topConfig.args.expertConfig.order=99
 
 

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -210,19 +210,38 @@ end
 ---},
 
 function WoWPro.InsertActionDescriptions(tabla, order)
+    local actionList = {}
     for action, icon in pairs(WoWPro.actiontypes) do
-        local label = WoWPro.actionlabels[action]
-        local nickname = label:gsub("%s+", "")
-        tabla[nickname] = {
-            order = order,
-            type = "description",
-            fontSize = "medium",
-            name = label .. " (" .. action .. ")",
-            image = icon,
-            imageWidth = 16,
-            imageHeight = 16
-        }
-        order = order + 1
+        table.insert(actionList, action)
+    end
+
+    table.sort(actionList, function(a, b)
+        local la = WoWPro.actionlabels[a] or a
+        local lb = WoWPro.actionlabels[b] or b
+        if la == lb then
+            return a < b
+        end
+        return la < lb
+    end)
+
+    for _, action in ipairs(actionList) do
+        -- Keep the legend compact by hiding expanded Accept subtypes (e.g. "A Campaign").
+        if not action:match("^A%s+") then
+            local icon = WoWPro.actiontypes[action]
+            local label = WoWPro.actionlabels[action] or action
+            local nickname = ("Action_%s"):format(action:gsub("%s+", "_"))
+            tabla[nickname] = {
+                order = order,
+                type = "description",
+                fontSize = "medium",
+                width = "full",
+                name = label .. " (" .. action .. ")",
+                image = icon,
+                imageWidth = 16,
+                imageHeight = 16
+            }
+            order = order + 1
+        end
     end
     return tabla
 end


### PR DESCRIPTION
Feel free to reject or share thoughts.

- Refactored addon options into clearer card-style sections while preserving existing behavior.
- Refined tab ordering, including a dedicated About tab.
- Expanded About with richer onboarding, command reference, runtime status, and troubleshooting guidance.
- Improved Guide Display spacing and control layout to reduce visual crowding.
- Simplified and clarified Ranks:
- Removed version clutter
- Added fuller explanations of rank behavior and scope
- Improved Profiles layout by stacking key controls and widening descriptions.
- Reworked Actions tab into a cleaner legend view:
- Added explanatory intro
- Polished Expert tab with clearer grouping and guidance.
- Updated Quest Engine Delay default fallback from 0.25 to 0.5.


Card Based Menu System
<img width="957" height="752" alt="image" src="https://github.com/user-attachments/assets/50d51bfc-8460-4475-b9f2-aafc12e49e7a" />
<img width="661" height="595" alt="image" src="https://github.com/user-attachments/assets/67286c99-5591-4066-ae13-16ddddb93801" />
<img width="672" height="600" alt="image" src="https://github.com/user-attachments/assets/95df438b-5f78-43d9-9433-880c2e899c42" />
<img width="669" height="592" alt="image" src="https://github.com/user-attachments/assets/b9eb9e37-31ef-4851-86db-e9323b692e97" />


Added a Helptab for user, debate on text needed

<img width="652" height="552" alt="image" src="https://github.com/user-attachments/assets/2a469ce5-eeb8-48fe-9b95-744ea1aa9811" />


local function createHelpConfig()
    return {
        name = "Help",
        type = "group",
        args = {
            gettingStarted = {
                order = 10,
                type = "group",
                name = "Getting Started",
                inline = true,
                args = {
                    intro = {
                        order = 1,
                        type = "description",
                        width = "full",
                        name = "Use these steps to get running with WoW-Pro as a player, then use the Recorder to build or edit your own guide.",
                    },
                    wowproHeader = {
                        order = 2,
                        type = "header",
                        name = "Starting WoW-Pro",
                    },
                    wowpro1 = {
                        order = 3,
                        type = "description",
                        width = "full",
                        name = "1) Open Guide List and choose a guide that matches your level, campaign, or expansion path.",
                    },
                    wowpro2 = {
                        order = 4,
                        type = "description",
                        width = "full",
                        name = "2) Open Main and set your automation preferences, especially Auto Accept, Auto Turn-in, and Auto Select, before you start questing.",
                    },
                    wowpro3 = {
                        order = 5,
                        type = "description",
                        width = "full",
                        name = "3) Open Guide Display and adjust frame size, number of rows, text scale, and background so the guide fits your UI cleanly.",
                    },
                    wowpro4 = {
                        order = 6,
                        type = "description",
                        width = "full",
                        name = "4) Start playing. WoW-Pro will load the selected guide into the main frame and advance steps as quests and objectives update.",
                    },
                    wowpro5 = {
                        order = 7,
                        type = "description",
                        width = "full",
                        name = "5) If a guide looks stuck or out of sync, use /wp reset to clear guide state and /wp log to inspect the debug log before reporting the issue.",
                    },
                    recorderHeader = {
                        order = 8,
                        type = "header",
                        name = "Starting With The Recorder",
                    },
                    recorder1 = {
                        order = 9,
                        type = "description",
                        width = "full",
                        name = "1) Enable WoWPro_Recorder in the AddOns list, then reload the UI if needed. When it is active, a recorder toolbar appears above the main WoW-Pro frame.",
                    },
                    recorder2 = {
                        order = 10,
                        type = "description",
                        width = "full",
                        name = "2) Click New on the recorder toolbar to create a guide. Choose the guide type first, then fill in the guide fields such as Guide ID, zone, author, faction, and level range.",
                    },
                    recorder3 = {
                        order = 11,
                        type = "description",
                        width = "full",
                        name = "3) Finish the New Guide dialog to register the guide. WoW-Pro will load that guide immediately so you can begin editing or recording steps into it.",
                    },
                    recorder4 = {
                        order = 12,
                        type = "description",
                        width = "full",
                        name = "4) Click Record to capture questing progress while you play. Click Stop any time you want to pause before moving, testing, or editing steps manually.",
                    },
                    recorder5 = {
                        order = 13,
                        type = "description",
                        width = "full",
                        name = "5) Use Open to load an existing guide for editing. Use Save to write the current recorder version to your saved guides so it can be reopened later.",
                    },
                    recorder6 = {
                        order = 14,
                        type = "description",
                        width = "full",
                        name = "6) In Advanced mode, use Add to insert a step after the selected step, or use buttons such as Run, Flight, Portal, Note, and Delete to refine the route.",
                    },
                    recorder7 = {
                        order = 15,
                        type = "description",
                        width = "full",
                        name = "7) Use /wpr to toggle Basic or Advanced recorder mode. Use /wpr help to list recorder slash commands, and /wpr qdebug on or off if you need extra quest API logging while testing.",
                    },
                    recorder8 = {
                        order = 16,
                        type = "description",
                        width = "full",
                        name = "8) After saving, reopen the guide with Open and run through a few steps to verify quest IDs, notes, and automatic completion behave the way you expect.",
                    },
                    exportHeader = {
                        order = 17,
                        type = "header",
                        name = "Exporting And Sharing",
                    },
                    export1 = {
                        order = 18,
                        type = "description",
                        width = "full",
                        name = "1) Click Save after recording or editing. The recorder opens a large text box containing the full Lua guide definition for the currently loaded guide.",
                    },
                    export2 = {
                        order = 19,
                        type = "description",
                        width = "full",
                        name = "2) Copy that text and paste it into a guide file if you want to move the guide into the addon source, share it with another author, or submit it for review.",
                    },
                    export3 = {
                        order = 20,
                        type = "description",
                        width = "full",
                        name = "3) The recorder also keeps a saved copy in WoWPro_RecorderDB, so you can reload the guide later with Open even if you have not moved it into a permanent guide file yet.",
                    },
                    export4 = {
                        order = 21,
                        type = "description",
                        width = "full",
                        name = "4) For out-of-game backup or sharing, look in your WoW SavedVariables for WoWPro_Recorder.lua under WTF/Account/<account>/SavedVariables. That file stores the recorder guides saved on this installation.",
                    },
                },
            },
            troubleshooting = {
                order = 20,
                type = "group",
                name = "Troubleshooting Checklist",
                inline = true,
                args = {
                    h1 = {
                        order = 1,
                        type = "description",
                        width = "full",
                        name = "- If steps do not advance, open Main and check automation toggles plus guide rank settings."
                    },
                    h2 = {
                        order = 2,
                        type = "description",
                        width = "full",
                        name = "- Use /wp log to inspect debug entries and /wp clear-log before reproducing issues."
                    },
                    h3 = {
                        order = 3,
                        type = "description",
                        width = "full",
                        name = "- Use /wp reset if saved state becomes inconsistent after major patches."
                    },
                    h4 = {
                        order = 4,
                        type = "description",
                        width = "full",
                        name = "- If needed, share logs and guide ID in Discord for faster support."
                    },
                },
            },
        },
    }
end




