### PR TITLE
Fix stale activestep refresh after quest completion

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4193,7 +4193,7 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     WoWPro.why[step] = why
     if not noUpdate then
         if step == WoWPro.ActiveStep and WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible() and not WoWPro.InitLockdown and not _G.InCombatLockdown() then
-            WoWPro:print("BUCKET_BYPASS: CompleteStep(%d) ActiveStep=%s immediate refresh", step, tostring(WoWPro.ActiveStep))
+            WoWPro:print("BUCKET_BYPASS: CompleteStep(%d) ActiveStep=%s visible=%s initLockdown=%s combat=%s immediate refresh", step, tostring(WoWPro.ActiveStep), tostring(WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()), tostring(WoWPro.InitLockdown), tostring(_G.InCombatLockdown()))
             WoWPro:RemoveMapPoint()
             WoWPro.UpdateGuideReal({["WoWPro.CompleteStep"] = 1})
         else

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4192,7 +4192,13 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     end
     WoWPro.why[step] = why
     if not noUpdate then
-        WoWPro:UpdateGuide("WoWPro.CompleteStep")
+        if step == WoWPro.ActiveStep and WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible() and not WoWPro.InitLockdown and not _G.InCombatLockdown() then
+            WoWPro:print("BUCKET_BYPASS: CompleteStep(%d) ActiveStep=%s immediate refresh", step, tostring(WoWPro.ActiveStep))
+            WoWPro:RemoveMapPoint()
+            WoWPro.UpdateGuideReal({["WoWPro.CompleteStep"] = 1})
+        else
+            WoWPro:UpdateGuide("WoWPro.CompleteStep")
+        end
     end
 end
 


### PR DESCRIPTION
This change fixes a case where a quest step could complete successfully, but the guide would continue showing the old step until the user manually reset or reloaded it.

The issue was not that the quest completion failed. The completion was recorded, but the guide did not always refresh immediately afterward, which left the UI looking stuck even though progress had already advanced behind the scenes.

To address this, the completion flow now triggers an immediate guide refresh when the completed step is also the current active step, instead of waiting for the normal deferred update path. That immediate refresh only runs when it is safe to do so, so the existing behavior remains unchanged in combat or other restricted states.

A small always-on log breadcrumb was also added for this bypass path. This gives us a clear signal in future reports without requiring debug logging and without adding extra noise to normal logs.