### PR TITLE
Fix US step visibility filtering for sticky step flow

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -1220,13 +1220,6 @@ WoWPro.MIDNIGHT = ((WoWPro.TocVersion >= 120000) and (WoWPro.TocVersion < 130000
 WoWPro.RETAIL_RELEASE = 12
 WoWPro.RETAIL = (WoWPro.TocVersion >= WoWPro.RETAIL_RELEASE * 10000)
 
--- TEMP DEBUG: Verify retail/runtime classification
-WoWPro:Print("WoWPro Runtime: TocVersion=%d, Client=%d, RETAIL=%s, CLASSIC=%s, BC=%s", WoWPro.TocVersion, WoWPro.Client,
-             tostring(WoWPro.RETAIL), tostring(WoWPro.CLASSIC), tostring(WoWPro.BC))
-WoWPro.DebugNextStep = true
-WoWPro.NextStepCallCount = 0
-WoWPro.NextStepCImplicitCount = 0
-
 -- Change this to fake out a classic load on retail
 WoWPro.FakeClassic = false
 if WoWPro.FakeClassic then

--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -1220,6 +1220,13 @@ WoWPro.MIDNIGHT = ((WoWPro.TocVersion >= 120000) and (WoWPro.TocVersion < 130000
 WoWPro.RETAIL_RELEASE = 12
 WoWPro.RETAIL = (WoWPro.TocVersion >= WoWPro.RETAIL_RELEASE * 10000)
 
+-- TEMP DEBUG: Verify retail/runtime classification
+WoWPro:Print("WoWPro Runtime: TocVersion=%d, Client=%d, RETAIL=%s, CLASSIC=%s, BC=%s", WoWPro.TocVersion, WoWPro.Client,
+             tostring(WoWPro.RETAIL), tostring(WoWPro.CLASSIC), tostring(WoWPro.BC))
+WoWPro.DebugNextStep = true
+WoWPro.NextStepCallCount = 0
+WoWPro.NextStepCImplicitCount = 0
+
 -- Change this to fake out a classic load on retail
 WoWPro.FakeClassic = false
 if WoWPro.FakeClassic then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1338,44 +1338,6 @@ function WoWPro:RowUpdate(offset)
 				WoWPro:ValidateMapCoords(GID,action,step,coord)
 			end
 		end
-        -- Unstickying stickies --
-        if unsticky and (not sticky) and i == WoWPro:GetActiveStickyCount()+1 then
-            for n, row in ipairs(WoWPro.rows) do
-                -- Match by step text AND questtext (QO) AND lootitem (L) to handle multiple stickies with same name but different objectives/items
-                local rowQuesttext = WoWPro.questtext[row.index]
-                local rowLootitem = WoWPro.lootitem[row.index]
-                local qoMatch = (questtext == rowQuesttext) or (not questtext and not rowQuesttext)
-
-                -- Compare lootitem tables by content, not reference
-                local lootMatch = false
-                if not lootitem and not rowLootitem then
-                    lootMatch = true
-                elseif lootitem and rowLootitem then
-                    -- Both have lootitem, compare contents
-                    lootMatch = true
-                    for itemID, qty in pairs(lootitem) do
-                        if rowLootitem[itemID] ~= qty then
-                            lootMatch = false
-                            break
-                        end
-                    end
-                    if lootMatch then
-                        for itemID, qty in pairs(rowLootitem) do
-                            if lootitem[itemID] ~= qty then
-                                lootMatch = false
-                                break
-                            end
-                        end
-                    end
-                end
-
-                if step == row.step:GetText() and qoMatch and lootMatch and WoWPro.sticky[row.index] and not completion[row.index] then
-                    completion[row.index] = true
-                    return true --reloading
-                end
-            end
-        end
-
         -- Counting stickies that are currently active (at the top) --
         if sticky and i == WoWPro:GetActiveStickyCount()+1 and not completion[k] then
             WoWPro:IncrementActiveStickyCount()
@@ -2291,6 +2253,12 @@ function WoWPro.NextStep(guideIndex, rowIndex)
     guide.skipped = guide.skipped or {}
     if not guideIndex then guideIndex = 1 end --guideIndex is the position in the guide
     if not rowIndex then rowIndex = 1 end --rowIndex is the position on the rows
+    if WoWPro.DebugNextStep then
+        WoWPro.NextStepCallCount = (WoWPro.NextStepCallCount or 0) + 1
+        if WoWPro.NextStepCallCount == 1 or (WoWPro.NextStepCallCount % 50) == 0 then
+            WoWPro:Print("NextStep() call #%d guideIndex=%d rowIndex=%s", WoWPro.NextStepCallCount, guideIndex, tostring(rowIndex))
+        end
+    end
     local skip = true
 
     while skip do
@@ -2732,6 +2700,12 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 
             -- C step implicit completion
             if (stepAction == "C") and WoWPro:QIDsInTableLogical(QID,WoWPro.QuestLog) and (not WoWPro.questtext[guideIndex]) then
+                if WoWPro.DebugNextStep then
+                    WoWPro.NextStepCImplicitCount = (WoWPro.NextStepCImplicitCount or 0) + 1
+                    if WoWPro.NextStepCImplicitCount <= 10 or (WoWPro.NextStepCImplicitCount % 25) == 0 then
+                        WoWPro:Print("NextStep C implicit candidate #%d guideIndex=%d step=%s QID=%s loot=%s", WoWPro.NextStepCImplicitCount, guideIndex, tostring(step), tostring(QID), tostring(WoWPro.lootitem[guideIndex] and "yes" or "no"))
+                    end
+                end
                 if WoWPro.lootitem and WoWPro.lootitem[guideIndex] and not WoWPro.LootItemsCollected(WoWPro.lootitem[guideIndex]) then
                     WoWPro:dbp("NextStep(): Skipping implicit C completion for loot-backed step %d; loot not collected.", guideIndex)
                 elseif QidMapReduce(QID,false,"&","^",function (qid) return WoWPro.QuestLog[qid] and WoWPro.QuestLog[qid].complete end, "C-implicit") then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1242,51 +1242,21 @@ function WoWPro:RowUpdate(offset)
     end
 
     -- Merge: stickies first, then regular.
-    -- US step visibility: US steps are only eligible to be shown after their corresponding S step is completed.
-    -- This means US steps are not added to the visible stepList until their S step is complete, regardless of US conditionals.
-    -- When a US step becomes the activestep, it completes its S step immediately (see NextStep logic).
+    -- US steps should only be visible when they are the first regular row after active stickies.
     local stepList = {}
     for _, v in ipairs(stickySteps) do
         table.insert(stepList, v)
     end
+    local firstRegular = true
     for _, v in ipairs(regularSteps) do
-        -- If this is a US step (unsticky and not sticky)
         if WoWPro.unsticky[v] and not WoWPro.sticky[v] then
-            -- Find the corresponding S step by QID, questtext (QO), and lootitem (L tag) if present
-            local foundSticky = nil
-            local qidUS = WoWPro.QID[v]
-            local qtextUS = WoWPro.questtext and WoWPro.questtext[v]
-            local lootUS = WoWPro.lootitem and WoWPro.lootitem[v]
-            for idx = 1, WoWPro.stepcount do
-                if WoWPro.sticky[idx] and not WoWPro.unsticky[idx]
-                    and WoWPro.QID[idx] == qidUS then
-                    local qtextS = WoWPro.questtext and WoWPro.questtext[idx]
-                    local lootS = WoWPro.lootitem and WoWPro.lootitem[idx]
-                    if qtextUS == qtextS and lootUS == lootS then
-                        if not completion[idx] then
-                            foundSticky = idx
-                            break
-                        end
-                    elseif qtextUS == qtextS and type(lootUS) == "table" and type(lootS) == "table" and deepTableEqual(lootUS, lootS) then
-                        if not completion[idx] then
-                            foundSticky = idx
-                            break
-                        end
-                    elseif not qtextUS and not qtextS and not lootUS and not lootS then
-                        -- Both questtext and lootitem are nil, treat as match
-                        if not completion[idx] then
-                            foundSticky = idx
-                            break
-                        end
-                    end
-                end
-            end
-            -- Only show US step if its S step is completed (or no S step exists)
-            if not foundSticky or completion[foundSticky] then
+            if firstRegular then
                 table.insert(stepList, v)
+                firstRegular = false
             end
         else
             table.insert(stepList, v)
+            firstRegular = false
         end
     end
     WoWPro.RowLimit = #stepList

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1242,21 +1242,51 @@ function WoWPro:RowUpdate(offset)
     end
 
     -- Merge: stickies first, then regular.
-    -- US steps should only be visible when they are the first regular row after active stickies.
+    -- US step visibility: US steps are only eligible to be shown after their corresponding S step is completed.
+    -- This means US steps are not added to the visible stepList until their S step is complete, regardless of US conditionals.
+    -- When a US step becomes the activestep, it completes its S step immediately (see NextStep logic).
     local stepList = {}
     for _, v in ipairs(stickySteps) do
         table.insert(stepList, v)
     end
-    local firstRegular = true
     for _, v in ipairs(regularSteps) do
+        -- If this is a US step (unsticky and not sticky)
         if WoWPro.unsticky[v] and not WoWPro.sticky[v] then
-            if firstRegular then
+            -- Find the corresponding S step by QID, questtext (QO), and lootitem (L tag) if present
+            local foundSticky = nil
+            local qidUS = WoWPro.QID[v]
+            local qtextUS = WoWPro.questtext and WoWPro.questtext[v]
+            local lootUS = WoWPro.lootitem and WoWPro.lootitem[v]
+            for idx = 1, WoWPro.stepcount do
+                if WoWPro.sticky[idx] and not WoWPro.unsticky[idx]
+                    and WoWPro.QID[idx] == qidUS then
+                    local qtextS = WoWPro.questtext and WoWPro.questtext[idx]
+                    local lootS = WoWPro.lootitem and WoWPro.lootitem[idx]
+                    if qtextUS == qtextS and lootUS == lootS then
+                        if not completion[idx] then
+                            foundSticky = idx
+                            break
+                        end
+                    elseif qtextUS == qtextS and type(lootUS) == "table" and type(lootS) == "table" and deepTableEqual(lootUS, lootS) then
+                        if not completion[idx] then
+                            foundSticky = idx
+                            break
+                        end
+                    elseif not qtextUS and not qtextS and not lootUS and not lootS then
+                        -- Both questtext and lootitem are nil, treat as match
+                        if not completion[idx] then
+                            foundSticky = idx
+                            break
+                        end
+                    end
+                end
+            end
+            -- Only show US step if its S step is completed (or no S step exists)
+            if not foundSticky or completion[foundSticky] then
                 table.insert(stepList, v)
-                firstRegular = false
             end
         else
             table.insert(stepList, v)
-            firstRegular = false
         end
     end
     WoWPro.RowLimit = #stepList
@@ -1338,6 +1368,44 @@ function WoWPro:RowUpdate(offset)
 				WoWPro:ValidateMapCoords(GID,action,step,coord)
 			end
 		end
+        -- Unstickying stickies --
+        if unsticky and (not sticky) and i == WoWPro:GetActiveStickyCount()+1 then
+            for n, row in ipairs(WoWPro.rows) do
+                -- Match by step text AND questtext (QO) AND lootitem (L) to handle multiple stickies with same name but different objectives/items
+                local rowQuesttext = WoWPro.questtext[row.index]
+                local rowLootitem = WoWPro.lootitem[row.index]
+                local qoMatch = (questtext == rowQuesttext) or (not questtext and not rowQuesttext)
+
+                -- Compare lootitem tables by content, not reference
+                local lootMatch = false
+                if not lootitem and not rowLootitem then
+                    lootMatch = true
+                elseif lootitem and rowLootitem then
+                    -- Both have lootitem, compare contents
+                    lootMatch = true
+                    for itemID, qty in pairs(lootitem) do
+                        if rowLootitem[itemID] ~= qty then
+                            lootMatch = false
+                            break
+                        end
+                    end
+                    if lootMatch then
+                        for itemID, qty in pairs(rowLootitem) do
+                            if lootitem[itemID] ~= qty then
+                                lootMatch = false
+                                break
+                            end
+                        end
+                    end
+                end
+
+                if step == row.step:GetText() and qoMatch and lootMatch and WoWPro.sticky[row.index] and not completion[row.index] then
+                    completion[row.index] = true
+                    return true --reloading
+                end
+            end
+        end
+
         -- Counting stickies that are currently active (at the top) --
         if sticky and i == WoWPro:GetActiveStickyCount()+1 and not completion[k] then
             WoWPro:IncrementActiveStickyCount()
@@ -2253,12 +2321,6 @@ function WoWPro.NextStep(guideIndex, rowIndex)
     guide.skipped = guide.skipped or {}
     if not guideIndex then guideIndex = 1 end --guideIndex is the position in the guide
     if not rowIndex then rowIndex = 1 end --rowIndex is the position on the rows
-    if WoWPro.DebugNextStep then
-        WoWPro.NextStepCallCount = (WoWPro.NextStepCallCount or 0) + 1
-        if WoWPro.NextStepCallCount == 1 or (WoWPro.NextStepCallCount % 50) == 0 then
-            WoWPro:Print("NextStep() call #%d guideIndex=%d rowIndex=%s", WoWPro.NextStepCallCount, guideIndex, tostring(rowIndex))
-        end
-    end
     local skip = true
 
     while skip do
@@ -2700,12 +2762,6 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 
             -- C step implicit completion
             if (stepAction == "C") and WoWPro:QIDsInTableLogical(QID,WoWPro.QuestLog) and (not WoWPro.questtext[guideIndex]) then
-                if WoWPro.DebugNextStep then
-                    WoWPro.NextStepCImplicitCount = (WoWPro.NextStepCImplicitCount or 0) + 1
-                    if WoWPro.NextStepCImplicitCount <= 10 or (WoWPro.NextStepCImplicitCount % 25) == 0 then
-                        WoWPro:Print("NextStep C implicit candidate #%d guideIndex=%d step=%s QID=%s loot=%s", WoWPro.NextStepCImplicitCount, guideIndex, tostring(step), tostring(QID), tostring(WoWPro.lootitem[guideIndex] and "yes" or "no"))
-                    end
-                end
                 if WoWPro.lootitem and WoWPro.lootitem[guideIndex] and not WoWPro.LootItemsCollected(WoWPro.lootitem[guideIndex]) then
                     WoWPro:dbp("NextStep(): Skipping implicit C completion for loot-backed step %d; loot not collected.", guideIndex)
                 elseif QidMapReduce(QID,false,"&","^",function (qid) return WoWPro.QuestLog[qid] and WoWPro.QuestLog[qid].complete end, "C-implicit") then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1341,19 +1341,11 @@ function WoWPro:RowUpdate(offset)
         local QID = tonumber(WoWPro.QID[k])
         local coord = WoWPro.map[k]
         local sticky = WoWPro.sticky[k]
-        local unsticky = WoWPro.unsticky[k]
         local use = WoWPro.use[k]
         local zone = WoWPro.zone[k]
-		local eab = WoWPro.eab[k]
+        local eab = WoWPro.eab[k]
         local target = WoWPro.target[k]
         local item = WoWPro.item[k]
-        local questtext = WoWPro.questtext[k]
-        local lootitem = WoWPro.lootitem[k]
-        completion = WoWProCharDB.Guide[GID].completion
-
-        if (i == 1) and not step then
-            WoWProCharDB.Guide[GID].done = true
-        end
 
 		if coord then
 			if (coord == "PLAYER") then
@@ -1368,44 +1360,6 @@ function WoWPro:RowUpdate(offset)
 				WoWPro:ValidateMapCoords(GID,action,step,coord)
 			end
 		end
-        -- Unstickying stickies --
-        if unsticky and (not sticky) and i == WoWPro:GetActiveStickyCount()+1 then
-            for n, row in ipairs(WoWPro.rows) do
-                -- Match by step text AND questtext (QO) AND lootitem (L) to handle multiple stickies with same name but different objectives/items
-                local rowQuesttext = WoWPro.questtext[row.index]
-                local rowLootitem = WoWPro.lootitem[row.index]
-                local qoMatch = (questtext == rowQuesttext) or (not questtext and not rowQuesttext)
-
-                -- Compare lootitem tables by content, not reference
-                local lootMatch = false
-                if not lootitem and not rowLootitem then
-                    lootMatch = true
-                elseif lootitem and rowLootitem then
-                    -- Both have lootitem, compare contents
-                    lootMatch = true
-                    for itemID, qty in pairs(lootitem) do
-                        if rowLootitem[itemID] ~= qty then
-                            lootMatch = false
-                            break
-                        end
-                    end
-                    if lootMatch then
-                        for itemID, qty in pairs(rowLootitem) do
-                            if lootitem[itemID] ~= qty then
-                                lootMatch = false
-                                break
-                            end
-                        end
-                    end
-                end
-
-                if step == row.step:GetText() and qoMatch and lootMatch and WoWPro.sticky[row.index] and not completion[row.index] then
-                    completion[row.index] = true
-                    return true --reloading
-                end
-            end
-        end
-
         -- Counting stickies that are currently active (at the top) --
         if sticky and i == WoWPro:GetActiveStickyCount()+1 and not completion[k] then
             WoWPro:IncrementActiveStickyCount()


### PR DESCRIPTION
**Bug**
- `US` steps were being treated like they were skipped when their paired `S` step was still incomplete.
- In WoWPro_Broker.lua, the regular step list construction removed `US` steps unless the matching `S` step was already completed.
- That meant a `US` could disappear from the guide even though it should still exist, waiting for earlier rows to clear.

**Why it was wrong**
- The `US` visibility decision is a display filter, not a skip condition.
- `US` should only be hidden when it is not the first non-sticky row after active stickies.
- The matching/completion logic for `S` was correct, but the visibility gate blocked the `US` too early.

**Fix**
- Change the step list merge logic so:
    - all sticky steps are added first
    - regular steps are added in order
    - `US` steps are only included if they are the first regular step after the stickies
    - This preserves intended UI behavior:
        - if a `US` is the first eligible regular row, it is shown
        - later `US` rows remain hidden until earlier regular rows are done

**Result**
- US now becomes active at the right time
- when it reaches `ActiveStickyCount + 1`, it can complete its paired S
- display/filtering now matches the intended `S`/`US` semantics instead of confusing it with skip logic