### PR TITLE
WoWPro_Recorder: fix Z-tag formatting in recorder output

### DIFF
--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -132,7 +132,7 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
     local zonetag = _G.C_Map.GetBestMapForUnit("player")
 	local zonetext = _G.GetZoneText()
 	if zonetext and zonetag then
-		zonetag = zonetag .. ";" .. zonetext
+		zonetag = zonetag .. "; " .. zonetext
 	end
     if zonetag == WoWPro.Guides[GID].zone then
         zonetag = nil


### PR DESCRIPTION
As per Cag's request

Add a space after ; when concatenating mapId and zone text 



Ensures recorder writes |Z|2576; Harandar| instead of |Z|2576;Harandar|