### PR TITLE
Auto complete bug fixes

### DIFF
--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -224,6 +224,29 @@ function WoWPro.GetLootTrackingInfo(lootItems)
     return tracks
 end
 
+function WoWPro.LootItemsCollected(lootItems)
+    if not lootItems or next(lootItems) == nil then
+        return true
+    end
+    local allPositiveComplete = true
+    local allNegativeComplete = true
+    local hasNegative = false
+    for itemID, qty in pairs(lootItems) do
+        local count = _G.WoWPro.C_Item_GetItemCount(itemID)
+        if qty > 0 then
+            if count < qty then
+                allPositiveComplete = false
+            end
+        else
+            hasNegative = true
+            if count >= -qty then
+                allNegativeComplete = false
+            end
+        end
+    end
+    return allPositiveComplete and (not hasNegative or allNegativeComplete)
+end
+
 -- Auto-Complete: Loot based --
 function WoWPro.AutoCompleteLoot()
     if not WoWPro.GuideLoaded then return end
@@ -334,27 +357,28 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
 
                 -- Quest AutoComplete --
                 if questComplete and (action == "A" or action == "C" or action == "T" or action == "N") and QID == questComplete then
-					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
-					break
-					else
-						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
-					end
-                end
-                -- Quest Accepts --
-                if WoWPro.newQuest == QID and action == "A" and not completion then
-                    WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: Accept")
-                    WoWPro.newQuest = nil -- We got it, dont let the recorder get it!
+                    if action == "C" and WoWPro.lootitem and WoWPro.lootitem[i] and not WoWPro.LootItemsCollected(WoWPro.lootitem[i]) then
+                        WoWPro:dbp("AutoCompleteQuestUpdate: skipping auto-complete for loot-backed C step %d", i)
+                        break
+                    elseif WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
+                        break
+                    else
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
+                    end
                 end
 
                 -- Quest Completion via QuestLog--
                 if WoWPro.QuestLog[QID] and action == "C" and not completion and WoWPro.QuestLog[QID].complete then
-					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
-					break
-					else
-						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog")
-						WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}
-						WoWPro.oldQuests[QID].complete = true -- We got it, dont let the recorder get it!
-					end
+                    if action == "C" and WoWPro.lootitem and WoWPro.lootitem[i] and not WoWPro.LootItemsCollected(WoWPro.lootitem[i]) then
+                        WoWPro:dbp("AutoCompleteQuestUpdate: skipping QuestLog completion for loot-backed C step %d", i)
+                        break
+                    elseif WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
+                        break
+                    else
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog")
+                        WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}
+                        WoWPro.oldQuests[QID].complete = true -- We got it, dont let the recorder get it!
+                    end
                 end
 
                 -- Partial Completion --

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -335,7 +335,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                 -- Quest AutoComplete --
                 if questComplete and (action == "A" or action == "C" or action == "T" or action == "N") and QID == questComplete then
 					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
-						return
+					break
 					else
 						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
 					end
@@ -349,7 +349,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                 -- Quest Completion via QuestLog--
                 if WoWPro.QuestLog[QID] and action == "C" and not completion and WoWPro.QuestLog[QID].complete then
 					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
-						return
+					break
 					else
 						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog")
 						WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -450,6 +450,8 @@ function WoWPro.AutoCompleteZone(_event)
     local action = WoWPro.action[currentindex] or "?"
     local step = WoWPro.step[currentindex] or "?"
     local targetzone = WoWPro.targetzone[currentindex] or "!"
+    local zoneTag = select(1, (";"):split(targetzone)) or targetzone
+    zoneTag = zoneTag:trim()
     local zonetext, subzonetext = _G.GetZoneText(), _G.GetSubZoneText():trim()
     WoWPro:dbp("AutoCompleteZone: [%s] or [%s] .vs. %s [%s]/[%s]", zonetext, subzonetext, action, step, targetzone)
     if action == "F" or action == "H" or action == "b" or action == "P" or action == "R" then
@@ -458,12 +460,12 @@ function WoWPro.AutoCompleteZone(_event)
                 WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..step)
                 return true
             end
-            if (targetzone == zonetext) or (targetzone == subzonetext) then
+            if (zoneTag == zonetext) or (zoneTag == subzonetext) then
                 WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone)
                 return true
             end
             local _, _, mapId = WoWPro:GetPlayerZonePosition()
-            if (tonumber(targetzone) and tonumber(targetzone) == mapId) then
+            if (tonumber(zoneTag) and tonumber(zoneTag) == mapId) then
                 WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone)
                 return true
             end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2337,6 +2337,14 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             local step = WoWPro.step[guideIndex]
             local stepAction = WoWPro.action[guideIndex]
 
+            if guide.completion[guideIndex]
+               and stepAction == "C"
+               and WoWPro.lootitem and WoWPro.lootitem[guideIndex]
+               and not WoWPro.LootItemsCollected(WoWPro.lootitem[guideIndex]) then
+                guide.completion[guideIndex] = false
+                WoWPro.why[guideIndex] = "NextStep(): Cleared completion for loot-backed C step because required loot is no longer present."
+            end
+
             -- Uncomplete repeatable A steps if quest no longer in log (L tag controls visibility) --
             if guide.completion[guideIndex] and WoWPro.repeatable and WoWPro.repeatable[guideIndex]
                and stepAction == "A" and QID then
@@ -3975,8 +3983,9 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         end
                     end
                 end
+                local allLootComplete = allPositiveComplete and (not hasNegative or allNegativeComplete)
                  -- For steps with L tags, auto-complete when all items are collected
-                if allPositiveComplete then
+                if allLootComplete then
                     if stepAction == "l" then
                         -- Auto-complete loot steps (both optional and non-optional)
                         if rowIndex == 1 then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -3981,30 +3981,6 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                             end
                         end
                         skip = true
-                        break
-                    else
-                        -- Show the step now that all items are collected
-                        WoWPro.why[guideIndex] = "NextStep(): Optional loot step shown - all items collected."
-                        skip = false
-                    end
-                end
-                if allPositiveComplete then
-                    if stepAction == "l" then
-                        -- Auto-complete loot steps (both optional and non-optional)
-                        if rowIndex == 1 then
-                            if WoWPro.optional and WoWPro.optional[guideIndex] then
-                                WoWPro.CompleteStep(guideIndex, "NextStep(): Optional loot step completed - all items collected.")
-                            else
-                                WoWPro.CompleteStep(guideIndex, "NextStep(): Loot step completed - all items collected.")
-                            end
-                        else
-                            if WoWPro.optional and WoWPro.optional[guideIndex] then
-                                WoWPro.why[guideIndex] = "NextStep(): Optional loot step ready to complete - all items collected."
-                            else
-                                WoWPro.why[guideIndex] = "NextStep(): Loot step ready to complete - all items collected."
-                            end
-                        end
-                        skip = true
                     elseif WoWPro.optional and WoWPro.optional[guideIndex] then
                         -- For optional steps with L tags (for U+L prerequisite scenarios)
                         if stepAction == "T" then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -348,9 +348,13 @@ function WoWPro.ObjectiveOperators.QuestDone(qid, objective)
     return done , status
 end
 
+-- Objective comparator semantics:
+-- Q< / S< should mean "objective count is less than or equal to target".
+-- Q> / S> should mean "objective count is greater than or equal to target".
+-- These literal operator meanings are now aligned with the function names.
 function WoWPro.ObjectiveOperators.QuestLess(qid, objective, target)
     local done = WoWPro.QuestLog[qid].ncompleted and WoWPro.QuestLog[qid].ncompleted[objective]
-    done = done and WoWPro.QuestLog[qid].ncompleted[objective] >= target
+    done = done and WoWPro.QuestLog[qid].ncompleted[objective] <= target
     local status = (WoWPro.QuestLog[qid].leaderBoard and WoWPro.QuestLog[qid].leaderBoard[objective]) or "?"
     return done , status
 end
@@ -364,7 +368,7 @@ end
 
 function WoWPro.ObjectiveOperators.QuestGreater(qid, objective, target)
     local done = WoWPro.QuestLog[qid].ncompleted and WoWPro.QuestLog[qid].ncompleted[objective]
-    done = done and WoWPro.QuestLog[qid].ncompleted[objective] <= target
+    done = done and WoWPro.QuestLog[qid].ncompleted[objective] >= target
     local status = (WoWPro.QuestLog[qid].leaderBoard and WoWPro.QuestLog[qid].leaderBoard[objective]) or "?"
     return done , status
 end
@@ -381,7 +385,7 @@ end
 
 function WoWPro.ObjectiveOperators.ScenarioLess(stage, objective, target)
     local done = WoWPro.Scenario.Criteria[objective] and WoWPro.Scenario.Criteria[objective].quantity
-    done = done and WoWPro.Scenario.Criteria[objective].quantity >= target
+    done = done and WoWPro.Scenario.Criteria[objective].quantity <= target
     local status = "?"
     if WoWPro.Scenario.Criteria[objective] then
         status = ("%s: %d/%d"):format(WoWPro.Scenario.Criteria[objective].criteriaString, WoWPro.Scenario.Criteria[objective].quantity, WoWPro.Scenario.Criteria[objective].totalQuantity)
@@ -401,7 +405,7 @@ end
 
 function WoWPro.ObjectiveOperators.ScenarioGreater(qid, objective, target)
     local done = WoWPro.Scenario.Criteria[objective] and WoWPro.Scenario.Criteria[objective].quantity
-    done = done and WoWPro.Scenario.Criteria[objective].quantity <= target
+    done = done and WoWPro.Scenario.Criteria[objective].quantity >= target
     local status = "?"
     if WoWPro.Scenario.Criteria[objective] then
         status = ("%s: %d/%d"):format(WoWPro.Scenario.Criteria[objective].criteriaString, WoWPro.Scenario.Criteria[objective].quantity, WoWPro.Scenario.Criteria[objective].totalQuantity)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1154,7 +1154,7 @@ function WoWPro:RowUpdate(offset)
             if WoWPro.sticky[tempK] then
                 WoWPro:IncrementActiveStickyCount()
             end
-            tempK = WoWPro.NextStep(tempK, 1)
+            tempK = WoWPro.NextStep(tempK, i)
             table.insert(allSteps, tempK)
             tempK = tempK + 1
         end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2758,7 +2758,9 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 
             -- C step implicit completion
             if (stepAction == "C") and WoWPro:QIDsInTableLogical(QID,WoWPro.QuestLog) and (not WoWPro.questtext[guideIndex]) then
-                if QidMapReduce(QID,false,"&","^",function (qid) return WoWPro.QuestLog[qid] and WoWPro.QuestLog[qid].complete end, "C-implicit") then
+                if WoWPro.lootitem and WoWPro.lootitem[guideIndex] and not WoWPro.LootItemsCollected(WoWPro.lootitem[guideIndex]) then
+                    WoWPro:dbp("NextStep(): Skipping implicit C completion for loot-backed step %d; loot not collected.", guideIndex)
+                elseif QidMapReduce(QID,false,"&","^",function (qid) return WoWPro.QuestLog[qid] and WoWPro.QuestLog[qid].complete end, "C-implicit") then
                     WoWPro.CompleteStep(guideIndex,"Implicit criteria met")
                 end
             end


### PR DESCRIPTION
### As reported by Spoony

### Fix
- Removed a duplicate allPositiveComplete branch from WoWPro_Broker.lua
    - The same loot completion logic was being executed twice
    - That could cause duplicate state changes, duplicate CompleteStep calls, and confusing behavior
- Fixed wrong comparator logic for quest and scenario objective operators
    - QuestLess now means “objective count is less than or equal to target”
    - QuestGreater now means “objective count is greater than or equal to target”
    - ScenarioLess now means “scenario quantity is less than or equal to target”
    - ScenarioGreater now means “scenario quantity is greater than or equal to target”
- Added a comment documenting the corrected operator meaning

### The Issue
- The duplicate branch made loot completion logic run twice for the same condition
- The comparator functions were backwards compared to Q<, Q>, S<, and S>
- That mismatch made guide conditions harder to understand and could produce incorrect step behavior
