### PR TITLE
Improve event handling for F steps

### DIFF
--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -801,7 +801,7 @@ end)
 WoWPro.RegisterEventHandler("TAXIMAP_OPENED", function(event, ...)
     WoWPro:RecordTaxiLocations(...)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
-    if (WoWPro.action[qidx] == "F" or WoWPro.action[qidx] == "b") then
+    if WoWPro.action[qidx] == "F" then
         if WoWProCharDB.AutoSelect == true then
             WoWPro.TakeTaxi(WoWPro.step[qidx])
         else
@@ -819,7 +819,7 @@ end)
 
 function WoWPro.PLAYER_CONTROL_LOST_PUNTED(event, ...)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
-    if (WoWPro.action[qidx] == "F" or WoWPro.action[qidx] == "b") then
+    if WoWPro.action[qidx] == "F" then
         if _G.UnitOnTaxi("player") then
             WoWPro.TaxiPendingStep = qidx
             WoWPro:dbp("PLAYER_CONTROL_LOST_PUNTED: UnitOnTaxi! pending taxi completion for step %d", qidx)
@@ -834,7 +834,7 @@ WoWPro.RegisterEventHandler("PLAYER_CONTROL_GAINED", function(event, ...)
         if not _G.UnitOnTaxi("player") then
             local qidx = WoWPro.TaxiPendingStep
             WoWPro.TaxiPendingStep = nil
-            if WoWPro.action[qidx] == "F" or WoWPro.action[qidx] == "b" then
+            if WoWPro.action[qidx] == "F" then
                 WoWPro:dbp("PLAYER_CONTROL_GAINED: Taxi has ended, completing pending step %d", qidx)
                 WoWPro.CompleteStep(qidx, "Taxi ride completed")
             else

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -835,14 +835,17 @@ end
 WoWPro.RegisterEventHandler("PLAYER_CONTROL_GAINED", function(event, ...)
     if WoWPro.TaxiPendingStep then
         if not _G.UnitOnTaxi("player") then
-            local qidx = WoWPro.TaxiPendingStep
-            WoWPro.TaxiPendingStep = nil
-            local action = WoWPro.action[qidx]
-            if action == "F" or action == "b" or action == "R" then
-                WoWPro:dbp("PLAYER_CONTROL_GAINED: Taxi has ended, completing pending step %d", qidx)
-                WoWPro.CompleteStep(qidx, "Taxi ride completed")
+            local currentindex = WoWPro.rows[1+WoWPro:GetActiveStickyCount()].index
+            if currentindex == WoWPro.TaxiPendingStep then
+                local completed = WoWPro.AutoCompleteZone("PLAYER_CONTROL_GAINED")
+                if completed then
+                    WoWPro:dbp("PLAYER_CONTROL_GAINED: completed pending taxi step %d", WoWPro.TaxiPendingStep)
+                    WoWPro.TaxiPendingStep = nil
+                else
+                    WoWPro:dbp("PLAYER_CONTROL_GAINED: pending taxi step %d ended but destination not reached", WoWPro.TaxiPendingStep)
+                end
             else
-                WoWPro:dbp("PLAYER_CONTROL_GAINED: Pending step %d is no longer a taxi step", qidx)
+                WoWPro:dbp("PLAYER_CONTROL_GAINED: pending taxi step %d is not the current active step %d", WoWPro.TaxiPendingStep, currentindex)
             end
         else
             WoWPro:dbp("PLAYER_CONTROL_GAINED: still on taxi, waiting for disembark")

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -821,13 +821,30 @@ function WoWPro.PLAYER_CONTROL_LOST_PUNTED(event, ...)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
     if (WoWPro.action[qidx] == "F" or WoWPro.action[qidx] == "b") then
         if _G.UnitOnTaxi("player") then
-            WoWPro:dbp("PLAYER_CONTROL_LOST_PUNTED: UnitOnTaxi! calling CompleteStep")
-            WoWPro.CompleteStep(qidx,"Took a taxi")
+            WoWPro.TaxiPendingStep = qidx
+            WoWPro:dbp("PLAYER_CONTROL_LOST_PUNTED: UnitOnTaxi! pending taxi completion for step %d", qidx)
         else
             WoWPro:dbp("PLAYER_CONTROL_LOST_PUNTED: not on taxi!")
         end
     end
 end
+
+WoWPro.RegisterEventHandler("PLAYER_CONTROL_GAINED", function(event, ...)
+    if WoWPro.TaxiPendingStep then
+        if not _G.UnitOnTaxi("player") then
+            local qidx = WoWPro.TaxiPendingStep
+            WoWPro.TaxiPendingStep = nil
+            if WoWPro.action[qidx] == "F" or WoWPro.action[qidx] == "b" then
+                WoWPro:dbp("PLAYER_CONTROL_GAINED: Taxi has ended, completing pending step %d", qidx)
+                WoWPro.CompleteStep(qidx, "Taxi ride completed")
+            else
+                WoWPro:dbp("PLAYER_CONTROL_GAINED: Pending step %d is no longer a taxi step", qidx)
+            end
+        else
+            WoWPro:dbp("PLAYER_CONTROL_GAINED: still on taxi, waiting for disembark")
+        end
+    end
+end)
 
 WoWPro.RegisterEventHandler("HEARTHSTONE_BOUND", function(event, ...)
     -- In all clients:

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -798,10 +798,12 @@ WoWPro.RegisterEventHandler("NEW_RECIPE_LEARNED", function(event, ...)
 end)
 
 -- Auto-Completion --
+-- TAXIMAP_OPENED is only for auto-select route selection and flight-point discovery.
+-- It does not mean the ride has started or ended.
 WoWPro.RegisterEventHandler("TAXIMAP_OPENED", function(event, ...)
     WoWPro:RecordTaxiLocations(...)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
-    if WoWPro.action[qidx] == "F" then
+    if WoWPro.action[qidx] == "F" or WoWPro.action[qidx] == "b" then
         if WoWProCharDB.AutoSelect == true then
             WoWPro.TakeTaxi(WoWPro.step[qidx])
         else
@@ -819,7 +821,8 @@ end)
 
 function WoWPro.PLAYER_CONTROL_LOST_PUNTED(event, ...)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
-    if WoWPro.action[qidx] == "F" then
+    local action = WoWPro.action[qidx]
+    if action == "F" or action == "b" or action == "R" then
         if _G.UnitOnTaxi("player") then
             WoWPro.TaxiPendingStep = qidx
             WoWPro:dbp("PLAYER_CONTROL_LOST_PUNTED: UnitOnTaxi! pending taxi completion for step %d", qidx)
@@ -834,7 +837,8 @@ WoWPro.RegisterEventHandler("PLAYER_CONTROL_GAINED", function(event, ...)
         if not _G.UnitOnTaxi("player") then
             local qidx = WoWPro.TaxiPendingStep
             WoWPro.TaxiPendingStep = nil
-            if WoWPro.action[qidx] == "F" then
+            local action = WoWPro.action[qidx]
+            if action == "F" or action == "b" or action == "R" then
                 WoWPro:dbp("PLAYER_CONTROL_GAINED: Taxi has ended, completing pending step %d", qidx)
                 WoWPro.CompleteStep(qidx, "Taxi ride completed")
             else


### PR DESCRIPTION
### Concern
- If the user takes a flight and chooses a destination different from the intended one, or gets off early, the step should not autocomplete until they arrive at the correct destination.
- In its current flow, completion can happen as soon as they board, and the final destination is never confirmed.
- If Auto-completion is triggered too early, `NextStep()` may skip over a step and the guide window starts doing funky things until it's finally sorted out.

### Proposal
- Keep the current `TAXIMAP_OPENED` auto-select behavior.
- Change the taxi trigger flow so completion is based on the correct event transition:
    - detect boarding on PLAYER_CONTROL_LOST + UnitOnTaxi("player")
    - mark the taxi step pending
    - complete it on PLAYER_CONTROL_GAINED once UnitOnTaxi("player") is false

### Changes
1. Add a helper:
    - `WoWPro_IsTaxiStep(qidx)` -> returns `action == "F"`
2. On `PLAYER_CONTROL_LOST`:
    - if current step is an `F` and `_G.UnitOnTaxi("player") is `TRUE`, then set `WoWPro.TaxiPendingStep = qidx`
3. On `PLAYER_CONTROL_GAINED`:
    - if `WoWPro.TaxiPendingStep` exists, current `qidx` matches it, and `_G.UnitOnTaxi("player")` is `FALSE`, complete that pending step and clear `WoWPro.TaxiPendingStep`
    
    **Note:** 
This is a trigger correction, not a change to the higher-level auto-completion policy. The completion still happens, but now it happens at the right trigger point.
This also prevents flights that take the scenic route and fly over a destination early from triggering before it's ready.

**I almost missed this:**
For boat/ship travel, the same bail-out risk exists, but boat don't have a taxi interface and are not covered by this taxi-event fix. No more different than running to a different location.
