### PR TITLE
Feature/broker onupdate memory opt

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -566,7 +566,7 @@ function WoWPro:OnEnable()
     WoWPro:RegisterBucketMessage("WoWPro_LoadGuide",0.25,WoWPro.LoadGuideReal)
     WoWPro:RegisterBucketMessage("WoWPro_LoadGuideSteps",0.25,WoWPro.LoadGuideStepsReal)
     WoWPro:RegisterBucketMessage("WoWPro_GuideSetup",0.25,WoWPro.SetupGuideReal)
-    WoWPro:RegisterBucketMessage("WoWPro_UpdateGuide",0.500,WoWPro.UpdateGuideReal)
+    WoWPro:RegisterBucketMessage("WoWPro_UpdateGuide",0.100,WoWPro.UpdateGuideReal)
     WoWPro:RegisterBucketMessage("WoWPro_UpdateGuideSlow",0.666,WoWPro.UpdateGuideRealSlow)
     WoWPro:RegisterBucketMessage("WoWPro_GuideSelect",0.333,WoWPro.SelectGuideReal)
     if WoWPro.Recorder then

--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -558,7 +558,7 @@ function WoWPro:OnEnable()
     WoWPro:RegisterBucketEvent({"CHAT_MSG_LOOT", "BAG_UPDATE"}, 0.333, WoWPro.AutoCompleteLoot)
     if WoWPro.RETAIL then
         WoWPro:RegisterBucketEvent({"QUEST_LOG_CRITERIA_UPDATE"}, 0.250, WoWPro.AutoCompleteCriteria)
-        WoWPro:RegisterBucketEvent({"CRITERIA_UPDATE"}, 0.50, WoWPro.UpdateGuideReal)
+        WoWPro:RegisterBucketEvent({"CRITERIA_UPDATE"}, 0.50, WoWPro.UpdateGuide)
     end
     WoWPro:RegisterBucketEvent({"LOOT_CLOSED"}, 0.250, WoWPro.AutoCompleteChest)
     WoWPro:RegisterBucketEvent({"TRADE_SKILL_SHOW", "TRADE_SKILL_LIST_UPDATE"}, 0.250, WoWPro.ScanTrade)

--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -558,14 +558,15 @@ function WoWPro:OnEnable()
     WoWPro:RegisterBucketEvent({"CHAT_MSG_LOOT", "BAG_UPDATE"}, 0.333, WoWPro.AutoCompleteLoot)
     if WoWPro.RETAIL then
         WoWPro:RegisterBucketEvent({"QUEST_LOG_CRITERIA_UPDATE"}, 0.250, WoWPro.AutoCompleteCriteria)
-        WoWPro:RegisterBucketEvent({"CRITERIA_UPDATE"}, 0.50, WoWPro.UpdateGuide)
+        -- CRITERIA_UPDATE can fire frequently while walking; remove it to avoid non-combat stutter.
+        -- WoWPro:RegisterBucketEvent({"CRITERIA_UPDATE"}, 0.50, WoWPro.UpdateGuide)
     end
     WoWPro:RegisterBucketEvent({"LOOT_CLOSED"}, 0.250, WoWPro.AutoCompleteChest)
     WoWPro:RegisterBucketEvent({"TRADE_SKILL_SHOW", "TRADE_SKILL_LIST_UPDATE"}, 0.250, WoWPro.ScanTrade)
     WoWPro:RegisterBucketMessage("WoWPro_LoadGuide",0.25,WoWPro.LoadGuideReal)
     WoWPro:RegisterBucketMessage("WoWPro_LoadGuideSteps",0.25,WoWPro.LoadGuideStepsReal)
     WoWPro:RegisterBucketMessage("WoWPro_GuideSetup",0.25,WoWPro.SetupGuideReal)
-    WoWPro:RegisterBucketMessage("WoWPro_UpdateGuide",0.333,WoWPro.UpdateGuideReal)
+    WoWPro:RegisterBucketMessage("WoWPro_UpdateGuide",0.500,WoWPro.UpdateGuideReal)
     WoWPro:RegisterBucketMessage("WoWPro_UpdateGuideSlow",0.666,WoWPro.UpdateGuideRealSlow)
     WoWPro:RegisterBucketMessage("WoWPro_GuideSelect",0.333,WoWPro.SelectGuideReal)
     if WoWPro.Recorder then

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -253,7 +253,7 @@ function WoWPro.AutoCompleteLoot()
             end
         end
     end
-    WoWPro:UpdateGuide("WoWPro.AutoCompleteLoot")
+    WoWPro:ScheduleGuideRefresh("WoWPro.AutoCompleteLoot")
 end
 
 local LUNARFALL_MAPID
@@ -329,7 +329,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                 if not WoWPro.CompletingQuest and ( action == "A" or action == "C" )
                 and completion and WoWPro.missingQuest == QID then
                     WoWProCharDB.Guide[GID].completion[i] = nil
-                    WoWPro:UpdateGuide("ACQU: Abandoned Quest")
+                    WoWPro:ScheduleGuideRefresh("ACQU: Abandoned Quest")
                 end
 
                 -- Quest AutoComplete --
@@ -456,7 +456,7 @@ function WoWPro.AutoCompleteCriteria()
     if WoWPro.QID[qidx] and WoWPro:IsQuestFlaggedCompleted(WoWPro.QID[qidx],true) then
         WoWPro.CompleteStep(qidx,"AutoCompleteCriteria-Quest")
     else
-        WoWPro:UpdateGuide("WoWPro.AutoCompleteCriteria?")
+        WoWPro:ScheduleGuideRefresh("WoWPro.AutoCompleteCriteria?")
     end
 end
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -941,7 +941,6 @@ end
 
 
 function WoWPro:UpdateGuide(From)
-    WoWPro:print("Signaled for UpdateGuide from %s", WoWPro.Ptable(From))
     if WoWPro.MaybeCombatLockdown() then
         WoWPro.PendingGuideUpdate = true
         WoWPro:dbp("UpdateGuide deferred until out of combat")
@@ -951,7 +950,6 @@ function WoWPro:UpdateGuide(From)
 end
 
 function WoWPro:UpdateGuideSlow(From)
-    WoWPro:print("Signaled for UpdateGuideSlow from %s", WoWPro.Ptable(From))
     WoWPro:SendMessage("WoWPro_UpdateGuideSlow",From)
 end
 
@@ -1343,18 +1341,52 @@ function WoWPro:RowUpdate(offset)
     -- Pre-build the visible steps so we can sort stickies to the top without reparenting rows
     -- StickyFrame reparenting is avoided because CheckButton rows are protected in combat.
     -- StickyTitleBar now keys off ActiveStickyCount, which is computed from the sorted rows.
-    local allSteps = {}
+    local allSteps = WoWPro.RowUpdateAllSteps
+    if not allSteps then
+        allSteps = {}
+        WoWPro.RowUpdateAllSteps = allSteps
+    else
+        table.wipe(allSteps)
+    end
+    local stickySteps = WoWPro.RowUpdateStickySteps
+    if not stickySteps then
+        stickySteps = {}
+        WoWPro.RowUpdateStickySteps = stickySteps
+    else
+        table.wipe(stickySteps)
+    end
+    local regularSteps = WoWPro.RowUpdateRegularSteps
+    if not regularSteps then
+        regularSteps = {}
+        WoWPro.RowUpdateRegularSteps = regularSteps
+    else
+        table.wipe(regularSteps)
+    end
+    local stepList = WoWPro.RowUpdateStepList
+    if not stepList then
+        stepList = {}
+        WoWPro.RowUpdateStepList = stepList
+    else
+        table.wipe(stepList)
+    end
+    local allStepsCount = 0
+    local stickyCount = 0
+    local regularCount = 0
+    local stepListCount = 0
+
     local tempK = k
     for i = 1, 15 do
         if WoWProDB.profile.guidescroll then
-            table.insert(allSteps, tempK)
+            allStepsCount = allStepsCount + 1
+            allSteps[allStepsCount] = tempK
             tempK = tempK + 1
         else
             if WoWPro.sticky[tempK] then
                 WoWPro:IncrementActiveStickyCount()
             end
             tempK = WoWPro.NextStep(tempK, 1)
-            table.insert(allSteps, tempK)
+            allStepsCount = allStepsCount + 1
+            allSteps[allStepsCount] = tempK
             tempK = tempK + 1
         end
     end
@@ -1363,9 +1395,8 @@ function WoWPro:RowUpdate(offset)
     -- Now sort: stickies first, then regular
     local completion = WoWProCharDB.Guide[GID].completion
     local stickyBoundary = WoWPro.ActiveStep or k
-    local stickySteps = {}
-    local regularSteps = {}
-    for _, stepIdx in ipairs(allSteps) do
+    for i = 1, allStepsCount do
+        local stepIdx = allSteps[i]
         if stepIdx then
             if WoWPro.sticky[stepIdx] then
                 -- Show sticky step if it's ready to be displayed (regardless of completion status)
@@ -1432,10 +1463,12 @@ function WoWPro:RowUpdate(offset)
                 end
 
                 if showSticky then
-                    table.insert(stickySteps, stepIdx)
+                    stickyCount = stickyCount + 1
+                    stickySteps[stickyCount] = stepIdx
                 end
             else
-                table.insert(regularSteps, stepIdx)
+                regularCount = regularCount + 1
+                regularSteps[regularCount] = stepIdx
             end
         end
     end
@@ -1444,11 +1477,12 @@ function WoWPro:RowUpdate(offset)
     -- US step visibility: US steps are only eligible to be shown after their corresponding S step is completed.
     -- This means US steps are not added to the visible stepList until their S step is complete, regardless of US conditionals.
     -- When a US step becomes the activestep, it completes its S step immediately (see NextStep logic).
-    local stepList = {}
-    for _, v in ipairs(stickySteps) do
-        table.insert(stepList, v)
+    for i = 1, stickyCount do
+        stepListCount = stepListCount + 1
+        stepList[stepListCount] = stickySteps[i]
     end
-    for _, v in ipairs(regularSteps) do
+    for i = 1, regularCount do
+        local v = regularSteps[i]
         -- If this is a US step (unsticky and not sticky)
         if WoWPro.unsticky[v] and not WoWPro.sticky[v] then
             -- Find the corresponding S step by QID, questtext (QO), and lootitem (L tag) if present
@@ -1482,16 +1516,18 @@ function WoWPro:RowUpdate(offset)
             end
             -- Only show US step if its S step is completed (or no S step exists)
             if not foundSticky or completion[foundSticky] then
-                table.insert(stepList, v)
+                stepListCount = stepListCount + 1
+                stepList[stepListCount] = v
             end
         else
-            table.insert(stepList, v)
+            stepListCount = stepListCount + 1
+            stepList[stepListCount] = v
         end
     end
-    WoWPro.RowLimit = #stepList
+    WoWPro.RowLimit = stepListCount
 
     -- Set ActiveStickyCount based on actual visible stickies
-    WoWPro:SetActiveStickyCount(#stickySteps)
+    WoWPro:SetActiveStickyCount(stickyCount)
     for i = 1, 15 do
         -- WoWPro:dbp("WoWPro:RowUpdate(i=%d)", i)
         -- Use sorted step list with stickies first --
@@ -2449,7 +2485,6 @@ function WoWPro.UpdateGuideReal(From)
         WoWPro.EventReplayStart()
     end
 end
-
 
 local Rep2IdAndClass
 Rep2IdAndClass = {

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1994,6 +1994,8 @@ if step then
                     currentRow.eabuttonSecured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
                     currentRow.eabuttonSecured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)
                 end
+
+                WoWPro:RegisterBrokerUpdateRow(currentRow)
             end
 
             if not eakb and currentRow.eabutton:IsVisible() and not _G.InCombatLockdown() then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1411,6 +1411,7 @@ function WoWPro:RowUpdate(offset)
         if not k then
             for j = i, 15 do
                 WoWPro.rows[j]:Hide()
+                WoWPro:UnregisterBrokerUpdateRow(WoWPro.rows[j])
                 if not _G.InCombatLockdown() then
                     if WoWPro.rows[j].itembutton then WoWPro.rows[j].itembutton:Hide() end
                     if WoWPro.rows[j].targetbutton then WoWPro.rows[j].targetbutton:Hide() end
@@ -1425,6 +1426,7 @@ function WoWPro:RowUpdate(offset)
             WoWPro.RowLimit = math.min(WoWPro.RowLimit or 15, i - 1)
             for j = i, 15 do
                 WoWPro.rows[j]:Hide()
+                WoWPro:UnregisterBrokerUpdateRow(WoWPro.rows[j])
                 if not _G.InCombatLockdown() then
                     if WoWPro.rows[j].itembutton then WoWPro.rows[j].itembutton:Hide() end
                     if WoWPro.rows[j].targetbutton then WoWPro.rows[j].targetbutton:Hide() end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1726,6 +1726,9 @@ if step then
                     if not _G.InCombatLockdown() then
                         currentRow.itembutton:Hide()
                     end
+                    if not currentRow.eabutton:IsShown() then
+                        WoWPro:UnregisterBrokerUpdateRow(currentRow)
+                    end
                 else
                     currentRow.itemicon.item_IsVisible = nil
                     currentRow.itemcooldown.OnCooldown = nil
@@ -1773,6 +1776,7 @@ if step then
                                 end
                             end
                         end)
+                        WoWPro:RegisterBrokerUpdateRow(currentRow)
                     end
                 end
 
@@ -1828,6 +1832,9 @@ if step then
             if not _G.InCombatLockdown() then
                 currentRow.itembutton:Hide()
                 currentRow.itembuttonSecured:Hide()
+            end
+            if not currentRow.eabutton:IsShown() then
+                WoWPro:UnregisterBrokerUpdateRow(currentRow)
             end
         end
 
@@ -1948,6 +1955,7 @@ if step then
                         end
                     end
                 end)
+                WoWPro:RegisterBrokerUpdateRow(currentRow)
 
 				if currentRow.eabutton:IsShown() then
 					currentRow.eabuttonSecured:Show()
@@ -1971,6 +1979,9 @@ if step then
         else
             if not _G.InCombatLockdown() then
                 currentRow.eabutton:Hide()
+            end
+            if not currentRow.itembutton:IsShown() then
+                WoWPro:UnregisterBrokerUpdateRow(currentRow)
             end
 			if not _G.InCombatLockdown() then
 				currentRow.eabuttonSecured:Hide()

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -70,6 +70,36 @@ function WoWPro:UnregisterBrokerUpdateRow(row)
     BrokerUpdateRowLookup[row] = nil
 end
 
+local function ApplyBrokerRowPendingSecureState(row)
+    if not row or _G.InCombatLockdown() then
+        return
+    end
+    local secureTarget = row.targetbuttonSecured
+    if secureTarget and secureTarget._pendingMacro then
+        secureTarget:Show()
+        secureTarget:SetAttribute("macrotext", secureTarget._pendingMacro)
+        secureTarget:ClearAllPoints()
+        if secureTarget._pendingPosition then
+            secureTarget:SetPoint(unpack(secureTarget._pendingPosition))
+        end
+        secureTarget:SetFrameStrata("HIGH")
+        if row.targetbutton then
+            secureTarget:SetFrameLevel(row.targetbutton:GetFrameLevel() + 1)
+        end
+        secureTarget._pendingMacro = nil
+        secureTarget._pendingPosition = nil
+    end
+end
+
+function WoWPro:ApplyBrokerPendingRowState()
+    if _G.InCombatLockdown() then
+        return
+    end
+    for _, row in ipairs(WoWPro.rows) do
+        ApplyBrokerRowPendingSecureState(row)
+    end
+end
+
 local function BrokerUpdateItemRow(currentRow)
     if not currentRow or not currentRow.itembutton or not currentRow.itembutton:IsShown() then
         return
@@ -2137,6 +2167,7 @@ function WoWPro.UpdateGuideReal(From)
         -- Cinematic hides things ...
         WoWPro:SendMessage("WoWPro_UpdateGuide","UpdateGuideReal()")
         WoWPro:dbp("UpdateGuideReal(): Punting")
+        return
     end
     if not WoWPro.GuideLoaded then
         WoWPro:print("Suppresssed guide update. Guide %s is not loaded yet!",tostring(GID))

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -25,6 +25,8 @@ local BrokerUpdateInterval = 0.1
 local BrokerUpdateRows = {}
 local BrokerUpdateRowLookup = {}
 WoWPro.PendingGuideUpdate = false
+WoWPro.PendingGuideRefresh = false
+WoWPro.PendingGuideRefreshReason = nil
 
 -- Debug toggles
 WoWPro.DEBUG_STICKY_PAIRING = false -- Set to true to enable sticky pairing debug output
@@ -939,6 +941,23 @@ function WoWPro:NextGuide(GID)
 
 end
 
+
+function WoWPro:ScheduleGuideRefresh(From)
+    if WoWPro.PendingGuideRefresh then
+        if not WoWPro.PendingGuideRefreshReason and From then
+            WoWPro.PendingGuideRefreshReason = From
+        end
+        return
+    end
+    WoWPro.PendingGuideRefresh = true
+    WoWPro.PendingGuideRefreshReason = From
+    _G.C_Timer.After(0.01, function()
+        WoWPro.PendingGuideRefresh = false
+        local reason = WoWPro.PendingGuideRefreshReason
+        WoWPro.PendingGuideRefreshReason = nil
+        WoWPro:UpdateGuide(reason or "Scheduled")
+    end)
+end
 
 function WoWPro:UpdateGuide(From)
     if WoWPro.MaybeCombatLockdown() then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -44,6 +44,31 @@ function WoWPro:IncrementActiveStickyCount()
     _activeStickyCount = _activeStickyCount + 1
 end
 
+-- Broker row update registration helpers
+function WoWPro:RegisterBrokerUpdateRow(row)
+    if not row or BrokerUpdateRowLookup[row] then
+        return
+    end
+    local index = #BrokerUpdateRows + 1
+    BrokerUpdateRows[index] = row
+    BrokerUpdateRowLookup[row] = index
+end
+
+function WoWPro:UnregisterBrokerUpdateRow(row)
+    local index = BrokerUpdateRowLookup[row]
+    if not index then
+        return
+    end
+    local lastIndex = #BrokerUpdateRows
+    if index ~= lastIndex then
+        local lastRow = BrokerUpdateRows[lastIndex]
+        BrokerUpdateRows[index] = lastRow
+        BrokerUpdateRowLookup[lastRow] = index
+    end
+    BrokerUpdateRows[lastIndex] = nil
+    BrokerUpdateRowLookup[row] = nil
+end
+
 
 -- Deep table comparison for lootitem matching
 local function deepTableEqual(t1, t2)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -18,6 +18,13 @@ WoWPro.mygroupsteps = {}
 WoWPro.myGroupTrack = {}
 WoWPro.playerGroup = {}
 
+-- Shared Broker update wiring
+local BrokerUpdateFrame = _G.CreateFrame("Frame")
+local BrokerUpdateElapsed = 0
+local BrokerUpdateInterval = 0.1
+local BrokerUpdateRows = {}
+local BrokerUpdateRowLookup = {}
+
 -- Debug toggles
 WoWPro.DEBUG_STICKY_PAIRING = false -- Set to true to enable sticky pairing debug output
 WoWPro.DEBUG_REPEATABLE = false -- Set to true to enable debug output for repeatable A step resets and quest log changes

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1832,43 +1832,6 @@ if step then
                         currentRow.itemicon.currentTexture = nil
                         currentRow.itembutton:SetAttribute("type1", "item")
                         currentRow.itembutton:SetAttribute("item1", "item:".._use)
-                        local timeElapsed = 0
-                        currentRow.itembutton:SetScript("OnUpdate", function(_,elapsed)
-                            timeElapsed = timeElapsed + elapsed
-                            if timeElapsed > 0.05 then
-                                timeElapsed = 0
-                                local itemtexture = WoWPro.C_Item_GetItemIconByID(_use)
-                                local start, duration, enabled = _G.WoWPro.GetItemCooldown(_use)
-                                if not start then
-                                    WoWPro:dbp("RowUpdate(): U¦%s/%s¦ has bad GetItemCooldown()", use, _use)
-                                end
-                                if _G.WoWPro.C_Item_GetItemCount(_use) > 0 and not currentRow.itemicon.item_IsVisible then
-                                    currentRow.itemicon.item_IsVisible = true
-                                    currentRow.itemicon:SetTexture(itemtexture)
-                                    currentRow.itemicon.currentTexture = itemtexture
-                                elseif itemtexture ~= currentRow.itemicon.currentTexture and _G.WoWPro.C_Item_GetItemCount(_use) > 0 and currentRow.itemicon.item_IsVisible then
-                                    currentRow.itemicon:SetTexture(itemtexture)
-                                    currentRow.itemicon.currentTexture = itemtexture
-                                elseif _G.WoWPro.C_Item_GetItemCount(_use) == 0 and  currentRow.itemicon.item_IsVisible then
-                                    currentRow.itemicon.item_IsVisible = false
-                                    currentRow.itemicon:SetTexture()
-                                    currentRow.itemicon.currentTexture = nil
-                                end
-                                if enabled and duration > 0 and not currentRow.itemcooldown.OnCooldown then
-                                    currentRow.itemcooldown:Show()
-                                    currentRow.itemcooldown:SetCooldown(start, duration)
-                                    currentRow.itemcooldown.OnCooldown = true
-                                    currentRow.itemcooldown.ActiveItem = _use
-                                elseif currentRow.itemcooldown.OnCooldown and duration == 0 then
-                                    currentRow.itemcooldown:Hide()
-                                    currentRow.itemcooldown.OnCooldown = false
-                                elseif currentRow.itemcooldown.ActiveItem ~= _use and start then
-                                    currentRow.itemcooldown.OnCooldown = false
-                                    currentRow.itemcooldown:SetCooldown(start, duration)
-                                    currentRow.itemcooldown.ActiveItem = _use
-                                end
-                            end
-                        end)
                         WoWPro:RegisterBrokerUpdateRow(currentRow)
                     end
                 end
@@ -2021,39 +1984,7 @@ if step then
                 currentRow.eabutton:SetAttribute("macrotext", mtext)
                 currentRow.eaicon.EAB1_IsVisible = nil
                 currentRow.eaicon.currentTexture = nil
-                local timeElapsed = 0
-                currentRow.eabutton:SetScript("OnUpdate", function(_, elapsed)
-                    -- Throttle to a max of 50ms updates
-                    timeElapsed = timeElapsed + elapsed
-                    if timeElapsed > 0.05 then
-                        timeElapsed = 0
-                        local eabIcon = nil
-                        if _G.ExtraActionButton1 and _G.ExtraActionButton1.icon then
-                            eabIcon = _G.ExtraActionButton1.icon
-                        elseif _G.ExtraActionButton1Icon then
-                            eabIcon = _G.ExtraActionButton1Icon
-                        end
-                        local eabtexture = eabIcon and eabIcon:GetTexture() or nil
-                        if _G.HasExtraActionBar() ~= currentRow.eaicon.EAB1_IsVisible then
-                            currentRow.eaicon.EAB1_IsVisible =  _G.HasExtraActionBar()
-                            if currentRow.eaicon.EAB1_IsVisible then
-                                currentRow.eaicon:SetTexture(eabtexture)
-                                currentRow.eaicon.currentTexture = eabtexture
-                            else
-                                currentRow.eaicon:SetTexture()
-                                currentRow.eaicon.currentTexture = nil
-                            end
-                        elseif eabtexture ~= currentRow.eaicon.currentTexture and _G.HasExtraActionBar() and currentRow.eaicon.EAB1_IsVisible then
-                            currentRow.eaicon.currentTexture = eabtexture
-                            currentRow.eaicon:SetTexture(eabtexture)
-                        end
-                    end
-                end)
-                WoWPro:RegisterBrokerUpdateRow(currentRow)
 
-				if currentRow.eabutton:IsShown() then
-					currentRow.eabuttonSecured:Show()
-					currentRow.eabuttonSecured:SetAttribute("macrotext", mtext)
 					currentRow.eabuttonSecured:ClearAllPoints()
 					currentRow.eabuttonSecured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
 					currentRow.eabuttonSecured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -968,6 +968,17 @@ function WoWPro:UpdateGuide(From)
     WoWPro:SendMessage("WoWPro_UpdateGuide",From)
 end
 
+function WoWPro:UpdateGuideImmediate(From)
+    if WoWPro.MaybeCombatLockdown() then
+        WoWPro.PendingGuideUpdate = true
+        WoWPro:dbp("UpdateGuideImmediate deferred until out of combat")
+        return
+    end
+    local fromTable = type(From) == "table" and From or { [tostring(From or "UpdateGuideImmediate")] = 1 }
+    WoWPro:dbp("UpdateGuideImmediate(%s)", tostring(From))
+    WoWPro.UpdateGuideReal(fromTable)
+end
+
 function WoWPro:UpdateGuideSlow(From)
     WoWPro:SendMessage("WoWPro_UpdateGuideSlow",From)
 end
@@ -4480,7 +4491,7 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     end
     WoWPro.why[step] = why
     if not noUpdate then
-        WoWPro:UpdateGuide("WoWPro.CompleteStep")
+        WoWPro:UpdateGuideImmediate("WoWPro.CompleteStep")
     end
 end
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1985,11 +1985,14 @@ if step then
                 currentRow.eaicon.EAB1_IsVisible = nil
                 currentRow.eaicon.currentTexture = nil
 
-					currentRow.eabuttonSecured:ClearAllPoints()
-					currentRow.eabuttonSecured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
-					currentRow.eabuttonSecured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)
-				end
-			end
+                if currentRow.eabutton:IsShown() then
+                    currentRow.eabuttonSecured:Show()
+                    currentRow.eabuttonSecured:SetAttribute("macrotext", mtext)
+                    currentRow.eabuttonSecured:ClearAllPoints()
+                    currentRow.eabuttonSecured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
+                    currentRow.eabuttonSecured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)
+                end
+            end
 
             if not eakb and currentRow.eabutton:IsVisible() and not _G.InCombatLockdown() then
                 local key1, key2 = _G.GetBindingKey("CLICK WoWPro_FauxEAButton:LeftButton")

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -69,6 +69,97 @@ function WoWPro:UnregisterBrokerUpdateRow(row)
     BrokerUpdateRowLookup[row] = nil
 end
 
+local function BrokerUpdateItemRow(currentRow)
+    if not currentRow or not currentRow.itembutton or not currentRow.itembutton:IsShown() then
+        return
+    end
+    local use = currentRow.BrokerUpdateUse
+    if not use then
+        return
+    end
+
+    local itemtexture = WoWPro.C_Item_GetItemIconByID(use)
+    local start, duration, enabled = _G.WoWPro.GetItemCooldown(use)
+    if not start then
+        return
+    end
+
+    if _G.WoWPro.C_Item_GetItemCount(use) > 0 and not currentRow.itemicon.item_IsVisible then
+        currentRow.itemicon.item_IsVisible = true
+        currentRow.itemicon:SetTexture(itemtexture)
+        currentRow.itemicon.currentTexture = itemtexture
+    elseif itemtexture ~= currentRow.itemicon.currentTexture and _G.WoWPro.C_Item_GetItemCount(use) > 0 and currentRow.itemicon.item_IsVisible then
+        currentRow.itemicon:SetTexture(itemtexture)
+        currentRow.itemicon.currentTexture = itemtexture
+    elseif _G.WoWPro.C_Item_GetItemCount(use) == 0 and currentRow.itemicon.item_IsVisible then
+        currentRow.itemicon.item_IsVisible = false
+        currentRow.itemicon:SetTexture()
+        currentRow.itemicon.currentTexture = nil
+    end
+
+    if enabled and duration > 0 and not currentRow.itemcooldown.OnCooldown then
+        currentRow.itemcooldown:Show()
+        currentRow.itemcooldown:SetCooldown(start, duration)
+        currentRow.itemcooldown.OnCooldown = true
+        currentRow.itemcooldown.ActiveItem = use
+    elseif currentRow.itemcooldown.OnCooldown and duration == 0 then
+        currentRow.itemcooldown:Hide()
+        currentRow.itemcooldown.OnCooldown = false
+    elseif currentRow.itemcooldown.ActiveItem ~= use and start then
+        currentRow.itemcooldown.OnCooldown = false
+        currentRow.itemcooldown:SetCooldown(start, duration)
+        currentRow.itemcooldown.ActiveItem = use
+    end
+end
+
+local function BrokerUpdateEABRow(currentRow)
+    if not currentRow or not currentRow.eabutton or not currentRow.eabutton:IsShown() then
+        return
+    end
+
+    local eabIcon = nil
+    if _G.ExtraActionButton1 and _G.ExtraActionButton1.icon then
+        eabIcon = _G.ExtraActionButton1.icon
+    elseif _G.ExtraActionButton1Icon then
+        eabIcon = _G.ExtraActionButton1Icon
+    end
+    local eabtexture = eabIcon and eabIcon:GetTexture() or nil
+
+    if _G.HasExtraActionBar() ~= currentRow.eaicon.EAB1_IsVisible then
+        currentRow.eaicon.EAB1_IsVisible = _G.HasExtraActionBar()
+        if currentRow.eaicon.EAB1_IsVisible then
+            currentRow.eaicon:SetTexture(eabtexture)
+            currentRow.eaicon.currentTexture = eabtexture
+        else
+            currentRow.eaicon:SetTexture()
+            currentRow.eaicon.currentTexture = nil
+        end
+    elseif eabtexture ~= currentRow.eaicon.currentTexture and _G.HasExtraActionBar() and currentRow.eaicon.EAB1_IsVisible then
+        currentRow.eaicon.currentTexture = eabtexture
+        currentRow.eaicon:SetTexture(eabtexture)
+    end
+end
+
+BrokerUpdateFrame:SetScript("OnUpdate", function(_, elapsed)
+    BrokerUpdateElapsed = BrokerUpdateElapsed + elapsed
+    if BrokerUpdateElapsed < BrokerUpdateInterval then
+        return
+    end
+    BrokerUpdateElapsed = 0
+
+    if WoWPro.MaybeCombatLockdown() then
+        return
+    end
+
+    for i = 1, #BrokerUpdateRows do
+        local currentRow = BrokerUpdateRows[i]
+        if currentRow then
+            BrokerUpdateItemRow(currentRow)
+            BrokerUpdateEABRow(currentRow)
+        end
+    end
+end)
+
 
 -- Deep table comparison for lootitem matching
 local function deepTableEqual(t1, t2)
@@ -1723,6 +1814,7 @@ if step then
 
                 if not _use then
                     -- Safety check - this shouldn't happen since we already checked SelectItemToUse above
+                    currentRow.BrokerUpdateUse = nil
                     if not _G.InCombatLockdown() then
                         currentRow.itembutton:Hide()
                     end
@@ -1730,6 +1822,7 @@ if step then
                         WoWPro:UnregisterBrokerUpdateRow(currentRow)
                     end
                 else
+                    currentRow.BrokerUpdateUse = _use
                     currentRow.itemicon.item_IsVisible = nil
                     currentRow.itemcooldown.OnCooldown = nil
                     currentRow.itemcooldown.ActiveItem = nil
@@ -1829,6 +1922,7 @@ if step then
                 end
             end
         else
+            currentRow.BrokerUpdateUse = nil
             if not _G.InCombatLockdown() then
                 currentRow.itembutton:Hide()
                 currentRow.itembuttonSecured:Hide()

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -24,6 +24,7 @@ local BrokerUpdateElapsed = 0
 local BrokerUpdateInterval = 0.1
 local BrokerUpdateRows = {}
 local BrokerUpdateRowLookup = {}
+WoWPro.PendingGuideUpdate = false
 
 -- Debug toggles
 WoWPro.DEBUG_STICKY_PAIRING = false -- Set to true to enable sticky pairing debug output
@@ -859,6 +860,11 @@ end
 
 function WoWPro:UpdateGuide(From)
     WoWPro:print("Signaled for UpdateGuide from %s", WoWPro.Ptable(From))
+    if WoWPro.MaybeCombatLockdown() then
+        WoWPro.PendingGuideUpdate = true
+        WoWPro:dbp("UpdateGuide deferred until out of combat")
+        return
+    end
     WoWPro:SendMessage("WoWPro_UpdateGuide",From)
 end
 
@@ -2151,10 +2157,11 @@ function WoWPro.UpdateGuideReal(From)
         return
     end
     if WoWPro.MaybeCombatLockdown() then
+        WoWPro.PendingGuideUpdate = true
         WoWPro:print("Punted guide update.  In Combat.")
-        WoWPro:SendMessage("WoWPro_UpdateGuide","InCombat")
         return
     end
+    WoWPro.PendingGuideUpdate = false
     if  not GID or not WoWPro.Guides[GID] then
         WoWPro:print("Suppresssed guide update. Guide %s is invalid.",tostring(GID))
         return

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -89,6 +89,58 @@ local function ApplyBrokerRowPendingSecureState(row)
         secureTarget._pendingMacro = nil
         secureTarget._pendingPosition = nil
     end
+
+    local secureItem = row.itembuttonSecured
+    if secureItem and secureItem._pendingType then
+        local itembutton = row.itembutton
+        if itembutton and itembutton:IsVisible() then
+            secureItem:Show()
+            if secureItem._pendingType == "item" then
+                secureItem:SetAttribute("type1", "item")
+                secureItem:SetAttribute("item1", secureItem._pendingItem1)
+            elseif secureItem._pendingType == "click1" then
+                secureItem:SetAttribute("type1", "click1")
+                secureItem:SetAttribute("click", secureItem._pendingClick or "clickbutton")
+                local pendingTrashUse = secureItem._pendingTrashUse
+                local pendingTrashStep = secureItem._pendingTrashStep
+                secureItem:SetScript("OnClick", function()
+                    WoWPro.TrashItem(pendingTrashUse, pendingTrashStep)
+                end)
+            elseif secureItem._pendingType == "SwitchPet" then
+                secureItem:SetAttribute("type", "SwitchPet")
+                secureItem.SwitchPet = function()
+                    _G.C_PetBattles.ChangePet(secureItem._pendingSwitchPet)
+                    WoWPro.CompleteStep(secureItem._pendingStep, "Clicked pet switch")
+                end
+            end
+            secureItem:ClearAllPoints()
+            secureItem:SetPoint("BOTTOMLEFT", itembutton, "BOTTOMLEFT", 0, 0)
+            secureItem:SetFrameLevel(itembutton:GetFrameLevel() + 1)
+            secureItem._pendingType = nil
+            secureItem._pendingItem1 = nil
+            secureItem._pendingClick = nil
+            secureItem._pendingTrashUse = nil
+            secureItem._pendingTrashStep = nil
+            secureItem._pendingSwitchPet = nil
+            secureItem._pendingStep = nil
+        end
+    end
+
+    local secureEA = row.eabuttonSecured
+    if secureEA and secureEA._pendingMacro then
+        local eabutton = row.eabutton
+        if eabutton and eabutton:IsVisible() then
+            secureEA:Show()
+            secureEA:SetAttribute("macrotext", secureEA._pendingMacro)
+            secureEA:ClearAllPoints()
+            if secureEA._pendingPosition then
+                secureEA:SetPoint(unpack(secureEA._pendingPosition))
+            end
+            secureEA:SetFrameLevel(eabutton:GetFrameLevel() + 1)
+            secureEA._pendingMacro = nil
+            secureEA._pendingPosition = nil
+        end
+    end
 end
 
 function WoWPro:ApplyBrokerPendingRowState()
@@ -1820,6 +1872,11 @@ if step then
                         currentRow.itembuttonSecured:SetPoint("BOTTOMLEFT", currentRow.itembutton, "BOTTOMLEFT", 0, 0)
                         currentRow.itembuttonSecured:SetFrameLevel(currentRow.itembutton:GetFrameLevel() + 1)
                     end
+                else
+                    currentRow.itembuttonSecured._pendingType = "click1"
+                    currentRow.itembuttonSecured._pendingClick = "clickbutton"
+                    currentRow.itembuttonSecured._pendingTrashUse = use
+                    currentRow.itembuttonSecured._pendingTrashStep = k
                 end
                 WoWPro:dbp("RowUpdate: enabled trash: %s", use)
                 if not itemkb and currentRow.itembutton:IsVisible() and not _G.InCombatLockdown() then
@@ -1883,6 +1940,9 @@ if step then
                         currentRow.itembuttonSecured:SetPoint("BOTTOMLEFT", currentRow.itembutton, "BOTTOMLEFT", 0, 0)
                         currentRow.itembuttonSecured:SetFrameLevel(currentRow.itembutton:GetFrameLevel() + 1)
                     end
+                else
+                    currentRow.itembuttonSecured._pendingType = "item"
+                    currentRow.itembuttonSecured._pendingItem1 = "item:".._use
                 end
 
                 WoWPro:dbp("RowUpdate: enabled use: %s", use)
@@ -1915,6 +1975,10 @@ if step then
                         currentRow.itembuttonSecured:SetPoint("BOTTOMLEFT", currentRow.itembutton, "BOTTOMLEFT", 0, 0)
                         currentRow.itembuttonSecured:SetFrameLevel(currentRow.itembutton:GetFrameLevel() + 1)
                     end
+                else
+                    currentRow.itembuttonSecured._pendingType = "SwitchPet"
+                    currentRow.itembuttonSecured._pendingSwitchPet = switch
+                    currentRow.itembuttonSecured._pendingStep = kk
                 end
             else
                 if not _G.InCombatLockdown() then
@@ -2032,6 +2096,9 @@ if step then
                 end
 
                 WoWPro:RegisterBrokerUpdateRow(currentRow)
+            else
+                currentRow.eabuttonSecured._pendingMacro = mtext
+                currentRow.eabuttonSecured._pendingPosition = {"BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0}
             end
 
             if not eakb and currentRow.eabutton:IsVisible() and not _G.InCombatLockdown() then

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -400,6 +400,7 @@ end)
 WoWPro.RegisterEventHandler("PLAYER_REGEN_ENABLED", function(event, ...)
     -- Combat lockdown ends before this event fires
     WoWPro.AutoHideFrame("|cff33ff33Combat Enter, AutoHideInCombat|r: " .. event, "COMBAT")
+    WoWPro:ApplyBrokerPendingRowState()
     if WoWPro.PendingGuideUpdate then
         WoWPro.PendingGuideUpdate = false
         WoWPro:dbp("Flush pending guide update after combat")

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -14,7 +14,7 @@ function WoWPro:OnEnableEvents()
     WoWPro.FirstUpdatePending = true
     WoWPro:RegisterEvents(nil)
     WoWPro:RegisterBucketMessage("WoWPro_PuntedQLU", 0.333, WoWPro.PuntedQLU)
-    WoWPro:RegisterBucketMessage("WoWPro_QuestLogUpdate", 0.333, WoWPro.QuestLogUpdateReal)
+    WoWPro:RegisterBucketMessage("WoWPro_QuestLogUpdate", 0.500, WoWPro.QuestLogUpdateReal)
     -- EventFrame is created earlier in WoWPro:OnEnable()
     WoWPro.EventFrame:SetScript("OnEvent",WoWPro.EventHandler)
 end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -400,7 +400,13 @@ end)
 WoWPro.RegisterEventHandler("PLAYER_REGEN_ENABLED", function(event, ...)
     -- Combat lockdown ends before this event fires
     WoWPro.AutoHideFrame("|cff33ff33Combat Enter, AutoHideInCombat|r: " .. event, "COMBAT")
-    WoWPro:UpdateGuide(event)
+    if WoWPro.PendingGuideUpdate then
+        WoWPro.PendingGuideUpdate = false
+        WoWPro:dbp("Flush pending guide update after combat")
+        WoWPro:UpdateGuide({reason = event, pending = true})
+    else
+        WoWPro:UpdateGuide(event)
+    end
 end)
 
 WoWPro.RegisterEventHandler("UPDATE_BINDINGS", WoWPro.PLAYER_REGEN_ENABLED)

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -1,4 +1,4 @@
--- luacheck: globals tostring tonumber string hooksecurefunc
+﻿-- luacheck: globals tostring tonumber string hooksecurefunc
 -- luacheck: globals select foreach ipairs pairs next tinsert type unpack
 
 --------------------------
@@ -14,6 +14,7 @@ function WoWPro:OnEnableEvents()
     WoWPro.FirstUpdatePending = true
     WoWPro:RegisterEvents(nil)
     WoWPro:RegisterBucketMessage("WoWPro_PuntedQLU", 0.333, WoWPro.PuntedQLU)
+    WoWPro:RegisterBucketMessage("WoWPro_QuestLogUpdate", 0.333, WoWPro.QuestLogUpdateReal)
     -- EventFrame is created earlier in WoWPro:OnEnable()
     WoWPro.EventFrame:SetScript("OnEvent",WoWPro.EventHandler)
 end
@@ -224,6 +225,28 @@ end
 
 
 
+
+function WoWPro.QuestLogUpdateReal(From)
+    local event = "QUEST_LOG_UPDATE"
+    local delta = WoWPro.PopulateQuestLog()
+    if WoWPro.DEBUG_REPEATABLE then
+        WoWPro:dbp("QUEST_LOG_UPDATE: delta = %d", delta)
+    end
+
+    if delta == 0 then
+        return
+    end
+    if WoWPro.Ready(event) then
+        WoWPro:AutoCompleteQuestUpdate(nil)
+        WoWPro:UpdateGuide(event)
+        if WoWProCharDB.AutoSelect and delta == 1 then
+            if WoWPro.QuestCount ~= 0 and WoWPro.QuestDialogActive then
+                WoWPro:dbp("ZZZT Faking %s, QuestCount is %d", WoWPro.QuestDialogActive, WoWPro.QuestCount)
+                WoWPro.DelayedEventHandler(WoWPro.EventFrame, WoWPro.QuestDialogActive)
+            end
+        end
+    end
+end
 
 WoWPro.RegisterEventHandler("UNIT_AURA", function(event, ...)
     if not WoWPro.MaybeCombatLockdown() then
@@ -857,29 +880,8 @@ if WoWPro.RETAIL then
 end
 
 WoWPro.RegisterEventHandler("QUEST_LOG_UPDATE", function(event, ...)
-    local delta = WoWPro.PopulateQuestLog()
-    if WoWPro.DEBUG_REPEATABLE then
-        WoWPro:dbp("QUEST_LOG_UPDATE: delta = %d", delta)
-    end
-
-    -- Check repeatable steps after quest log update
-    if WoWPro.CheckRepeatableSteps then
-        WoWPro.CheckRepeatableSteps()
-    end
-
-    if delta == 0 then
-        return
-    end
     if WoWPro.Ready(event) then
-        WoWPro:AutoCompleteQuestUpdate(nil)
-        WoWPro:UpdateGuide(event)
-        if WoWProCharDB.AutoSelect and delta == 1 then
-        -- OK, now get the next quest if QuestCount is set
-            if WoWPro.QuestCount ~= 0 and WoWPro.QuestDialogActive then
-                WoWPro:dbp("ZZZT Faking %s, QuestCount is %d", WoWPro.QuestDialogActive, WoWPro.QuestCount)
-                WoWPro.DelayedEventHandler(WoWPro.EventFrame, WoWPro.QuestDialogActive)
-            end
-        end
+        WoWPro:SendMessage("WoWPro_QuestLogUpdate", event)
     end
 end)
 
@@ -915,6 +917,7 @@ function WoWPro.DelayedEventHandler(frame,event)
         WoWPro.EventHandler(frame,event)
     end)
 end
+
 
 
 

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -238,7 +238,7 @@ function WoWPro.QuestLogUpdateReal(From)
     end
     if WoWPro.Ready(event) then
         WoWPro:AutoCompleteQuestUpdate(nil)
-        WoWPro:UpdateGuide(event)
+        WoWPro:ScheduleGuideRefresh(event)
         if WoWProCharDB.AutoSelect and delta == 1 then
             if WoWPro.QuestCount ~= 0 and WoWPro.QuestDialogActive then
                 WoWPro:dbp("ZZZT Faking %s, QuestCount is %d", WoWPro.QuestDialogActive, WoWPro.QuestCount)
@@ -285,7 +285,7 @@ end, true)
 WoWPro.RegisterEventHandler("VARIABLES_LOADED", function(event) return; end, true)
 
 WoWPro.RegisterEventHandler("SPELLS_CHANGED", function(event)
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
     end)
 
 -- Unlocking event processing after things get settled --
@@ -311,7 +311,7 @@ if not WoWPro.CLASSIC then
     WoWPro.RegisterEventHandler("NEUTRAL_FACTION_SELECT_RESULT", function (event, ...)
         WoWPro:dbp("Detected Faction selection. Re-evaluating guide.")
         WoWPro.Faction = _G.UnitFactionGroup("player")
-        WoWPro:UpdateGuide(event)
+        WoWPro:ScheduleGuideRefresh(event)
     end)
 end
 
@@ -325,7 +325,7 @@ WoWPro.RegisterEventHandler("ZONE_CHANGED", function(event, ...)
     end
     if WoWPro.Ready(event) then
         if WoWPro.AutoCompleteZone(...) then
-            WoWPro:UpdateGuide(event)
+            WoWPro:ScheduleGuideRefresh(event)
         end
     end
 end)
@@ -336,12 +336,12 @@ WoWPro.RegisterEventHandler("ZONE_CHANGED_NEW_AREA", WoWPro.ZONE_CHANGED)
 -- Scenario Tracking
 WoWPro.RegisterModernEventHandler("SCENARIO_UPDATE", function(event, ...)
     WoWPro.ProcessScenarioStage(...)
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
     end)
 
 WoWPro.RegisterModernEventHandler("SCENARIO_CRITERIA_UPDATE", function(event, ...)
     WoWPro.ProcessScenarioCriteria(false)
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
     end)
 
 WoWPro.RegisterModernEventHandler("CRITERIA_COMPLETE",WoWPro.SCENARIO_CRITERIA_UPDATE)
@@ -363,7 +363,7 @@ WoWPro.RegisterModernEventHandler("PET_BATTLE_OPENING_START", function(event, ..
 end)
 
 WoWPro.RegisterModernEventHandler("PET_BATTLE_PET_ROUND_RESULTS", function(event, ...)
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
     end)
 
 WoWPro.RegisterModernEventHandler("PET_BATTLE_PET_CHANGED", function(event,team)
@@ -402,7 +402,7 @@ WoWPro.RegisterModernEventHandler("PET_BATTLE_CLOSE", function(event, ...)
         WoWPro.current_strategy = nil
         WoWPro:dbp("WoWPro.current_strategy = nil")
     end
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
 --  WoWPro.UnregisterAllEvents()
 --  WoWPro:RegisterEvents()
     end)
@@ -416,7 +416,7 @@ WoWPro.RegisterEventHandler("PLAYER_REGEN_DISABLED", function(event, ...)
     WoWPro.AutoHideFrame("|cff33ff33Combat Enter, AutoHideInCombat|r: " .. event, "COMBAT")
     -- Combat lockdown begins after this event
     if not WoWPro.MaybeCombatLockdown() then
-        WoWPro:UpdateGuide(event)
+        WoWPro:ScheduleGuideRefresh(event)
     end
 end)
 
@@ -429,7 +429,7 @@ WoWPro.RegisterEventHandler("PLAYER_REGEN_ENABLED", function(event, ...)
         WoWPro:dbp("Flush pending guide update after combat")
         WoWPro:UpdateGuide({reason = event, pending = true})
     else
-        WoWPro:UpdateGuide(event)
+        WoWPro:ScheduleGuideRefresh(event)
     end
 end)
 
@@ -444,7 +444,7 @@ WoWPro.RegisterEventHandler("GROUP_ROSTER_UPDATE", function(event, ...)
 		WoWPro.GroupSync = false
 	end
 	if successfulRequest then
-		WoWPro:UpdateGuide(event)
+		WoWPro:ScheduleGuideRefresh(event)
 		WoWPro:SendGroupInfo()
 	end
 end)
@@ -460,7 +460,7 @@ if WoWPro.RETAIL then
 		if successfulRequest then
 			if _G.IsInJailersTower() and not _G.C_PlayerChoice.IsWaitingForPlayerChoiceResponse() then
 				WoWPro.AnimaPowers = WoWPro.AnimaPowers + 1
-				WoWPro:UpdateGuide(event)
+				WoWPro:ScheduleGuideRefresh(event)
 			end
 		end
 	end)
@@ -512,7 +512,7 @@ WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 				else
 					_G.C_ChatInfo.SendAddonMessage("WoWPro", "NeedGroup NOW" , "PARTY")
 				end
-				WoWPro:UpdateGuide(event)
+				WoWPro:ScheduleGuideRefresh(event)
 			elseif synctype == "track" and WoWPro.GroupSync then
 				if (WoWPro.playerGroup[sender] ~= nil) then
 					local gindex, gtrack = string.split(" ", message, 2)
@@ -614,7 +614,7 @@ function WoWPro.GOSSIP_SHOW_PUNTED(event, ...)
     end
 
     if WoWPro.gossip and WoWPro.GossipText and WoWPro.gossip[qidx] then
-        WoWPro:UpdateGuide(event)
+        WoWPro:ScheduleGuideRefresh(event)
     end
 end
 
@@ -838,7 +838,7 @@ WoWPro.RegisterEventHandler("TAXIMAP_OPENED", function(event, ...)
             WoWPro:print("TAXIMAP_OPENED: Not trying to travel as AutoSelect is not active.")
         end
     end
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
 end)
 
 WoWPro.RegisterEventHandler("PLAYER_CONTROL_LOST", function(event, ...)
@@ -887,7 +887,7 @@ end)
 
 WoWPro.RegisterEventHandler("UI_INFO_MESSAGE", function(event, ...)
     WoWPro:AutoCompleteGetFP(event, ...)
-    WoWPro:UpdateGuide(event)
+    WoWPro:ScheduleGuideRefresh(event)
 end)
 
 WoWPro.RegisterEventHandler("PLAYER_TARGET_CHANGED", function(event, ...)

--- a/WoWPro_Leveling/TBC/Horde/INTRO_BCC_Tauren.lua
+++ b/WoWPro_Leveling/TBC/Horde/INTRO_BCC_Tauren.lua
@@ -7,292 +7,292 @@ WoWPro:GuideLevels(guide, 1, 12, 2)
 WoWPro:GuideNextGuide(guide, 'CLASSIC_BC_Silverpine_Forest')
 WoWPro:GuideSteps(guide, function() return [[
 
-A The Hunt Begins|QID|747|M|44.87,77.08|N|From Grull Hawkwind.|
-A A Humble Task|QID|752|M|44.19,76.06|N|From Chief Hawkwind.|
-C The Hunt Begins|QID|747|M|47.87,77.76|QO|1|N|Kill Plainstriders around the camp.|
+A The Hunt Begins|QID|747|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|
+A A Humble Task|QID|752|M|44.19,76.06|Z|1412; Mulgore|N|From Chief Hawkwind.|
+C The Hunt Begins|QID|747|M|47.87,77.76|Z|1412; Mulgore|L|4739 7;4740 7|ITEM|4739;4740|N|Plainstriders around the camp.|T|Plainstrider|
 ; lv 2
-T A Humble Task|QID|752|M|50.03,81.16|N|To Greatmother Hawkwind.|
-A A Humble Task|QID|753|M|50.03,81.16|N|From Greatmother Hawkwind.|PRE|752|
-C Water Pitcher|QID|753|L|4755|M|50.22,81.37|N|Click the Water Pitcher on the fountain.|
+T A Humble Task|QID|752|M|50.03,81.16|Z|1412; Mulgore|N|To Greatmother Hawkwind.|
+A A Humble Task|QID|753|PRE|752|M|50.03,81.16|Z|1412; Mulgore|N|From Greatmother Hawkwind.|
+C Water Pitcher|QID|753|M|50.22,81.37|Z|1412; Mulgore|L|4755|N|Pick up the Water Pitcher on the well.|
 
-T The Hunt Begins|QID|747|M|44.87,77.08|N|To Grull Hawkwind.|
-A Simple Note|QID|3091|M|44.87,77.08|N|From Grull Hawkwind.|PRE|747|R|Tauren|C|Warrior|
-A Etched Note|QID|3092|M|44.87,77.08|N|From Grull Hawkwind.|PRE|747|R|Tauren|C|Hunter|
-A Rune-Inscribed Note|QID|3093|M|44.87,77.08|N|From Grull Hawkwind.|R|Tauren|C|Shaman|
-A Verdant Note|QID|3094|M|44.87,77.08|N|From Grull Hawkwind.|PRE|747|R|Tauren|C|Druid|
-A The Hunt Continues|QID|750|M|44.87,77.08|N|From Grull Hawkwind.|PRE|747|
-r Sell junk, you will need money for your first training.|QID|753|M|45.29,76.52|N|Right-click this step off when complete.|
+T The Hunt Begins|QID|747|M|44.87,77.08|Z|1412; Mulgore|N|To Grull Hawkwind.|
+A Simple Note|QID|3091|PRE|747|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|R|Tauren|C|Warrior|
+A Etched Note|QID|3092|PRE|747|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|R|Tauren|C|Hunter|
+A Rune-Inscribed Note|QID|3093|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|R|Tauren|C|Shaman|
+A Verdant Note|QID|3094|PRE|747|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|C|Druid|
+A The Hunt Continues|QID|750|PRE|747|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|
+r Sell junk|ACTIVE|3091^3092^3093^3094|M|45.29,76.52|Z|1412; Mulgore|N|You'll need the money for your training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+T Simple Note|QID|3091|M|44.02,76.13|Z|1412; Mulgore|N|To Harutt Thunderhorn.|
+T Etched Note|QID|3092|M|44.26,75.70|Z|1412; Mulgore|N|To Lanka Farshot.|
+T Rune-Inscribed Note|QID|3093|M|45.01,75.95|Z|1412; Mulgore|N|To Meela Dawnstrider.|
+T Verdant Note|QID|3094|M|45.09,75.94|Z|1412; Mulgore|N|To Gart Mistrunner.|
+= Level 2 Training|ACTIVE|753|PRE|3091^3092^3093^3094|M|PLAYER|CC|N|Do your level 2 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|2|
 
-T Rune-Inscribed Note|QID|3093|M|45.01,75.95|N|To Meela Dawnstrider.|R|Tauren|C|Shaman|
-T Verdant Note|QID|3094|M|45.09,75.94|N|To Gart Mistrunner.|R|Tauren|C|Druid|
-T A Humble Task|QID|753|M|44.19,76.06|N|To Chief Hawkwind.|
-A Rites of the Earthmother|QID|755|M|44.19,76.06|N|From Chief Hawkwind.|PRE|753|
-T Simple Note|QID|3091|M|44.02,76.13|N|To Harutt Thunderhorn.|R|Tauren|C|Warrior|
-T Etched Note|QID|3092|M|44.26,75.70|N|To Lanka Farshot.|R|Tauren|C|Hunter|
-
-C The Hunt Continues|QID|750|N|Kill Mountain Cougars for their pelts.|S|
-T Rites of the Earthmother|QID|755|M|42.57,92.17|N|To Seer Graytongue.|
-A Rite of Strength|QID|757|M|42.57,92.17|N|From Seer Graytongue.|PRE|755|
+T A Humble Task|QID|753|M|44.19,76.06|Z|1412; Mulgore|N|To Chief Hawkwind.|
+A Rites of the Earthmother|QID|755|PRE|753|M|44.19,76.06|Z|1412; Mulgore|N|From Chief Hawkwind.|
+C The Hunt Continues|QID|750|M|49.48,90.36|Z|1412; Mulgore|L|4742 10|ITEM|4742|N|Mountain Cougars.|S|
+T Rites of the Earthmother|QID|755|M|42.57,92.17|Z|1412; Mulgore|N|To Seer Graytongue.|
+A Rite of Strength|QID|757|PRE|755|M|42.57,92.17|Z|1412; Mulgore|N|From Seer Graytongue.|
 ; lv 3
-C The Hunt Continues|QID|750|M|44.21,89.06|QO|1|N|Kill Mountain Cougars until you have all 10 Mountain Cougar Pelts.|US|
-L Level 4|N|Grind to level 4. The quest we turn in gives 250 XP, so you can stop at 1150 XP.|LVL|3;1150|
+C The Hunt Continues|QID|750|M|49.48,90.36|Z|1412; Mulgore|L|4742 10|ITEM|4742|N|Mountain Cougars.|T|Mountain Cougar|US|
+L Level 4|ACTIVE|750|M|PLAYER|CC|N|Grind until you're within 3 bubbles of level 4.|LVL|3;-250|
 
-T The Hunt Continues|QID|750|M|44.87,77.08|N|To Grull Hawkwind.|
+T The Hunt Continues|QID|750|M|44.87,77.08|Z|1412; Mulgore|N|To Grull Hawkwind.|
 ; lv 4
-A The Battleboars|QID|780|M|44.87,77.08|N|From Grull Hawkwind.|PRE|750|
-r Sell Junk|QID|780|M|45.29,76.52|
-A Break Sharptusk!|QID|3376|M|44.80,76.86|N|From Brave Windfeather, who walks around the camp.|
-A Call of Earth|QID|1519|M|44.73,76.19|N|From Seer Ravenfeather.|R|Tauren|C|Shaman|
-N Train level 4 skills/spells|QID|780|N|Before heading out go to your trainer and learn your level 4 spells/skills. Right-click this step off.|
+A The Battleboars|QID|780|PRE|750|M|44.87,77.08|Z|1412; Mulgore|N|From Grull Hawkwind.|
+r Sell Junk|AVAILABLE|3376|M|45.29,76.52|Z|1412; Mulgore|N|Sell your junk.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+= Level 4 Training|AVAILABLE|3376|PRE|750|M|PLAYER|CC|N|Do your level 4 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|4|
+A Break Sharptusk!|QID|3376|M|44.80,76.86|Z|1412; Mulgore|N|From Brave Windfeather, who walks around the camp.|T|Brave Windfeather|
+A Call of Earth|QID|1519|M|44.73,76.19|Z|1412; Mulgore|N|From Seer Ravenfeather.|C|Shaman|
 
-C The Battleboars|QID|780|M|56.98,85.95|QO|1;2|N|Kill the Battleboars in front of the tunnel until you complete the Quest.|
-C Rite of Strength|QID|757|QO|1|N|Kill Quillboars for their Bristleback Belts on the way.|S|
-C Break Sharptusk!|QID|3376|M|58.05,85.10;62.24,81.49;62.51,78.81;64.65,77.71|CS|QO|1|N|Work your way to Sharptusk inside the big tent and kill him.|
+C The Battleboars|QID|780|M|56.98,85.95|Z|1412; Mulgore|L|4848 8;4849 8|ITEM|4848;4849|N|the Battleboars in front of the Brambleblade Ravine entrance.|
+C Rite of Strength|QID|757|M|61.02,76.11|Z|1412; Mulgore|L|4770 12|ITEM|4770|N|Bristleback Quillboars in Brambleblade Ravine.|S|
+C Break Sharptusk!|QID|3376|M|64.65,77.71|Z|1412; Mulgore|L|10459|ITEM|10459|N|Chief Sharptusk Thornmantle inside the big building.\n[color=FF0000]NOTE: [/color]After entering through the tunnel and clearing your way to the building entrance, pull everything from inside first before you attack Sharptusk.\nIf you stand on the roof of the building, they will run around to the side of the building to climb and get you.|
 ; lv 5
-l Dirt-stained Map|AVAILABLE|781|M|63.24,82.70|L|4851|N|Inside this cave is a Dirt-stained Map. Loot it. There may be a rare called "Squeler" Thornmantle in the cave.|
-A Attack on Camp Narache|QID|781|U|4851|N|Right-click the Dirt-stained Map.|
-C Rite of Strength|QID|757|N|Kill the Quillboars until you have all Bristleback Belts.|US|
-C Call of Earth|QID|1519|M|64.80,79.20|N|Make sure you have the 2 Ritual Salves.|R|Tauren|C|Shaman|
-H Camp Narache|QID|757|
+l Dirt-stained Map|AVAILABLE|781|M|63.24,82.70|Z|1412; Mulgore|L|4851|N|Loot the Map from the ground inside the cave.\n[color=FF0000]NOTE: [/color]You'll have to kill a Shaman and "Squealer" Thornmantle to get to it.|
+A Attack on Camp Narache|QID|781|M|PLAYER|CC|N|From the Dirt-stained Map.|U|4851|O|
+C Rite of Strength|QID|757|M|61.02,76.11|Z|1412; Mulgore|L|4770 12|ITEM|4770|N|Bristleback Quillboars in Brambleblade Ravine.|US|
+C Call of Earth|QID|1519|M|64.80,79.20|Z|1412; Mulgore|N|\n[color=FF0000]NOTE: [/color]Make sure you have the 2 Ritual Salves.|
+H Camp Narache|ACTIVE|780|M|44.88,77.22|Z|1412; Mulgore|N|Hearth back to Camp Narache.|
 
-T The Battleboars|QID|780|M|44.87,77.08|N|To Grull Hawkwind.|
-T Break Sharptusk!|QID|3376|M|44.80,76.86|N|To Brave Windfeather, who walks around the camp.|
-T Call of Earth|QID|1519|M|44.73,76.19|N|To Seer Ravenfeather.|R|Tauren|C|Shaman|
-A Call of Earth|QID|1520|M|44.73,76.19|N|From Seer Ravenfeather.|PRE|1519|R|Tauren|C|Shaman|
-T Rite of Strength|QID|757|M|44.19,76.06|N|To Chief Hawkwind.|
-A Rites of the Earthmother|QID|763|M|44.19,76.06|N|From Chief Hawkwind.|PRE|757|
-T Attack on Camp Narache|QID|781|M|44.19,76.06|N|To Chief Hawkwind.|
+T The Battleboars|QID|780|M|44.87,77.08|Z|1412; Mulgore|N|To Grull Hawkwind.|
+T Break Sharptusk!|QID|3376|M|44.80,76.86|Z|1412; Mulgore|N|To Brave Windfeather, who walks around the camp.|
+T Call of Earth|QID|1519|M|44.73,76.19|Z|1412; Mulgore|N|To Seer Ravenfeather.|
+A Call of Earth|QID|1520|PRE|1519|M|44.73,76.19|Z|1412; Mulgore|N|From Seer Ravenfeather.|C|Shaman|
+T Rite of Strength|QID|757|M|44.19,76.06|Z|1412; Mulgore|N|To Chief Hawkwind.|
+A Rites of the Earthmother|QID|763|PRE|757|M|44.19,76.06|Z|1412; Mulgore|N|From Chief Hawkwind.|
+T Attack on Camp Narache|QID|781|M|44.19,76.06|Z|1412; Mulgore|N|To Chief Hawkwind.|
 
 ; --- Shaman class quest
-R Kodo Rock|QID|1521|M|53.95,80.21|R|Tauren|C|Shaman|
-T Call of Earth|QID|1520|M|53.83,80.57|U|6635|N|Use the Earth Sapta once you are at Kodo Rock.|R|Tauren|C|Shaman|
-A Call of Earth|QID|1521|M|53.83,80.57|PRE|1520|R|Tauren|C|Shaman|
-T Call of Earth|QID|1521|M|44.73,76.19|N|To Seer Ravenfeather.|R|Tauren|C|Shaman|
-N Train other skills|QID|1521|N|You can train the remaining skills.|R|Tauren|C|Shaman|
+R Kodo Rock|AVAILABLE|1521|M|53.95,80.21|C|Shaman|
+T Call of Earth|QID|1520|M|53.83,80.57|Z|1412; Mulgore|N|Use the Earth Sapta once you are at Kodo Rock.|U|6635|
+A Call of Earth|QID|1521|PRE|1520|M|53.83,80.57|C|Shaman|
+T Call of Earth|QID|1521|M|44.73,76.19|Z|1412; Mulgore|N|To Seer Ravenfeather.|
 ; ---
 
-A A Task Unfinished|QID|1656|M|41.46,81.86;38.52,81.56|CS|N|From Antur Fallow.|
-
-R Bloodhoof Village|AVAILABLE|743|M|38.00,81.46;36.09,78.65;36.12,75.60;38.32,73.57;42.72,69.24;49.35,64.24;48.95,63.00|CS|N|Run to Bloodhoof|
-A Dangers of the Windfury|QID|743|M|47.35,62.01|N|From Ruul Eagletalon.|
-
-A Poison Water|QID|748|M|48.53,60.39|N|From Mull Thunderhorn.|R|Tauren|
-A Swoop Hunting|QID|761|M|48.71,59.32|N|From Harken Windtotem inside the building.|
-
-T Rites of the Earthmother|QID|763|M|47.51,60.17|N|To Baine Bloodhoof.|
-A Rite of Vision|QID|767|M|47.51,60.17|N|From Baine Bloodhoof.|PRE|763|
-A Sharing the Land|QID|745|M|47.51,60.17|N|From Baine Bloodhoof.|
-
-T Rite of Vision|QID|767|M|47.76,57.54|N|To Zarlman Two-Moons.|
-A Rite of Vision|QID|771|M|47.76,57.54|N|From Zarlman Two-Moons.|PRE|767|
-A Mazzranache|QID|766|M|46.99,57.07|N|From Maur Raincaller.|
-
-h Bloodhoof Village|QID|1656|M|46.70,61.00|N|At Innkeeper Kauth.|
-T A Task Unfinished|QID|1656|M|46.62,61.09|N|To Innkeeper Kauth.|
-N First Aid|ACTIVE|766|P|First Aid;129;0+0|M|46.80,60.84|N|From Vira Younghoof, just inside the Inn.\nIf you don't have enough money to pay for it, wait until you can.|
+A A Task Unfinished|QID|1656|M|38.52,81.56|Z|1412; Mulgore|N|From Antur Fallow.\n[color=FF0000]NOTE: [/color]Follow the road to the arch at the top of the hill.|
+R Bloodhoof Village|AVAILABLE|743|ACTIVE|1656|M|48.95,63.00|Z|1412; Mulgore|N|Follow the road to the village.|
+A Dangers of the Windfury|QID|743|M|47.35,62.01|Z|1412; Mulgore|N|From Ruul Eagletalon.|
+A Poison Water|QID|748|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|R|Tauren|
+A Swoop Hunting|QID|761|M|48.71,59.32|Z|1412; Mulgore|N|From Harken Windtotem inside the building.|
+C Poison Water|QID|748|M|40.08,65.54|Z|1412; Mulgore|L|4758 6;4759 4|ITEM|4758;4759|N|Prairie Wolves and Plainstriders.|S|
+C Swoop Hunting|QID|761|M|47.00,41.00|Z|1412; Mulgore|L|4769 8|ITEM|4769|N|Swoops.|S|
+L Level 6|ACTIVE|763|M|PLAYER|CC|N|Grind until you're within 2.5 bubbles of level 6.\n[color=FF0000]NOTE: [/color]We grabbed those quests so you could work on them while grinding.|LVL|5;-340|
+T Rites of the Earthmother|QID|763|M|47.51,60.17|Z|1412; Mulgore|N|To Baine Bloodhoof.| ;340 exp
+A Rite of Vision|QID|767|PRE|763|M|47.51,60.17|Z|1412; Mulgore|N|From Baine Bloodhoof.|
+A Sharing the Land|QID|745|M|47.51,60.17|Z|1412; Mulgore|N|From Baine Bloodhoof.|
+A Dwarven Digging|QID|746|M|47.51,60.17|Z|1412; Mulgore|N|From Baine Bloodhoof.|
+T Rite of Vision|QID|767|M|47.76,57.54|Z|1412; Mulgore|N|To Zarlman Two-Moons.|
+A Rite of Vision|QID|771|PRE|767|M|47.76,57.54|Z|1412; Mulgore|N|From Zarlman Two-Moons.|
+A Mazzranache|QID|766|M|46.99,57.07|Z|1412; Mulgore|N|From Maur Raincaller.|
+= Level 6 Training|ACTIVE|1656|M|PLAYER|CC|N|Do your level 6 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|6|IZ|Bloodhoof Village|
+= First Aid|ACTIVE|1656|M|46.80,60.84|Z|1412; Mulgore|N|From Vira Younghoof for 95c (just inside the Inn).\n[color=FF0000]NOTE: [/color]If you don't have enough money to pay for it, skip this step and come back when you can.|SPELL|First Aid Apprentice; 3273|
+h Bloodhoof Village|ACTIVE|1656|M|46.62,61.09|Z|1412; Mulgore|N|At Innkeeper Kauth.|
+T A Task Unfinished|QID|1656|M|46.62,61.09|Z|1412; Mulgore|N|To Innkeeper Kauth.|
+= Cooking|ACTIVE|771|M|45.41,58.11|Z|1412; Mulgore|N|From Pyall Silentstride for 95c (inside the tent with the vendors).\n[color=FF0000]NOTE: [/color]If you don't have enough money to pay for it, skip this step and come back when you can.|SPELL|Cooking Apprentice; 2550|IZ|Bloodhoof Village|
 ; lv 6
-C Poison Water|QID|748|QO|1;2|N|Kill Prairie Wolves and Plainstriders on your way.|R|Tauren|S|
-C Swoop Hunting|QID|761|QO|1|N|Kill Swoops you encounter on your way for their Trophy Quills.|S|
-C Mazzranache|QID|766|QO|1;3;4|N|Kill Prairie Wolves, Plainstriders and Swoops on the way until you get the parts.|S|
-C Rite of Vision|QID|771|QO|2|N|Loot Ambercorn below trees on your way.|NC|S|
-C Rite of Vision|QID|771|QO|1|M|53.67,66.34|N|Clear around the well and loot two Well Stones.|
-C Rite of Vision|QID|771|QO|2|N|Search for Ambercorns below the trees.|US|
-C Poison Water|QID|748|QO|1;2|N|Kill Prairie Wolves and Plainstriders until you complete the quest.|R|Tauren|US|
-T Poison Water|QID|748|M|48.53,60.39|N|To Mull Thunderhorn if you already have completed the quest.|R|Tauren|
-A Winterhoof Cleansing|QID|754|M|48.53,60.39|N|From Mull Thunderhorn.|R|Tauren|PRE|748|
-T Rite of Vision|QID|771|M|47.76,57.54|N|To Zarlman Two-Moons.|
-A Rite of Vision|QID|772|M|47.76,57.54|N|From Zarlman Two-Moons.|PRE|771|
-N Rite of Vision|QID|772|U|4823|N|Use the Water of the Seers, a 30 second cast. Ignore the Plains Vision. You can't destroy the Water, doing so will automatically cancel the quest. Right-Click this step to continue.|
-; --- Commented out to improve guide flow without removing it.  t Mazzranache|QID|766|M|46.99,57.07|N|To Maur Raincaller.|
-r Sell Junk and Repair|QID|754|M|45.90,58.73|N|Sell Junk and repair before heading out again.|
-C Winterhoof Cleansing|QID|754|M|53.67,66.34|QO|1|U|5411|N|Clear your way to the well and use the provided Winterhoof Cleansing Totem.|
-C Sharing the Land|QID|745|M|53.60,73.13;48.56,73.11|CN|QO|1;2;3|N|There are multiple Palemane camps to choose from, but only the east one has Poachers. Watch out for Snagglespear, a rare that hits relatively hard.|
+C Mazzranache|QID|766|M|59.28,62.16|Z|1412; Mulgore|L|4804;4805;4806;4807|ITEM|4804;4805;4806;4807|N|Prairie Wolves, Cougars, Plainstriders, and Swoops.|S|
+C Rite of Vision|QID|771|M|52.03,63.70|Z|1412; Mulgore|L|4809 2|ITEM|4809|N|Loot Ambercorn from under the trees.|S|
+C Rite of Vision|QID|771|M|53.67,66.34|Z|1412; Mulgore|L|4808 2|ITEM|4808|N|Clear a spot and loot two Well Stones.\n[color=FF0000]NOTE: [/color]The two on the west side are probably the easiest to get.|
+C Rite of Vision|QID|771|M|52.03,63.70|Z|1412; Mulgore|L|4809 2|ITEM|4809|N|Loot Ambercorn from under the trees.|US|
+C Poison Water|QID|748|M|40.08,65.54|Z|1412; Mulgore|L|4758 6;4759 4|ITEM|4758;4759|N|Prairie Wolves and Plainstriders.|US|
+T Poison Water|QID|748|M|48.53,60.39|Z|1412; Mulgore|N|To Mull Thunderhorn.|
+A Winterhoof Cleansing|QID|754|PRE|748|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|R|Tauren|
+T Rite of Vision|QID|771|M|47.76,57.54|Z|1412; Mulgore|N|To Zarlman Two-Moons.|
+A Rite of Vision|QID|772|PRE|771|M|47.76,57.54|Z|1412; Mulgore|N|From Zarlman Two-Moons.|
+C Rite of Vision|ACTIVE|772|M|47.76,57.54|Z|1412; Mulgore|N|Use the Water of the Seer immediately to prevent something happening to it and you having to collect everything again.\n[color=FF0000]NOTE: [/color]This will trigger an event you can ignore for now.|U|4823|O|
+t Mazzranache|QID|766|M|46.99,57.07|Z|1412; Mulgore|N|To Maur Raincaller.|IZ|Bloodhoof Village| ; ** Adding IZ to prevent step showing as soon as quest complete - Hendo72
+r Repair/Sell|AVAILABLE|749|M|46.19,58.55|Z|1412; Mulgore|N|There are vendors inside the large building to whom you can sell and repair with.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|IZ|Bloodhoof Village|
+C Winterhoof Cleansing|QID|754|M|53.52,66.03|Z|1412; Mulgore|N|Clear your way to the Water Well and use the Winterhoof Cleansing Totem.\n[color=FF0000]NOTE: [/color]The northwest corner is probably the best place to do it (less mobs to clear).|U|5411|NC|
+C Sharing the Land|QID|745|M|53.60,73.13;48.56,73.11|CN|Z|1412; Mulgore|N|Kill the required Palemane Tanners (Caster), Skinners (Melee), and Poachers (Range) in 3 separate camps.\n[color=FF0000]NOTE: [/color]Start at the easternmost camp until you're done with the Poachers (you can only find them here) and move west to the other camps.\nSnagglespear (lv 9 rare) spawns around the camps; hitting relatively hard and using Net to trap you.|
 ; lv 7
-C Mazzranache|QID|766|QO|1;3;4|N|Kill Prairie Wolves, Plainstriders and Swoops on the way until you get the parts.|US|
-C Mazzranache|QID|766|QO|2|N|Kill Flatland Cougars until one drops a Femur.|S|
-C Dangers of the Windfury|QID|743|M|62.22,71.05|QO|1|N|Kill Windfury Harpies.|
-R Camp Taurajo|QID|754|M|69.70,60.50|CS|N|While you're in the area, run to Camp Taurajo to get the flight point. Watch out for the level 10 wolves.|TAXI|-Camp Taurajo|
-f Camp Taurajo|QID|754|M|44.44,59.15|Z|The Barrens|N|Get the flight point at Omusa Thunderhorn.|TAXI|-Camp Taurajo|
-A The Ravaged Caravan|QID|749|M|59.82,62.51;57.45,61.25;52.03,59.66|CN|N|From Morin Cloudstalker, who patrols the road.|
-T The Ravaged Caravan|QID|749|M|53.74,48.17|N|Work your way into the camp and right-click the Sealed Supply Crate.|
-A The Ravaged Caravan|QID|751|M|53.74,48.17|N|From the Sealed Supply Crate.|PRE|749|
-T The Ravaged Caravan|QID|751|M|59.82,62.51;57.45,61.25;52.03,59.66|CC|N|To Morin Cloudstalker, who patrols the road.|
+C Dangers of the Windfury|QID|743|M|62.22,71.05|Z|1412; Mulgore|L|4751 8|ITEM|4751|N|Windfury Harpies.|
+R Camp Taurajo|AVAILABLE|749|M|43.73,58.63|Z|1413; The Barrens|N|While you're in the area, run to Camp Taurajo to get the flight point.\n[color=FF0000]NOTE: [/color]Watch out for the level 10 wolves.|TAXI|-Camp Taurajo|
+f Camp Taurajo|AVAILABLE|749|M|44.44,59.15|Z|1413; The Barrens|N|Get the flight point at Omusa Thunderhorn.|TAXI|-Camp Taurajo|
+A The Ravaged Caravan|QID|749|M|69.71,60.63|Z|1412; Mulgore|N|From Morin Cloudstalker.\n[color=FF0000]NOTE: [/color]He patrols the road between the intersection and the Barrens border.|
+T The Ravaged Caravan|QID|749|M|53.74,48.17|Z|1412; Mulgore|N|Clear the Caravan and click on the Sealed Supply Crate.|
+A The Ravaged Caravan|QID|751|PRE|749|M|53.74,48.17|Z|1412; Mulgore|N|From the Sealed Supply Crate.|
+T The Ravaged Caravan|QID|751|M|69.71,60.63|Z|1412; Mulgore|N|To Morin Cloudstalker on the road.\n[color=FF0000]NOTE: [/color]Start at the intersection unless you know where to begin looking for him.|
 ; lv 8
-A Supervisor Fizsprocket|QID|765|M|59.82,62.51;57.45,61.25;52.03,59.66|CC|N|To Morin Cloudstalker, who patrols the road.|PRE|751|
-A The Venture Co.|QID|764|M|61.30,63.30;57.45,61.25;52.03,59.66|CC|N|To Morin Cloudstalker, who patrols the road.|PRE|751|
-C Mazzranache|QID|766|QO|2|N|Kill Flatland Cougars until one drops a Femur.|US|
-T Winterhoof Cleansing|QID|754|M|48.53,60.39|N|To Mull Thunderhorn.|
-A Thunderhorn Totem|QID|756|M|48.53,60.39|N|From Mull Thunderhorn.|PRE|754|
-T Dangers of the Windfury|QID|743|M|47.35,62.01|N|From Ruul Eagletalon.|
-T Sharing the Land|QID|745|M|47.51,60.17|N|To Baine Bloodhoof.|
-A Dwarven Digging|QID|746|M|47.51,60.17|N|From Baine Bloodhoof.|
-T Mazzranache|QID|766|M|46.99,57.07|N|To Maur Raincaller.|
-r Sell Junk and Repair|QID|756|M|45.90,58.73|N|Sell Junk and repair and train your skills before heading out again.|
+A Supervisor Fizsprocket|QID|765|PRE|751|M|69.71,60.63|Z|1412; Mulgore|N|From Morin Cloudstalker.|
+A The Venture Co.|QID|764|PRE|751|M|69.71,60.63|Z|1412; Mulgore|N|From Morin Cloudstalker.|
+C Mazzranache|QID|766|M|59.28,62.16|Z|1412; Mulgore|L|4804;4805;4806;4807|ITEM|4804;4805;4806;4807|N|Prairie Wolves, Cougars, Plainstriders, and Swoops.|US|
+L Level 8|AVAILABLE|765|M|PLAYER|CC|N|Grind until you're within 8 bubbles of level 8.|LVL|7;-1800|
+H Bloodhoof Village|ACTIVE|754|M|46.62,61.09|Z|1412; Mulgore|N|Hearth back to Bloodhoof Village if you're far away from it.|
+T Sharing the Land|QID|745|M|47.51,60.17|Z|1412; Mulgore|N|To Baine Bloodhoof.|
+T Winterhoof Cleansing|QID|754|M|48.53,60.39|Z|1412; Mulgore|N|To Mull Thunderhorn.|
+A Thunderhorn Totem|QID|756|PRE|754|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|
+T Dangers of the Windfury|QID|743|M|47.35,62.01|Z|1412; Mulgore|N|To Ruul Eagletalon.|
+= Level 8 Training|ACTIVE|756|M|PLAYER|CC|N|Do your level 8 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|8|IZ|Bloodhoof Village|
+r Repair/Sell|ACTIVE|756|M|46.19,58.55|Z|1412; Mulgore|N|There are vendors inside the large building to whom you can sell and repair with.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|IZ|Bloodhoof Village|
 
-C Thunderhorn Totem|QID|756|QO|1;2|N|Kill Prairie Stalkers and Flatland Cougars on the way.|S|
-C Dwarven Digging|QID|746|M|31.26,49.83|L|4702 5|N|Kill Dwarves for the Prospector's Picks.|
-C Dwarven Digging|QID|746|M|31.26,49.83|QO|1|U|4702|N|Use the Picks at the forge to destroy them.|NC|
+l Thunderhorn Totem|ACTIVE|756|QO|1;2|M|42.12,47.80|Z|1412; Mulgore|N|Kill and loot Prairie Stalkers and Flatland Cougars.|S|
+C Dwarven Digging|ACTIVE|746|M|31.26,49.83|Z|1412; Mulgore|L|4702 5|ITEM|4702|N|Dwarves at Bael'dun Digsite.|
+C Dwarven Digging|QID|746|M|31.26,49.83|Z|1412; Mulgore|N|Use the Picks at the forge to destroy them.\n[color=FF0000]NOTE: [/color]Clear the entire area first and be quick about getting this done because they respawn rather quickly.\n \nMake sure you have AT LEAST 1 OPEN BAG SLOT to put the broken tool before you start destroying them.\n \nIf you're having trouble, you can use the Forge in Thunder Bluff instead.|U|4702|NC|
+* Prospector's Pick|PRE|746|M|31.26,49.83|Z|1412; Mulgore|N|Once you've gotten yourself to a safer location, trash the Prospector's Picks you have left over.|U|4702|O|
 ; lv 9
-T Rite of Vision|QID|772|M|34.60,37.77;32.72,36.09|CS|N|To Seer Wiserunner inside the cave.|
-A Rite of Wisdom|QID|773|M|32.72,36.09|N|From Seer Wiserunner.|PRE|772|
-C Swoop Hunting|QID|761|N|Kill Swoops to complete the quest on your way back to Bloodhoof Village.|
-C Thunderhorn Totem|QID|756|M|42.12,47.80|QO|1;2|N|Kill Stalkers and Cougars on the way back to Bloodhoof Village.|US|
-T Swoop Hunting|QID|761|M|48.71,59.32|N|To Harken Windtotem.|
-T Thunderhorn Totem|QID|756|M|48.53,60.39|N|From Mull Thunderhorn.|
-A Thunderhorn Cleansing|QID|758|M|48.53,60.39|N|From Mull Thunderhorn.|PRE|756|R|Tauren|
-T Dwarven Digging|QID|746|M|47.51,60.17|N|To Baine Bloodhoof. Dispose of any leftover Prospector's Picks.|
-r Sell Junk and Repair|QID|758|M|45.90,58.73|N|Sell Junk and repair and train your skills before heading out again.|
+T Rite of Vision|QID|772|M|33.38,36.53;32.72,36.09|CS|Z|1412; Mulgore|N|To Seer Wiserunner inside the cave.|
+A Rite of Wisdom|QID|773|PRE|772|M|32.72,36.09|Z|1412; Mulgore|N|From Seer Wiserunner.|
+C Swoop Hunting|QID|761|M|47.00,41.00|Z|1412; Mulgore|L|4769 8|N|Swoops.|US|
+l Thunderhorn Totem|ACTIVE|756|QO|1;2|M|42.12,47.80|Z|1412; Mulgore|N|Kill and loot Prairie Stalkers and Flatland Cougars.|US|
+R Bloodhoof Village|ACTIVE|761|M|48.95,63.00|Z|1412; Mulgore|N|Return to the village.|
+r Repair/Sell|ACTIVE|761|M|46.19,58.55|Z|1412; Mulgore|N|There are vendors inside the large building to whom you can sell and repair with.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|IZ|Bloodhoof Village|
+T Swoop Hunting|QID|761|M|48.71,59.32|Z|1412; Mulgore|N|To Harken Windtotem.|
+T Thunderhorn Totem|QID|756|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|
+A Thunderhorn Cleansing|QID|758|PRE|756|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|R|Tauren|
+T Dwarven Digging|QID|746|M|47.51,60.17|Z|1412; Mulgore|N|To Baine Bloodhoof.|
 
-C Thunderhorn Cleansing|QID|758|M|44.33,45.33|QO|1|U|5415|N|Clear the way to the well and use the totem.|
-A A Sacred Burial|QID|833|M|59.86,25.61|N|From Lorekeeper Raintotem.|
-C A Sacred Burial|QID|833|QO|1|N|Kill Bristleback Interlopers on the way.|S|
-T Rite of Wisdom|QID|773|M|61.45,21.01|N|To Ancestral Spirit.|
-A Journey into Thunder Bluff|QID|775|M|61.45,21.01|N|From Ancestral Spirit.|PRE|773|
-C A Sacred Burial|QID|833|N|Kill Bristleback Interlopers.|US|
-T A Sacred Burial|QID|833|M|59.86,25.61|N|To Lorekeeper Raintotem.|
-L Level 10|QID|758|N|If you are not level 10, grind a bit on the Bristleback.|LVL|10|
-H Bloodhoof Village|QID|758|
-A The Hunter's Way|QID|861|M|46.76,60.22|N|From Skorn Whitecloud.|LVL|10|
-T Thunderhorn Cleansing|QID|758|M|48.53,60.39|N|To Mull Thunderhorn.|R|Tauren|
-A Wildmane Totem|QID|759|M|48.53,60.39|N|From Mull Thunderhorn.|PRE|758|R|Tauren|
-r Sell Junk and Repair|QID|775|M|45.90,58.73|N|Sell Junk and repair and train your skills before heading out again.|
+C Thunderhorn Cleansing|QID|758|M|44.48,45.47|Z|1412; Mulgore|N|Clear a spot beside the well and use the totem.|U|5415|
+A A Sacred Burial|QID|833|M|59.86,25.61|Z|1412; Mulgore|N|From Lorekeeper Raintotem at his camp in Red Rocks.|
+C A Sacred Burial|QID|833|M|60.72,20.79|Z|1412; Mulgore|N|Kill Bristleback Interlopers.|S|
+T Rite of Wisdom|QID|773|M|61.45,21.01|Z|1412; Mulgore|N|To Ancestral Spirit.|
+A Journey into Thunder Bluff|QID|775|PRE|773|M|61.45,21.01|Z|1412; Mulgore|N|From Ancestral Spirit.\n[color=FF0000]NOTE: [/color]You'll have to clear your way into the camp.|
+C A Sacred Burial|QID|833|M|60.72,20.79|Z|1412; Mulgore|N|Kill Bristleback Interlopers.|US|
+T A Sacred Burial|QID|833|M|59.86,25.61|Z|1412; Mulgore|N|To Lorekeeper Raintotem.|
+L Level 10|AVAILABLE|861|M|PLAYER|CC|N|Grind until you're within 2.5 bubbles of level 10.|LVL|9;-700|
+H Bloodhoof Village|ACTIVE|758|M|46.62,61.09|Z|1412; Mulgore|N|Hearth back to Bloodhoof Village if you're hearthstone is available.|
+A The Hunter's Way|QID|861|M|46.76,60.22|Z|1412; Mulgore|N|From Skorn Whitecloud.|LVL|10|
+T Thunderhorn Cleansing|QID|758|M|48.53,60.39|Z|1412; Mulgore|N|To Mull Thunderhorn.|
+A Wildmane Totem|QID|759|PRE|758|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|R|Tauren|
+= lv 10 Training|AVAILABLE|1505&2984&5928&6061|M|PLAYER|CC|N|Do your level 10 training before accepting your class quest.\n[color=FF0000]NOTE: [/color]Don't forget to spend your talent point (<n> by default)\n\nManually check this step off to continue.|LVL|10|IZ|Bloodhoof Village|
 
-; --- class quests ------------------------------------------------------------
+; --- lv 10 class quests ------------------------------------------------------------
 ; --- Warrior
-A Veteran Uzzek|QID|1505|M|49.51,60.58|N|From Krang Stonehoof.|R|Tauren|C|Warrior|
+A Veteran Uzzek|QID|1505|M|49.51,60.58|Z|1412; Mulgore|N|From Krang Stonehoof.|R|Tauren|C|Warrior|
 ; --- Shaman
-A Call of Fire|QID|2984|M|48.39,59.16|N|From Narm Skychaser.|R|Tauren|C|Shaman|
+A Call of Fire|QID|2984|M|48.39,59.16|Z|1412; Mulgore|N|From Narm Skychaser.|C|Shaman|
 ; --- Druid
-A Heeding the Call|QID|5928|M|48.48,59.65|N|From Gennia Runetotem.|R|Tauren|C|Druid| ; Multiple QIDs... 5928 is the primary one.
+A Heeding the Call|QID|5926^5927^5928|M|48.48,59.65|Z|1412; Mulgore|N|From Gennia Runetotem.|C|Druid| ; Multiple QIDs... 5928 is the one you get here - Hendo72
 ; --- Hunter {Tame pet quest chain}
-A Taming the Beast|QID|6061|M|47.82,55.68|N|From Yaw Sharpmane.|R|Tauren|C|Hunter|
-C Taming the Beast|QID|6061|M|43.55,51.80|U|15914|N|Use the Taming Rod on an Adult Plainstrider, either north or south of Either north or south of Bloodhoof Village.|R|Tauren|C|Hunter|
-T Taming the Beast|QID|6061|M|47.82,55.68|N|To Yaw Sharpmane.|R|Tauren|C|Hunter|
-A Taming the Beast|QID|6087|M|47.82,55.68|N|From Yaw Sharpmane.|PRE|6061|R|Tauren|C|Hunter|
-C Taming the Beast|QID|6087|M|47.07,49.26|U|15915|N|Use the Taming Rod on an Prairie Stalker north of the Bloodhoof Village.|R|Tauren|C|Hunter|
-T Taming the Beast|QID|6087|M|47.82,55.68|N|To Yaw Sharpmane.|R|Tauren|C|Hunter|
-A Taming the Beast|QID|6088|M|47.82,55.68|N|From Yaw Sharpmane.|PRE|6087|R|Tauren|C|Hunter|
-C Taming the Beast|QID|6088|M|48.82,46.57|U|15916|N|Use the Taming Rod on a Swoop north of the Bloodhoof Village. You may want to wait for the first Swoop Stun before you start the taming.|R|Tauren|C|Hunter|
-T Taming the Beast|QID|6088|M|47.82,55.68|N|To Yaw Sharpmane.|R|Tauren|C|Hunter|
-A Training the Beast|QID|6089|M|47.82,55.68|N|From Yaw Sharpmane.|PRE|6088|R|Tauren|C|Hunter|
+A Taming the Beast|QID|6061|M|47.82,55.68|Z|1412; Mulgore|N|From Yaw Sharpmane.|R|Tauren|C|Hunter|
+C Taming the Beast|QID|6061|M|43.55,51.80|Z|1412; Mulgore|N|Use the Taming Rod on an Adult Plainstrider, either north or south of Either north or south of Bloodhoof Village.|U|15914|
+T Taming the Beast|QID|6061|M|47.82,55.68|Z|1412; Mulgore|N|To Yaw Sharpmane.|
+A Taming the Beast|QID|6087|PRE|6061|M|47.82,55.68|Z|1412; Mulgore|N|From Yaw Sharpmane.|R|Tauren|C|Hunter|
+C Taming the Beast|QID|6087|M|47.07,49.26|Z|1412; Mulgore|N|Use the Taming Rod on an Prairie Stalker north of the Bloodhoof Village.|U|15915|
+T Taming the Beast|QID|6087|M|47.82,55.68|Z|1412; Mulgore|N|To Yaw Sharpmane.|
+A Taming the Beast|QID|6088|PRE|6087|M|47.82,55.68|Z|1412; Mulgore|N|From Yaw Sharpmane.|R|Tauren|C|Hunter|
+C Taming the Beast|QID|6088|M|48.82,46.57|Z|1412; Mulgore|N|Use the Taming Rod on a Swoop north of the Bloodhoof Village.NOTE You may want to wait for the first Swoop Stun before you start the taming.|U|15916|
+T Taming the Beast|QID|6088|M|47.82,55.68|Z|1412; Mulgore|N|To Yaw Sharpmane.|
+A Training the Beast|QID|6089|PRE|6088|M|47.82,55.68|Z|1412; Mulgore|N|From Yaw Sharpmane.|R|Tauren|C|Hunter|
 ; ---
-R Thunder Bluff|QID|775|M|36.11,28.92|N|Run to Thunder Bluff and go up the lift.|
-A Preparation for Ceremony|QID|744|M|37.69,59.57|Z|Thunder Bluff|N|From Eyahn Eagletalon.|
+R Thunder Bluff|QID|775|M|36.11,28.92|Z|1412; Mulgore|N|Run to Thunder Bluff and go up the lift.|
+A Preparation for Ceremony|QID|744|M|37.69,59.57|Z|1456; Thunder Bluff|N|From Eyahn Eagletalon.|
 ; --- Complete Hunter {Tame pet quest chain}
-T Training the Beast|QID|6089|M|57.29,89.75|Z|Thunder Bluff|N|To Holt Thunderhorn.|R|Tauren|C|Hunter|
+T Training the Beast|QID|6089|M|57.29,89.75|Z|1456; Thunder Bluff|N|To Holt Thunderhorn.|
 ; ---
-
-T Journey into Thunder Bluff|QID|775|M|60.26,51.69|Z|Thunder Bluff|N|To Cairne Bloodhoof.|
-A Rites of the Earthmother|QID|776|M|60.26,51.69|Z|Thunder Bluff|N|From Cairne Bloodhoof.|PRE|775|
-A Testing an Enemy's Strength|QID|5723|M|61.30,40.38;70.53,31.77|Z|Thunder Bluff|CC|N|Pick this quest up from Rahauro if you are planning to run the dungeon Ragefire Chasm.|RANK|3|
-A Searching for the Lost Satchel|QID|5722|M|70.53,31.77|Z|Thunder Bluff|ELITE|N|[color=E6CC80]Dungeon: 'Dungeon'[/color]\nPick this quest up from Rahauro if you are planning to run the dungeon Ragefire Chasm.|RANK|3|
-A The Barrens Oases|QID|886|M|78.57,28.57|Z|Thunder Bluff|N|From Arch Druid Hamuul Runetotem on Elder Rise.|
+T Journey into Thunder Bluff|QID|775|M|60.26,51.69|Z|1456; Thunder Bluff|N|To Cairne Bloodhoof, High Chieftain.|
+A Rites of the Earthmother|QID|776|PRE|775|M|60.26,51.69|Z|1456; Thunder Bluff|N|From Cairne Bloodhoof.|
+A Testing an Enemy's Strength|QID|5723|M|61.30,40.38;70.53,31.77|Z|1456; Thunder Bluff|CC|ELITE|N|[color=E6CC80]Dungeon: 'Ragefire Chasm'[/color]\nFrom Rahauro.|DUNGEON|
+A Searching for the Lost Satchel|QID|5722|M|70.53,31.77|Z|1456; Thunder Bluff|ELITE|N|[color=E6CC80]Dungeon: 'Ragefire Chasm'[/color]\nFrom Rahauro.|DUNGEON|
+A The Barrens Oases|QID|886|M|78.57,28.57|Z|1456; Thunder Bluff|N|From Arch Druid Hamuul Runetotem on Elder Rise.|
 
 ; --- Druid Bear form (Feral Combat) quest chain
-T Heeding the Call|QID|5926^5927^5928|M|76.47,27.26|Z|Thunder Bluff|N|To Turak Runetotem.|R|Tauren|C|Druid|
-A Moonglade|QID|5922|M|76.47,27.26|Z|Thunder Bluff|N|From Turak Runetotem.|PRE|5926|R|Tauren|C|Druid|
-P Moonglade|ACTIVE|5922|N|Use the Teleport: Moonglade spell you learned from Turak Runetotem.|R|Tauren|C|Druid|
-T Moonglade|QID|5922|M|56.21,30.62|Z|1450; Moonglade|N|To Dendrite Starblaze.|R|Tauren|C|Druid|
-A Great Bear Spirit|QID|5930|M|56.21,30.62|Z|1450; Moonglade|N|From Dendrite Starblaze.|PRE|5922|R|Tauren|C|Druid|
-C Great Bear Spirit|QID|5930|M|53.39,31.16;45.03,26.67;39.31,27.44|Z|1450; Moonglade|CC|QO|1|N|Talk to the bear spirit until quest is complete.|CHAT|R|Tauren|C|Druid|
-T Great Bear Spirit|QID|5930|M|56.21,30.62|Z|1450; Moonglade|N|To Dendrite Starblaze. Use Teleport: Moonglade again instead of running back.|R|Tauren|C|Druid|
-A Back to Thunder Bluff|QID|5932|M|56.21,30.62|Z|1450; Moonglade|N|From Dendrite Starblaze.|PRE|5930|C|Druid|
-F Thunder Bluff|QID|5932|M|44.29,45.85|Z|1450; Moonglade|N|Speak with Bumthen Plainswind to fly back to Thunder Bluff.\nGo grab a coffee. It's a looong flight.|R|Tauren|C|Druid|
-T Back to Thunder Bluff|QID|5932|M|76.47,27.26|Z|Thunder Bluff|N|To Turak Runetotem.|R|Tauren|C|Druid|
-A Body and Heart|QID|6002|M|76.47,27.26|Z|Thunder Bluff|N|From Turak Runetotem.|PRE|5932|R|Tauren|C|Druid|
-F Camp Taurajo|QID|6002|M|46.98,49.84|Z|Thunder Bluff|R|Tauren|C|Druid|
-C Body and Heart|QID|6002|M|41.96,59.78;42.00,60.90|Z|The Barrens|CC|QO|1|U|15710|N|Be careful of the level 20 Thunderheads that roam the area. Stay on the road until you pass the house. Use the Cenarion Lunardust at the Moonkin Stone to summon Lunaclaw. Kill him and talk to his ghost to complete the quest.\n[color=FF0000]NOTE: [/color]The Cenarion Lunardust is a one-time use item. If you die, run back as fast you can. If Lunaclaw despawns, you will have to go back to Turak Runetotem in Thunder Bluff, abandon the quest and restart it.|R|Tauren|C|Druid|
-F Thunder Bluff|QID|6002|M|44.44,59.15|Z|The Barrens|R|Tauren|C|Druid|
-T Body and Heart|QID|6002|M|76.47,27.26|Z|Thunder Bluff|N|To Turak Runetotem.|R|Tauren|C|Druid|
+T Heeding the Call|QID|5926^5927^5928|M|76.47,27.26|Z|1456; Thunder Bluff|N|To Turak Runetotem.|
+A Moonglade|QID|5922|PRE|5926|M|76.47,27.26|Z|1456; Thunder Bluff|N|From Turak Runetotem.|C|Druid|
+P Moonglade|ACTIVE|5922|M|PLAYER|CC|N|Use the Teleport: Moonglade spell you learned from Turak Runetotem.|C|Druid|
+T Moonglade|QID|5922|M|56.21,30.62|Z|1450; Moonglade|N|To Dendrite Starblaze.|
+A Great Bear Spirit|QID|5930|PRE|5922|M|56.21,30.62|Z|1450; Moonglade|N|From Dendrite Starblaze.|C|Druid|
+C Great Bear Spirit|QID|5930|M|53.39,31.16;45.03,26.67;39.31,27.44|CC|Z|1450; Moonglade|N|Speak with the Great Bear Spirit.|CHAT|
+T Great Bear Spirit|QID|5930|M|56.21,30.62|Z|1450; Moonglade|N|To Dendrite Starblaze.\n[color=FF0000]NOTE: [/color]Use Teleport: Moonglade again to save running back.|
+A Back to Thunder Bluff|QID|5932|PRE|5930|M|56.21,30.62|Z|1450; Moonglade|N|From Dendrite Starblaze.|C|Druid|
+F Thunder Bluff|QID|5932|M|44.29,45.85|Z|1450; Moonglade|N|Speak with Bumthen Plainswind to fly back to Thunder Bluff.\n[color=FF0000]NOTE: [/color]Go grab a coffee; it's a 10 minute flight.\nIt's easier than hearthing and running from Bloodhoof.|C|Druid|
+T Back to Thunder Bluff|QID|5932|M|76.47,27.26|Z|1456; Thunder Bluff|N|To Turak Runetotem.|
+A Body and Heart|QID|6002|PRE|5932|M|76.47,27.26|Z|1456; Thunder Bluff|N|From Turak Runetotem.|C|Druid|
+F Camp Taurajo|QID|6002|M|46.98,49.84|Z|1456; Thunder Bluff|C|Druid|
+R Moonkin Stone|ACTIVE|6002|M|42.00,60.90|CS|Z|1413; The Barrens|N|Run to the Moonkin Stone in the alcove behind the house just south of Camp Taurajo.NOTE Avoid the level 20 Thunderheads that roam the area by staying on the road until you get to the house.|
+U Body and Heart|ACTIVE|6002|M|42.00,60.90|Z|1413; The Barrens|N|Use the Cenarion Lunardust at the Moonkin Stone to summon Lunaclaw.NOTE If you die, run back as fast you can because if Lunaclaw despawns, you'll have to go back to Turak Runetotem in Thunder Bluff, abandon the quest and restart it.|U|15710|O|
+C Body and Heart|QID|6002|M|42.00,60.90|CC|Z|1413; The Barrens|N|Kill Lunaclaw and speak with Lunaclaw Spirit before he despawns.|
+F Thunder Bluff|QID|6002|M|44.44,59.15|Z|1413; The Barrens|C|Druid|
+T Body and Heart|QID|6002|M|76.47,27.26|Z|1456; Thunder Bluff|N|To Turak Runetotem.|
 ; ---
 
-R Exit Thunder Bluff|QID|759|M|67.42,28.69;50.85,32.38|Z|Thunder Bluff|CS|N|Use the lifts on the north side to exit Thunder Bluff.|
-C Wildmane Totem|QID|759|QO|1|N|Kill Prairie Wolf Alphas to collect their teeth.|S|
-C The Hunter's Way|QID|861|QO|1|N|Kill Flatland Prowlers on the way.|S|
-C Preparation for Ceremony|QID|744|M|51.87,6.26;54.82,11.00;56.06,15.82|CC|QO|1;2|N|Kill Windfury Matriarchs for the Bronze Feathers and Sorceresses for the Azure Feathers at these locations.\n[color=FF0000]NOTE: [/color]Watch for Sister Hatelash, a lv 11 rare elite. She spawns around the 2nd camp.|
+R Exit Thunder Bluff|QID|759|M|67.42,28.69;50.85,32.38|CS|Z|1456; Thunder Bluff|N|Use the lifts on the north side to exit Thunder Bluff.|
+C Wildmane Totem|QID|759|M|50.91,14.50|Z|1412; Mulgore|L|4803 8|N|Prairie Wolf Alphas.|S|
+C The Hunter's Way|QID|861|M|50.91,14.50|Z|1412; Mulgore|L|5203 4|N|Flatland Prowlers.|S|
+C Preparation for Ceremony|QID|744|QO|1;2|M|51.87,6.26;54.82,11.00;56.06,15.82|CC|Z|1412; Mulgore|N|Kill and loot Windfury Matriarchs for the Bronze Feathers and Sorceresses for the Azure Feathers at the three locations.\n[color=FF0000]NOTE: [/color]Watch for Sister Hatelash (lv 11 rare elite) around the 2nd camp.|
 ; lv 11
-C Rites of the Earthmother|QID|776|M|51.22,13.51;56.55,29.44;53.12,14.89;54.48,19.67;53.96,23.12;55.20,31.05;54.50,32.29;52.94,32.13;52.10,31.46;51.94,27.58;50.81,25.20;49.54,20.95;49.10,16.60|CC|QO|1|N|Kill Arra'chea for his Horn. He travels clockwise.|
-C Wildmane Totem|QID|759|QO|1|N|Finish collecting your Prairie Wolf Alpha Teeth.|US|
-C The Hunter's Way|QID|861|M|53.19,34.87|QO|1|N|Finish collecting your Flatland Prowler Claws.|US|
-R Venture Co. Mine|QID|764|M|60.58,49.77|CC|N|Run to the Venture Co. Mine.|
-C The Venture Co.|QID|764|QO|1;2|N|Kill Venture Co. Workers and Supervisors on the way.|S|
-K Supervisor Fizsprocket|QID|765|M|61.45,47.22;64.83,43.40|CS|L|4819|N|Carefully work your way into the mine and kill Supervisor Fizsprocket and loot his Clipboard. He is level 12.|
-C The Venture Co.|QID|764|QO|1;2|N|Kill the remaining Venture Co. Workers and Supervisors for this quest.|US|
-T The Venture Co.|QID|764|M|55.17,60.66|N|To Morin Cloudstalker, who patrols the road.|
-T Supervisor Fizsprocket|QID|765|M|55.17,60.66|N|To Morin Cloudstalker.|
-T Wildmane Totem|QID|759|M|48.53,60.39|N|To Mull Thunderhorn.|R|Tauren|
+C Rites of the Earthmother|QID|776|M|51.22,13.51;56.55,29.44;53.12,14.89;54.48,19.67;53.96,23.12;55.20,31.05;54.50,32.29;52.94,32.13;52.10,31.46;51.94,27.58;50.81,25.20;49.54,20.95;49.10,16.60|CC|Z|1412; Mulgore|L|4841|N|Arra'chea.NOTE He travels clockwise through the waypoints.\nFind a clear spot to attack him.|T|Arra'chea|
+C Wildmane Totem|QID|759|M|50.91,14.50|Z|1412; Mulgore|L|4803 8|N|Prairie Wolf Alphas.NOTE They are spread all over the area.|US|
+C The Hunter's Way|QID|861|QO|1|M|53.19,34.87|Z|1412; Mulgore|L|5203 4|N|Flatland Prowlers.NOTE They are spread all over the area.|US|
+R The Venture Co. Mine|ACTIVE|764|M|60.58,49.77|Z|1412; Mulgore|N|Run to the Venture Co. Mine.|
+C The Venture Co.|QID|764|M|64.29,42.24|Z|1412; Mulgore|N|Kill the required Venture Co. Workers and Supervisors.|S|
+C Supervisor Fizsprocket|QID|765|M|61.45,47.22;64.78,43.38|CS|Z|1412; Mulgore|L|4819|N|Supervisor Fizsprocket (lv 12) after you carefully work your way into the mine.|
+C The Venture Co.|QID|764|M|60.47,49.65|Z|1412; Mulgore|N|Kill the required Venture Co. Workers and Supervisors.|US|
+T The Venture Co.|QID|764|M|69.71,60.63|Z|1412; Mulgore|N|To Morin Cloudstalker on the road.\n[color=FF0000]NOTE: [/color]Start at the intersection unless you know where to begin looking for him.|T|Morin Cloudstalker|
+T Supervisor Fizsprocket|QID|765|M|69.71,60.63|Z|1412; Mulgore|N|To Morin Cloudstalker.|
+T Wildmane Totem|QID|759|M|48.53,60.39|Z|1412; Mulgore|N|To Mull Thunderhorn in Bloodhoof Village.|
 ; lv 12
-A Wildmane Cleansing|QID|760|M|48.53,60.39|N|From Mull Thunderhorn.|PRE|759|R|Tauren|
-R Thunder Bluff|QID|744|M|36.11,28.92|N|Run to Thunder Bluff and go up the lift.|
-T Preparation for Ceremony|QID|744|M|37.69,59.57|Z|Thunder Bluff|N|To Eyahn Eagletalon.|
-T The Hunter's Way|QID|861|M|61.52,80.92|Z|Thunder Bluff|N|To Melor Stonehoof.|
-A Sergra Darkthorn|QID|860|M|61.52,80.92|Z|Thunder Bluff|N|From Melor Stonehoof.|PRE|861|
-T Rites of the Earthmother|QID|776|M|60.26,51.69|Z|Thunder Bluff|N|To Cairne Bloodhoof.|
-R Exit Thunder Bluff|QID|760|M|50.85,32.38|Z|Thunder Bluff|CC|N|Use the lifts on the north side to exit Thunder Bluff.|
-C Wildmane Cleansing|QID|760|M|42.65,14.23|QO|1|U|5416|N|Clear your way to the well and use the Wildmane Totem.\n\n[color=FF0000]NOTE: [/color]Pulling the Supervisor will draw EVERYONE around him.|NC|
-H Bloodhoof Village|QID|760|N|Hearth back to Bloodhoof Village.|
-T Wildmane Cleansing|QID|760|M|48.53,60.39|N|To Mull Thunderhorn.|R|Tauren|
-R Camp Taurajo|QID|886|M|69.70,60.50;75.90,61.00|CS|N|Run to Camp Taurajo. There is no way to fly from Bloodhoof. You can run back to Thunder Bluff if you REALLY want to fly.|TAXI|Camp Taurajo|
-R Camp Taurajo|QID|886|M|69.70,60.50;75.90,61.00|CS|N|Run to Camp Taurajo.|TAXI|-Camp Taurajo|
-f Camp Taurajo|QID|886|M|44.44,59.15|Z|The Barrens|N|Get the flight point from Omusa Thunderhorn.|TAXI|-Camp Taurajo|
-A Journey to the Crossroads|QID|854|M|44.88,58.61|Z|The Barrens|N|From Kirge Sternhorn.|R|Tauren|
-R The Crossroads|QID|886|M|47.31,57.64;51.07,49.00;52.06,32.10|CS|Z|The Barrens|N|Run to the Crossroads while staying on the road.\n\n[color=FF0000]NOTE: [/color]If you stray from the road, you will die. Some of the mobs will be up to 5+ levels above you.|
-T The Barrens Oases|QID|886|M|52.26,31.93|Z|The Barrens|N|To Tonga Runetotem.|
-A The Forgotten Pools|QID|870|M|52.26,31.93|Z|The Barrens|N|From Tonga Runetotem.|PRE|886|
-T Sergra Darkthorn|QID|860|M|52.23,31.01|Z|The Barrens|N|To Sergra Darkthorn.|
-A Plainstrider Menace|QID|844|M|52.23,31.01|Z|The Barrens|N|From Sergra Darkthorn.|PRE|860|
-T Journey to the Crossroads|QID|854|M|51.50,30.87|Z|The Barrens|N|To Thork.|R|Tauren|
-f Crossroads|QID|6361|M|51.50,30.33|Z|The Barrens|N|At Devrak.|TAXI|-Crossroads|
-A A Bundle of Hides|QID|6361|M|51.21,29.05|Z|The Barrens|N|From Jahan Hawkwing.|R|Tauren|
-T A Bundle of Hides|QID|6361|M|51.50,30.33|Z|The Barrens|N|To Devrak.|
-A Ride to Thunder Bluff|QID|6362|M|51.50,30.33|Z|The Barrens|N|From Devrak.|PRE|6361|R|Tauren|
-F Thunder Bluff|QID|6362|M|51.50,30.33|Z|The Barrens|N|Fly to Thunder Bluff.|R|Tauren|
-T Ride to Thunder Bluff|QID|6362|M|45.73,55.83|Z|Thunder Bluff|N|To Ahanu, in a tent at the lowest level from the tower.|
-A Tal the Wind Rider Master|QID|6363|M|45.73,55.83|Z|Thunder Bluff|N|From Ahanu.|PRE|6362|R|Tauren|
-T Tal the Wind Rider Master|QID|6363|M|46.98,49.84|Z|Thunder Bluff|N|To Tal at the top of the tower.|R|Tauren|
-A Return to Jahan|QID|6364|M|46.98,49.84|Z|Thunder Bluff|N|From Tal.|PRE|6363|R|Tauren|
-F Crossroads|QID|6364|M|47.02,49.83|Z|Thunder Bluff|N|Fly back to The Crossroads.|R|Tauren|
-T Return to Jahan|QID|6364|M|51.21,29.05|Z|The Barrens|N|To Jahan Hawkwing.|R|Tauren|
+A Wildmane Cleansing|QID|760|PRE|759|M|48.53,60.39|Z|1412; Mulgore|N|From Mull Thunderhorn.|R|Tauren|
+R Thunder Bluff|QID|744|M|36.11,28.92|Z|1412; Mulgore|N|Run to Thunder Bluff and go up the lift.|S|
+L Level 12|AVAILABLE|860|M|PLAYER|CC|N|Grind until you're halfway to level 12.|LVL|11;-2975|
+R Thunder Bluff|QID|744|M|36.11,28.92|Z|1412; Mulgore|N|Run to Thunder Bluff and go up the lift.|US|
+T Preparation for Ceremony|QID|744|M|37.69,59.57|Z|1456; Thunder Bluff|N|To Eyahn Eagletalon.|
+T The Hunter's Way|QID|861|M|61.52,80.92|Z|1456; Thunder Bluff|N|To Melor Stonehoof.|
+A Sergra Darkthorn|QID|860|PRE|861|M|61.52,80.92|Z|1456; Thunder Bluff|N|From Melor Stonehoof.|
+T Rites of the Earthmother|QID|776|M|60.26,51.69|Z|1456; Thunder Bluff|N|To Cairne Bloodhoof.|
+= Level 12 Training|ACTIVE|760|M|PLAYER|CC|N|Do your level 12 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|12|IZ|Thunder Bluff|
+R Wildmane Water Well|ACTIVE|760|M|42.31,15.37|Z|1412; Mulgore|N|Use the lifts on the north side to exit Thunder Bluff and head north.|
+C Wildmane Cleansing|QID|760|M|42.65,14.23|Z|1412; Mulgore|N|Clear your way to the well and use the Wildmane Totem.\n \n[color=FF0000]NOTE: [/color]Pulling the Supervisor will draw EVERYONE around him.|U|5416|NC|
+H Bloodhoof Village|ACTIVE|760|M|46.62,61.09|Z|1412; Mulgore|N|Hearth back to Bloodhoof Village.|
+T Wildmane Cleansing|QID|760|M|48.53,60.39|Z|1412; Mulgore|N|To Mull Thunderhorn.|
+R Camp Taurajo|QID|886|M|43.73,58.63|Z|1413; The Barrens|N|Run to Camp Taurajo.NOTE Unless you really want to run back to Thunder Bluff and fly there.|TAXI|Camp Taurajo|
+; ** In case they didn't do it earlier when the guide told them to do it. - Hendo72
+R Camp Taurajo|QID|886|M|43.73,58.63|Z|1413; The Barrens|N|Run to Camp Taurajo.|TAXI|-Camp Taurajo|
+f Camp Taurajo|QID|886|M|44.44,59.15|Z|1413; The Barrens|N|Get the flight point from Omusa Thunderhorn.|TAXI|-Camp Taurajo|
+A Journey to the Crossroads|QID|854|M|44.88,58.61|Z|1413; The Barrens|N|From Kirge Sternhorn.|R|Tauren|
+R The Crossroads|QID|886|M|47.31,57.64;51.07,49.00;52.06,32.10|CS|Z|1413; The Barrens|N|Run to the Crossroads while staying on the road.\n[color=FF0000]NOTE: [/color]If you stray from the road, you WILL die. Some of the mobs will be up to 5+ levels above you.|
+N Available quests at The Crossroads|AVAILABLE|6364|Z|1413; The Barrens|N|You may find multiple quests available for you to pick up around The Crossroads. We're only turning in and picking up specific ones.\nThis is because we are following a specific quest path and the other quests won't be done until we return in "The Barrens" guide.\n\nManually check this step off to continue.|
+T The Barrens Oases|QID|886|M|52.26,31.93|Z|1413; The Barrens|N|To Tonga Runetotem.|
+A The Forgotten Pools|QID|870|PRE|886|M|52.26,31.93|Z|1413; The Barrens|N|From Tonga Runetotem.|
+T Sergra Darkthorn|QID|860|M|52.23,31.01|Z|1413; The Barrens|N|To Sergra Darkthorn.|
+A Plainstrider Menace|QID|844|PRE|860|M|52.23,31.01|Z|1413; The Barrens|N|From Sergra Darkthorn.|
+T Journey to the Crossroads|QID|854|M|51.50,30.87|Z|1413; The Barrens|N|To Thork.|
+f Crossroads|QID|6361|M|51.50,30.33|Z|1413; The Barrens|N|At Devrak.|TAXI|-Crossroads|
+A A Bundle of Hides|QID|6361|M|51.21,29.05|Z|1413; The Barrens|N|From Jahan Hawkwing.|R|Tauren|
+T A Bundle of Hides|QID|6361|M|51.50,30.33|Z|1413; The Barrens|N|To Devrak.|
+A Ride to Thunder Bluff|QID|6362|PRE|6361|M|51.50,30.33|Z|1413; The Barrens|N|From Devrak.|R|Tauren|
+F Thunder Bluff|QID|6362|M|51.50,30.33|Z|1413; The Barrens|N|Fly to Thunder Bluff.|R|Tauren|
+T Ride to Thunder Bluff|QID|6362|M|45.73,55.83|Z|1456; Thunder Bluff|N|To Ahanu, in a tent at the lowest level from the tower.|
+A Tal the Wind Rider Master|QID|6363|PRE|6362|M|45.73,55.83|Z|1456; Thunder Bluff|N|From Ahanu.|R|Tauren|
+T Tal the Wind Rider Master|QID|6363|M|46.98,49.84|Z|1456; Thunder Bluff|N|To Tal at the top of the tower.|
+A Return to Jahan|QID|6364|PRE|6363|M|46.98,49.84|Z|1456; Thunder Bluff|N|From Tal.|R|Tauren|
+F Crossroads|QID|6364|M|47.02,49.83|Z|1456; Thunder Bluff|N|Fly back to The Crossroads.|R|Tauren|
+T Return to Jahan|QID|6364|M|51.21,29.05|Z|1413; The Barrens|N|To Jahan Hawkwing.|
 
-N A very long run|AVAILABLE|445|N|The trek from The Crossroads to Orgrimmar is a long run. The simplest route is to just stick to the road and follow the signs.\nIt's faster, and a little more perilous, to take shortcuts off the main road.\nI have found a route that it is a little faster and less likely to get you killed.|
-R Far Watch Outpost|AVAILABLE|445|M|52.67,23.17;61.89,19.17|CC|Z|The Barrens|N|Take the north road out of The Crossroads to the first intersection. Follow the road east to Far Watch Outpost.|
+N A very long run|AVAILABLE|445|Z|1412; Mulgore|N|Because you are Tauren, you won't have the flightpath to Orgrimmar and the trek from The Crossroads to Orgrimmar is a long run.\nThe simplest route is to just stick to the road and follow the signs.\nIt's faster, and a little more perilous, to take shortcuts to straighten out the route.\nI have found a route that it is a little faster and less likely to get you killed.\n[color=FF0000]NOTE: [/color]Manually check this step off to get started.|R|Tauren|TAXI|-Orgrimmar|
+R Far Watch Outpost|AVAILABLE|445|M|52.67,23.17;61.89,19.17|CC|Z|1413; The Barrens|N|Take the north road out of The Crossroads to the first intersection. Follow the road east to Far Watch Outpost.|R|Tauren|TAXI|-Orgrimmar|
 
 ; --- Tauren Warrior class quest
-N Warrior class quest|ACTIVE|1505|N|This is the area to do your class quest.|R|Tauren|C|Warrior|
-T Veteran Uzzek|QID|1505|M|61.38,21.11|Z|The Barrens|N|To Veteran Uzzek.|R|Tauren|C|Warrior|
-A Path of Defense|QID|1498|M|61.38,21.11|Z|The Barrens|N|From Veteran Uzzek.|PRE|1505|R|Tauren|C|Warrior|
-R Thunder Ridge|ACTIVE|1498|M|39.18,32.29|Z|Durotar|N|Cross the bridge over the river and run to the entrance of Thunder Ridge.|R|Tauren|C|Warrior|
-C Path of Defense|QID|1498|M|43.4,24.8|Z|Durotar|QO|1|N|Kill Thunder Lizards for their scales in Thunder Ridge.|R|Tauren|C|Warrior|
-T Path of Defense|QID|1498|M|61.38,21.11|N|Head back To Uzzek at Far Watch Outpost.|R|Tauren|C|Warrior|
+N Warrior class quest|ACTIVE|1505|Z|1412; Mulgore|N|This is the area to do your class quest.NOTECONT|R|Tauren|C|Warrior|
+T Veteran Uzzek|QID|1505|M|61.38,21.11|Z|1413; The Barrens|N|To Veteran Uzzek.|
+A Path of Defense|QID|1498|PRE|1505|M|61.38,21.11|Z|1413; The Barrens|N|From Veteran Uzzek.|R|Tauren|C|Warrior|
+R Thunder Ridge|ACTIVE|1498|M|39.18,32.29|Z|1411; Durotar|N|Cross the bridge over the river and run to the entrance of Thunder Ridge.|R|Tauren|C|Warrior|
+C Path of Defense|QID|1498|QO|1|M|43.4,24.8|Z|1411; Durotar|N|Kill Thunder Lizards for their scales in Thunder Ridge.|
+T Path of Defense|QID|1498|M|61.38,21.11|Z|1412; Mulgore|N|Head back To Uzzek at Far Watch Outpost.|R|Tauren|C|Warrior|
 ; ---
 
 ; --- Tauren Shaman Fire Totem quest
-T Call of Fire|QID|2983|M|55.86,19.94|Z|The Barrens|N|To Kranal Fiss at Grol'dom Farm. He wanders around a bit.|R|Tauren|C|Shaman|
-A Call of Fire|QID|1524|M|55.86,19.94|Z|The Barrens|N|From Kranal Fiss.|PRE|2983|R|Tauren|C|Shaman|
-R Shrine of the Dormant Flame|ACTIVE|1524|M|36.69,57.43|Z|Durotar|CC|N|Follow the hidden path here upwards.|R|Tauren|C|Shaman|
-T Call of Fire|QID|1524|M|38.52,58.92|Z|Durotar|N|To Telf Joolam.|R|Tauren|C|Shaman|
-A Call of Fire|QID|1525|M|38.52,58.92|Z|Durotar|N|From Telf Joolam.|PRE|1524|R|Tauren|C|Shaman|
-R Far Watch Outpost|ACTIVE|1525|M|55.11,24.89|Z|The Barrens|N|Make your way back to the bridge and cross over the river.|R|Tauren|C|Shaman|
-K Razormane Spellcasters|M|57.04,23.08|Z|The Barrens|L|5026|N|Make your way to Thorn Hill (SW of Far Watch Outpost). Kill Razormane Geomancers, Thornweavers, Water Seekers, or Mystics until you loot the Tar Fire.|R|Tauren|C|Shaman|
-R Dustwind Cave|ACTIVE|1525|M|50.63,43.97;54.14,40.68|CS|Z|Durotar|N|Make your way to Razor Hill. Cut through and exit out the east gate. Go up the hill and follow the ridge north to the cave entrance. The Burning Blade Cultists are inside.|R|Tauren|C|Shaman|
-K Burning Blade Cultist|ACTIVE|1525|L|6652|N|Kill the Cultists until you loot the Reagent Pouch.|R|Tauren|C|Shaman|
-A Conscript of the Horde|QID|840|M|50.84,43.59|Z|Durotar|N|From Takrin Pathseeker. We pick this up because its on the way and free XP.|R|Tauren|C|Shaman|
-T Call of Fire|QID|1525|M|38.52,58.92|Z|Durotar|N|Make your way back to Telf Joolam.|R|Tauren|C|Shaman|
-R Far Watch Outpost|ACTIVE|1525|M|55.11,24.89|Z|The Barrens|N|Make your way back to the bridge and cross over the river.|R|Tauren|C|Shaman|
-T Conscript of the Horde|QID|840|M|62.26,19.37|N|To Kargal Battlescar.|R|Tauren|C|Shaman|
-A Crossroads Conscription|QID|842|M|62.26,19.37|N|From Kargal Battlescar.|PRE|840|R|Tauren|C|Shaman|
+T Call of Fire|QID|1522^1523^2983^2984|M|55.86,19.94|Z|1413; The Barrens|N|To Kranal Fiss at Grol'dom Farm. He wanders around a bit.|
+A Call of Fire|QID|1524|PRE|1522^1523^2983^2984|M|55.86,19.94|Z|1413; The Barrens|N|From Kranal Fiss.|C|Shaman|
+R Shrine of the Dormant Flame|ACTIVE|1524|M|36.69,57.43|CC|Z|1411; Durotar|N|Follow the hidden path here upwards.|C|Shaman|
+T Call of Fire|QID|1524|M|38.52,58.92|Z|1411; Durotar|N|To Telf Joolam.|
+A Call of Fire|QID|1525|PRE|1524|M|38.52,58.92|Z|1411; Durotar|N|From Telf Joolam.|C|Shaman|
+R Far Watch Outpost|ACTIVE|1525|M|55.11,24.89|Z|1413; The Barrens|N|Make your way back to the bridge and cross over the river.|C|Shaman|
+C Call of Fire|QID|1525|M|57.04,23.08|Z|1413; The Barrens|L|5026|ITEM|5026|N|Razormane Geomancers, Thornweavers, Water Seekers, or Mystics in Thorn Hill (SW of Far Watch Outpost).|
+R Dustwind Cave|ACTIVE|1525|M|50.63,43.97;54.14,40.68|CS|Z|1411; Durotar|N|Go through Razor Hill and exit out the east gate. Go up the hill and follow the ridge north to the cave entrance.|C|Shaman|
+C Call of Fire|QID|1525|M|52.00,25.00|Z|1412; Mulgore|L|6652|ITEM|6652|N|Burning Blade Cultists.|
+A Conscript of the Horde|QID|840|M|50.84,43.59|Z|1411; Durotar|N|From Takrin Pathseeker.\n[color=FF0000]NOTE: [/color]We pick this up because its free XP.|C|Shaman|
+T Call of Fire|QID|1525|M|38.52,58.92|Z|1411; Durotar|N|Make your way back to Telf Joolam.|
+R Far Watch Outpost|ACTIVE|1525|M|55.11,24.89|Z|1413; The Barrens|N|Make your way back to the bridge and cross over the river.|C|Shaman|
+T Conscript of the Horde|QID|840|M|62.26,19.37|Z|1412; Mulgore|N|To Kargal Battlescar.|
+A Crossroads Conscription|QID|842|PRE|840|M|62.26,19.37|Z|1412; Mulgore|N|From Kargal Battlescar.|C|Shaman|
 ; ---
 
-R Easy way|AVAILABLE|445|M|61.89,19.17;62.87,8.60|Z|The Barrens|CC|N|From here, take the road north to the bend before Boulder Lode Mine.|
-R Orgrimmar|AVAILABLE|445|M|36.17,23.14;45.54,12.08|Z|Durotar|CC|N|At this point, you can either take your chances with the level 15+ mobs and make a run straight north for the west entrance to Orgrimmar (not recommended), or cross the Southfury River and head for the south entrance. We will be crossing the river. Your best bet is to stick to the shoreline. Follow it north and then follow the mountain wall east to the entrance. The mobs in this area should be level 10ish.|
-f Orgrimmar|AVAILABLE|445|M|47.58,65.27;45.41,63.88|Z|Orgrimmar|CC|N|Get the FP from Doras at the top of the tower.|TAXI|-Orgrimmar|
-
-R Leave Orgrimmar|AVAILABLE|445|M|52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|
-N READ FIRST: Druids|AVAILABLE|445|N|[color=FF0000]NOTE: [/color]Unfortunately, there is only one Druid class trainer outside of Kalimdor, in Silvermoon City. The Orb Of Translocation to the side of the entrance to Undercity will take you to Silvermoon City.|R|Tauren|C|Druid|
-b Tirisfal Glades|AVAILABLE|445|M|50.88,13.83|Z|Durotar|N|Take the Zepplin to Tirisfal Glade.|
-R Undercity|AVAILABLE|445|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity.|
-f Undercity|AVAILABLE|445|M|63.86,48.04|Z|Undercity|N|Grab the FP from Michael Garrett.|TAXI|-Undercity|
-R Leave Undercity|AVAILABLE|445|M|65.99,36.85;66.22,0.90|CC|Z|Undercity|N|Take the elevator up and leave Undercity through the front gates.|
+R Easy way|AVAILABLE|445|M|61.89,19.17;62.87,8.60|CC|Z|1413; The Barrens|N|From here, take the road north to the bend before Boulder Lode Mine.|
+R Orgrimmar|AVAILABLE|445|M|52.42,84.43|Z|1454; Orgrimmar|N|At this point, you can either take your chances with the level 15+ mobs and make a run straight north for the west entrance to Orgrimmar (not recommended), or cross the Southfury River and head for the south entrance.NOTE We'll be crossing the river and your best bet is to stick to the shoreline, following it north to the mountain wall and then east to the entrance. The mobs in this area should be level 10ish.|
+f Orgrimmar|AVAILABLE|445|M|45.11,63.89|Z|1454; Orgrimmar|N|Get the FP from Doras at the top of the tower.|TAXI|-Orgrimmar|
+R Leave Orgrimmar|AVAILABLE|445|M|45.56,12.20|Z|1411; Durotar|CC|N|Exit Orgrimmar through the south gate.|
+N READ FIRST: Druids|AVAILABLE|445|Z|1412; Mulgore|N|[color=FF0000]NOTE: [/color]Unfortunately, there are no Druid class trainers outside of Kalimdor. Therefore, any time you require training, use your Moonglade portal (which will require you to fly back to Thunder Bluff and take the Zepplin back), or you can take the zepplin back and fly to Thunder Bluff from Orgrimmar. Either way, you have some traveling to do every 2 levels.\nTime wise, you're looking at about 30-45 minutes (roundtrip). You can shorten the time by using your hearth, but that may mean not having it available when you need it.\nConsidering the next guide is short, you can always wait until you return to Kalimdor to do your training.\nNOTECONT|C|Druid|
 
 ]]
 end)


### PR DESCRIPTION
## TL;DR
1. **Consolidate and stabilize broker refresh timing**
    - use one shared updater instead of many separate row refresh handlers.
    - one timer controls broker row updates, so refreshes happen in one place and at a steady pace.
2. **Make row refresh safe during combat**
    - detect combat lockdown and postpone UI changes that are not allowed while fighting.
    - don’t touch protected broker row state in combat; wait until it’s safe and then update cleanly.
3. **Cut repeated table allocations from `RowUpdate()`**
    - keep four reusable step arrays on WoWPro and clear them with `table.wipe(...)` instead of recreating them.
    - reuse the same temporary buffers every refresh so the addon does not make new garbage tables over and over.

## Details
### 1. Broker update path refactor
#### Why:
- The old update model was scattered and inefficient. Each row could end up managing its own refresh behavior, and updates could happen unevenly.
#### How:
- The branch centralizes refresh work into one shared broker updater frame:
    - `BrokerUpdateFrame:SetScript("OnUpdate", ...)`
    - one fixed-timer loop drives row refreshes
    - rows register/unregister with that shared updater
#### Result:
- more consistent broker updates, easier maintenance, and a single place to control refresh timing.

### 2. Combat-safe row refresh
#### Why:
- WoW UI is strict during combat. Changing protected rows or button bindings while in combat can cause errors or break the addon.
#### How:
- The branch adds safety checks and deferred handling:
    - `WoWPro.MaybeCombatLockdown()` blocks unsafe refresh activity during combat
    - row updates that touch secure state are delayed until combat ends
    - a “flush after combat” helper applies pending row changes safely once combat is over
    - override bindings are cleared only when not in combat
#### Result:
- broker refresh behaves correctly in combat and does not trigger protected-frame failures.

### 3. Reduced GC / memory churn in `RowUpdate()`
#### Why:
- `RowUpdate()` runs frequently, and allocating temporary tables every refresh creates a lot of garbage. That leads to Lua GC pauses and UI stutter.
#### How:
 - The branch reuses internal scratch buffers instead of rebuilding them each time:
    - replace temporary tables with persistent ones on WoWPro
    - `WoWPro.RowUpdateAllSteps`
    - `WoWPro.RowUpdateStickySteps`
    - `WoWPro.RowUpdateRegularSteps`
    - `WoWPro.RowUpdateStepList`
    - each update now uses table.wipe(...) instead of {}
#### Result:
 - the same row selection and sorting logic runs, but with much lower allocation overhead and smoother refresh performance.