### PR TITLE
Add edge case L/O tag

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4021,6 +4021,10 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         elseif stepAction == "A" then
                             WoWPro.why[guideIndex] = "NextStep(): Optional accept ready - enough loot in bags."
                             skip = false
+                        elseif stepAction == "R" or stepAction == "F" or stepAction == "H" or stepAction == "b" or stepAction == "P" or stepAction == "f" then
+                            -- Optional travel steps should remain visible when the loot prerequisite is met
+                            WoWPro.why[guideIndex] = "NextStep(): Optional travel step shown - enough loot in bags."
+                            skip = false
                         else
                             -- U, C, B, N, etc. - auto-complete when items collected
                             if rowIndex == 1 then


### PR DESCRIPTION
When an `|L|xxx|` and `|O|` tag are used together, the step only shows  when the loot requirement is met.
This only applies to `A`/`T` steps.

This will add travel steps for use with fringe cases where you want them to travel somewhere based on having an item.

**Example**:
R Thunder Bluff|ACTIVE|746|M|37.81,78.86|Z|1456; Thunder Bluff|L|4702 5|N|Instead of using the Forge in Bael'dun, go use the one in Thunder Bluff.\n[color=FF0000]NOTE: [/color]This is because the Bael'dun Dwarves respawn very quickly and can make it difficult to get the quest done.\n \nSkip this step if you want to use to it anyway.|O|