### PR TITLE
No more choppy chopy

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1060,47 +1060,47 @@ function WoWPro.SetActionTexture(currentRow)
     local QID = WoWPro.QID[k]
 
     -- Set default Texture
-    currentRow.action:SetTexture(WoWPro.actiontypes[action])
+    currentRow.iconTexture:SetTexture(WoWPro.actiontypes[action])
     -- Set custom Texure
-    currentRow.action.tooltip.text:SetText(WoWPro.actionlabels[action])
+    currentRow.iconTexture.tooltip.text:SetText(WoWPro.actionlabels[action])
     if WoWPro.action[k] == "C" then
         local tex = WoWPro.GetQuestIconActive(QID)
-        WoWPro.SetAtlasOrTexture(currentRow.action, tex)
-        currentRow.action.tooltip.text:SetText("Campaign Quest")
+        WoWPro.SetAtlasOrTexture(currentRow.iconTexture, tex)
+        currentRow.iconTexture.tooltip.text:SetText("Campaign Quest")
     end
     if WoWPro.noncombat[k] and (WoWPro.action[k] == "C" or WoWPro.action[k] == "N") then
-        currentRow.action:SetTexture("Interface\\AddOns\\WoWPro\\Textures\\Config.tga")
-        currentRow.action.tooltip.text:SetText("No Combat")
+        currentRow.iconTexture:SetTexture("Interface\\AddOns\\WoWPro\\Textures\\Config.tga")
+        currentRow.iconTexture.tooltip.text:SetText("No Combat")
     elseif WoWPro.hand[k] and (WoWPro.action[k] == "C" or WoWPro.action[k] == "N") then
-        currentRow.action:SetTexture(WoWPro.actiontypes["HAND TAG"])
-        currentRow.action.tooltip.text:SetText(WoWPro.actionlabels["HAND TAG"])
+        currentRow.iconTexture:SetTexture(WoWPro.actiontypes["HAND TAG"])
+        currentRow.iconTexture.tooltip.text:SetText(WoWPro.actionlabels["HAND TAG"])
     elseif WoWPro.inspect[k] and (WoWPro.action[k] == "C" or WoWPro.action[k] == "N") then
-        currentRow.action:SetTexture(WoWPro.actiontypes["INSPECT TAG"])
-        currentRow.action.tooltip.text:SetText(WoWPro.actionlabels["INSPECT TAG"])
+        currentRow.iconTexture:SetTexture(WoWPro.actiontypes["INSPECT TAG"])
+        currentRow.iconTexture.tooltip.text:SetText(WoWPro.actionlabels["INSPECT TAG"])
     elseif WoWPro.lootitem[k] and WoWPro.action[k] == "C" then
-        currentRow.action:SetTexture(WoWPro.actiontypes['l'])
-        currentRow.action.tooltip.text:SetText("Loot Complete")
+        currentRow.iconTexture:SetTexture(WoWPro.actiontypes['l'])
+        currentRow.iconTexture.tooltip.text:SetText("Loot Complete")
     elseif WoWPro.chat[k] then
-        currentRow.action:SetTexture("Interface\\GossipFrame\\Gossipgossipicon")
-        currentRow.action.tooltip.text:SetText("Chat")
+        currentRow.iconTexture:SetTexture("Interface\\GossipFrame\\Gossipgossipicon")
+        currentRow.iconTexture.tooltip.text:SetText("Chat")
     elseif WoWPro.jump[k] then
-        currentRow.action:SetTexture("Interface\\Icons\\spell_arcane_teleportironforge")
-        currentRow.action.tooltip.text:SetText("Jump")
+        currentRow.iconTexture:SetTexture("Interface\\Icons\\spell_arcane_teleportironforge")
+        currentRow.iconTexture.tooltip.text:SetText("Jump")
     elseif WoWPro.vehichle[k] then
         -- Yeah, that is how blizzard spelled it!
-        currentRow.action:SetTexture("Interface\\CURSOR\\vehichleCursor")
-        currentRow.action.tooltip.text:SetText("Take Vehicle")
+        currentRow.iconTexture:SetTexture("Interface\\CURSOR\\vehichleCursor")
+        currentRow.iconTexture.tooltip.text:SetText("Take Vehicle")
     elseif WoWPro.elite[k] and WoWPro.action[k] == "A" then
-        currentRow.action:SetTexture(WoWPro.actiontypes[action.." ELITE"])
-        currentRow.action.tooltip.text:SetText("Elite Quest")
+        currentRow.iconTexture:SetTexture(WoWPro.actiontypes[action.." ELITE"])
+        currentRow.iconTexture.tooltip.text:SetText("Elite Quest")
     elseif WoWPro.action[k] == "A" then
         local tex = WoWPro.GetQuestIconOffer(QID)
-        WoWPro.SetAtlasOrTexture(currentRow.action, tex)
-        currentRow.action.tooltip.text:SetText("Campaign Quest")
+        WoWPro.SetAtlasOrTexture(currentRow.iconTexture, tex)
+        currentRow.iconTexture.tooltip.text:SetText("Campaign Quest")
     elseif WoWPro.action[k] == "T" then
         local tex = WoWPro.GetQuestIconComplete(QID)
-        WoWPro.SetAtlasOrTexture(currentRow.action, tex)
-        currentRow.action.tooltip.text:SetText("Campaign Quest")
+        WoWPro.SetAtlasOrTexture(currentRow.iconTexture, tex)
+        currentRow.iconTexture.tooltip.text:SetText("Campaign Quest")
     end
 end
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1058,49 +1058,53 @@ function WoWPro.SetActionTexture(currentRow)
     local k = currentRow.index
     local action = WoWPro.action[k]
     local QID = WoWPro.QID[k]
+    if not currentRow or not currentRow.iconTexture then return end
+
+    currentRow.iconTexture.tooltip = currentRow.iconTexture.tooltip or { text = "" }
+    local tooltipText = currentRow.iconTexture.tooltip
 
     -- Set default Texture
     currentRow.iconTexture:SetTexture(WoWPro.actiontypes[action])
-    -- Set custom Texure
-    currentRow.iconTexture.tooltip.text:SetText(WoWPro.actionlabels[action])
+    -- Set custom Texture tooltip text
+    tooltipText.text = WoWPro.actionlabels[action] or ""
     if WoWPro.action[k] == "C" then
         local tex = WoWPro.GetQuestIconActive(QID)
         WoWPro.SetAtlasOrTexture(currentRow.iconTexture, tex)
-        currentRow.iconTexture.tooltip.text:SetText("Campaign Quest")
+        tooltipText.text = "Campaign Quest"
     end
     if WoWPro.noncombat[k] and (WoWPro.action[k] == "C" or WoWPro.action[k] == "N") then
         currentRow.iconTexture:SetTexture("Interface\\AddOns\\WoWPro\\Textures\\Config.tga")
-        currentRow.iconTexture.tooltip.text:SetText("No Combat")
+        currentRow.iconTexture.tooltip.text = "No Combat"
     elseif WoWPro.hand[k] and (WoWPro.action[k] == "C" or WoWPro.action[k] == "N") then
         currentRow.iconTexture:SetTexture(WoWPro.actiontypes["HAND TAG"])
-        currentRow.iconTexture.tooltip.text:SetText(WoWPro.actionlabels["HAND TAG"])
+        currentRow.iconTexture.tooltip.text = WoWPro.actionlabels["HAND TAG"]
     elseif WoWPro.inspect[k] and (WoWPro.action[k] == "C" or WoWPro.action[k] == "N") then
         currentRow.iconTexture:SetTexture(WoWPro.actiontypes["INSPECT TAG"])
-        currentRow.iconTexture.tooltip.text:SetText(WoWPro.actionlabels["INSPECT TAG"])
+        currentRow.iconTexture.tooltip.text = WoWPro.actionlabels["INSPECT TAG"]
     elseif WoWPro.lootitem[k] and WoWPro.action[k] == "C" then
         currentRow.iconTexture:SetTexture(WoWPro.actiontypes['l'])
-        currentRow.iconTexture.tooltip.text:SetText("Loot Complete")
+        currentRow.iconTexture.tooltip.text = "Loot Complete"
     elseif WoWPro.chat[k] then
         currentRow.iconTexture:SetTexture("Interface\\GossipFrame\\Gossipgossipicon")
-        currentRow.iconTexture.tooltip.text:SetText("Chat")
+        currentRow.iconTexture.tooltip.text = "Chat"
     elseif WoWPro.jump[k] then
         currentRow.iconTexture:SetTexture("Interface\\Icons\\spell_arcane_teleportironforge")
-        currentRow.iconTexture.tooltip.text:SetText("Jump")
+        currentRow.iconTexture.tooltip.text = "Jump"
     elseif WoWPro.vehichle[k] then
         -- Yeah, that is how blizzard spelled it!
         currentRow.iconTexture:SetTexture("Interface\\CURSOR\\vehichleCursor")
-        currentRow.iconTexture.tooltip.text:SetText("Take Vehicle")
+        currentRow.iconTexture.tooltip.text = "Take Vehicle"
     elseif WoWPro.elite[k] and WoWPro.action[k] == "A" then
         currentRow.iconTexture:SetTexture(WoWPro.actiontypes[action.." ELITE"])
-        currentRow.iconTexture.tooltip.text:SetText("Elite Quest")
+        currentRow.iconTexture.tooltip.text = "Elite Quest"
     elseif WoWPro.action[k] == "A" then
         local tex = WoWPro.GetQuestIconOffer(QID)
         WoWPro.SetAtlasOrTexture(currentRow.iconTexture, tex)
-        currentRow.iconTexture.tooltip.text:SetText("Campaign Quest")
+        currentRow.iconTexture.tooltip.text = "Campaign Quest"
     elseif WoWPro.action[k] == "T" then
         local tex = WoWPro.GetQuestIconComplete(QID)
         WoWPro.SetAtlasOrTexture(currentRow.iconTexture, tex)
-        currentRow.iconTexture.tooltip.text:SetText("Campaign Quest")
+        currentRow.iconTexture.tooltip.text = "Campaign Quest"
     end
 end
 

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -640,7 +640,7 @@ function WoWPro.RowSizeSet()
 
         if row.trackcheck and row.track:GetText() ~= "" then
             row.track:Show()
-            row.track:SetPoint("TOPLEFT", row.action, "BOTTOMLEFT", 0, -noteh-5)
+            row.track:SetPoint("TOPLEFT", row.iconTexture, "BOTTOMLEFT", 0, -noteh-5)
             trackh = row.track:GetHeight()
             row.progressBar:SetWidth(row:GetWidth()-30)
         else
@@ -649,7 +649,7 @@ function WoWPro.RowSizeSet()
             trackh = 1
         end
 
-        newh = noteh + trackh + max(row.step:GetHeight(),row.action:GetHeight()) + space*2 +3
+        newh = noteh + trackh + max(row.step:GetHeight(),row.iconTexture:GetHeight()) + space*2 +3
         if row.progressBar:IsVisible() then
             newh = newh + 20
         end
@@ -1869,10 +1869,10 @@ function WoWPro:CreateRows()
         row.check:SetScript("OnLeave", function(this)
             _G.GameTooltip:Hide()
         end)
-        row.action = WoWPro:CreateAction(row, row.check)
-        row.step = WoWPro:CreateStep(row, row.action)
-        row.note = WoWPro:CreateNote(row, row.action)
-        row.track = WoWPro:CreateTrack(row, row.action)
+        row.iconTexture = WoWPro:CreateIcon(row, row.check)
+        row.step = WoWPro:CreateStep(row, row.iconTexture)
+        row.note = WoWPro:CreateNote(row, row.iconTexture)
+        row.track = WoWPro:CreateTrack(row, row.iconTexture)
         row.progressBar = WoWPro:CreateProgressBar(row, row.track)
         row.progressBar:Hide()
         row.itembutton, row.itemicon, row.itemcooldown = WoWPro:CreateItemButton(WoWPro.MainFrame, i, row)

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -549,7 +549,7 @@ function WoWPro:CreateScrollbar(parent, offset, step, where)
 end
 
 do
-    local tooltip = _G.CreateFrame("Frame", nil, _G.UIParent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
+    local tooltip = _G.CreateFrame("Frame", nil, WoWPro.MainFrame, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     tooltip:SetBackdrop( {
         bgFile = [[Interface\Tooltips\UI-Tooltip-Background]],
         edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -48,7 +48,7 @@ function WoWPro:CreateCheck(parent)
     return check
 end
 
-function WoWPro:CreateAction(parent, anchor)
+function WoWPro:CreateIcon(parent, anchor)
     local frame = _G.CreateFrame("Frame", nil, parent)
     frame:SetPoint("LEFT", anchor, "RIGHT", 3, 0)
     frame:SetWidth(16)
@@ -585,14 +585,14 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
     row:SetHeight(rowHeight or 25)
 
     row.check = WoWPro:CreateCheck(row)
-    row.action = WoWPro:CreateAction(row, row.check)
-    row.action.frame:SetScript("OnEnter", function()
+    row.iconTexture = WoWPro:CreateIcon(row, row.check)
+    row.iconTexture.frame:SetScript("OnEnter", function()
         if row.index then
             tooltip:ClearAllPoints()
             if WoWPro.GetSide(WoWPro.MainFrame) == "TOP" then
-                tooltip:SetPoint("TOPLEFT", row.action.frame, "BOTTOMRIGHT", 2, 2)
+                tooltip:SetPoint("TOPLEFT", row.iconTexture.frame, "BOTTOMRIGHT", 2, 2)
             else
-                tooltip:SetPoint("BOTTOMLEFT", row.action.frame, "TOPRIGHT", 2, -2)
+                tooltip:SetPoint("BOTTOMLEFT", row.iconTexture.frame, "TOPRIGHT", 2, -2)
             end
             tooltiptext:SetHeight(125)
             -- Step Tooltip
@@ -608,8 +608,8 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
                                                                             tostring(WoWPro.why[row.index])))
             elseif WoWPro.why and WoWPro.why[row.index] then
                 tooltiptext:SetText(("Step %d: %s"):format(row.index, tostring(WoWPro.why[row.index])))
-            elseif row.action and row.action.tooltip and row.action.tooltip.text then
-                tooltiptext:SetText(tostring(row.action.tooltip.text:GetText() or ""))
+            elseif row.iconTexture and row.iconTexture.tooltip and row.iconTexture.tooltip.text then
+                tooltiptext:SetText(tostring(row.iconTexture.tooltip.text:GetText() or ""))
             else
                 tooltiptext:SetText(("Step %d"):format(row.index))
             end
@@ -618,16 +618,16 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
             tooltip:Show()
         end
     end)
-    row.action.frame:SetScript("OnLeave", function()
+    row.iconTexture.frame:SetScript("OnLeave", function()
         tooltip:Hide()
     end)
---- row.action.frame:RegisterForClicks("AnyUp")
---- row.action.frame:SetScript("OnClick", function(self, button, down)
+--- row.iconTexture.frame:RegisterForClicks("AnyUp")
+--- row.iconTexture.frame:SetScript("OnClick", function(self, button, down)
 ---     WoWPro.PickQuestline(WoWPro.QID[row.index], WoWPro.step[row.index])
 --- end)
 
-    row.step = WoWPro:CreateStep(row, row.action)
-    row.note = WoWPro:CreateNote(row, row.action)
+    row.step = WoWPro:CreateStep(row, row.iconTexture)
+    row.note = WoWPro:CreateNote(row, row.iconTexture)
     return row
 end
 

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -59,7 +59,7 @@ function WoWPro:CreateAction(parent, anchor)
     action.frame = frame
     action:SetAllPoints()
 
-    local tooltip = _G.CreateFrame("Frame", nil, _G.UIParent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
+    local tooltip = _G.CreateFrame("Frame", nil, WoWPro.MainFrame, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     tooltip:SetBackdrop( {
         bgFile = [[Interface\CHARACTERFRAME\UI-Party-Background]],
         edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -59,46 +59,28 @@ function WoWPro:CreateIcon(parent, anchor)
     action.frame = frame
     action:SetAllPoints()
 
-    local tooltip = _G.CreateFrame("Frame", nil, WoWPro.MainFrame, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
-    tooltip:SetBackdrop( {
-        bgFile = [[Interface\CHARACTERFRAME\UI-Party-Background]],
-        edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],
-        tile = true, tileSize = 16, edgeSize = 16,
-        insets = { left = 4,  right = 3,  top = 4,  bottom = 3 }
-    })
-    tooltip:SetBackdropColor(0.1, 0.1, 0.1, 1)
-    tooltip:SetHeight(125)
-    tooltip:SetWidth(64)
-    tooltip:SetAlpha(1)
-    tooltip:SetFrameStrata("TOOLTIP")
-    tooltip:Hide()
-
-    local tooltiptext = tooltip:CreateFontString(nil, nil, "GameFontNormal")
-    tooltiptext:SetPoint("TOPLEFT", 10, -10)
-    tooltiptext:SetPoint("RIGHT", -10, 0)
-    tooltiptext:SetJustifyH("LEFT")
-    tooltiptext:SetJustifyV("TOP")
-    tooltiptext:SetWidth(50)
-    tooltiptext:SetAlpha(1)
-    tooltiptext:SetText("")
-    tooltip.text = tooltiptext
+    action.tooltip = { text = "" }
 
     frame:SetScript("OnEnter", function()
-        tooltip:ClearAllPoints()
-        if WoWPro.GetSide(WoWPro.MainFrame) == "TOP" then
-            tooltip:SetPoint("TOPLEFT", frame, "BOTTOMRIGHT", 0, 0)
-        else
-            tooltip:SetPoint("BOTTOMLEFT", frame, "TOPRIGHT", 0, 0)
+        local text = action.tooltip and action.tooltip.text
+        if text and text ~= "" then
+            local gt = _G.GameTooltip
+            local backdrop = {
+                bgFile = [[Interface\Tooltips\UI-Tooltip-Background]],
+                edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],
+                tile = true, tileSize = 16, edgeSize = 16,
+                insets = { left = 4, right = 3, top = 4, bottom = 3 }
+            }
+            gt:SetBackdrop(backdrop)
+            gt:SetBackdropColor(0, 0, 0, 0.95)
+            gt:SetOwner(frame, "ANCHOR_RIGHT")
+            gt:SetText(text, nil, nil, nil, nil, true)
+            gt:Show()
         end
-        tooltiptext:SetHeight(125)
-        tooltiptext:SetHeight(tooltiptext:GetStringHeight())
-        tooltip:SetHeight(tooltiptext:GetStringHeight()+20)
-        tooltip:Show()
     end)
     frame:SetScript("OnLeave", function()
-        tooltip:Hide()
+        _G.GameTooltip:Hide()
     end)
-    action.tooltip = tooltip
 
     return action
 end
@@ -578,49 +560,11 @@ end
 
 function WoWPro:CreateGuideRow(parent, rowHeight)
     local row = _G.CreateFrame("Frame", nil, parent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
-    local tooltip = WoWPro.GuideRowTooltip
-    local tooltiptext = tooltip.tooltiptext
-    tooltip:SetFrameLevel(row:GetFrameLevel() + 1)
     row:SetPoint("LEFT", 12, 0)
     row:SetHeight(rowHeight or 25)
 
     row.check = WoWPro:CreateCheck(row)
     row.iconTexture = WoWPro:CreateIcon(row, row.check)
-    row.iconTexture.frame:SetScript("OnEnter", function()
-        if row.index then
-            tooltip:ClearAllPoints()
-            if WoWPro.GetSide(WoWPro.MainFrame) == "TOP" then
-                tooltip:SetPoint("TOPLEFT", row.iconTexture.frame, "BOTTOMRIGHT", 2, 2)
-            else
-                tooltip:SetPoint("BOTTOMLEFT", row.iconTexture.frame, "TOPRIGHT", 2, -2)
-            end
-            tooltiptext:SetHeight(125)
-            -- Step Tooltip
-            if WoWPro.why and WoWPro.why[row.index] and WoWPro.active[row.index] and not WoWPro.QID[row.index] then
-                tooltiptext:SetText(("Step %d/ACTIVE %s: %s"):format(row.index, tostring(WoWPro.active[row.index]),
-                                                                     tostring(WoWPro.why[row.index])))
-            elseif WoWPro.why and WoWPro.why[row.index] and not WoWPro.active[row.index] and WoWPro.QID[row.index] then
-                tooltiptext:SetText(("Step %d/QID %s: %s"):format(row.index, tostring(WoWPro.QID[row.index]),
-                                                                     tostring(WoWPro.why[row.index])))
-            elseif WoWPro.why and WoWPro.why[row.index] and WoWPro.active[row.index] and  WoWPro.QID[row.index] then
-                tooltiptext:SetText(("Step %d/QID %s/ACTIVE %s: %s"):format(row.index, tostring(WoWPro.QID[row.index]),
-                                                                            tostring(WoWPro.active[row.index]),
-                                                                            tostring(WoWPro.why[row.index])))
-            elseif WoWPro.why and WoWPro.why[row.index] then
-                tooltiptext:SetText(("Step %d: %s"):format(row.index, tostring(WoWPro.why[row.index])))
-            elseif row.iconTexture and row.iconTexture.tooltip and row.iconTexture.tooltip.text then
-                tooltiptext:SetText(tostring(row.iconTexture.tooltip.text:GetText() or ""))
-            else
-                tooltiptext:SetText(("Step %d"):format(row.index))
-            end
-            tooltiptext:SetHeight(tooltiptext:GetStringHeight())
-            tooltip:SetHeight(tooltiptext:GetStringHeight()+20)
-            tooltip:Show()
-        end
-    end)
-    row.iconTexture.frame:SetScript("OnLeave", function()
-        tooltip:Hide()
-    end)
 --- row.iconTexture.frame:RegisterForClicks("AnyUp")
 --- row.iconTexture.frame:SetScript("OnClick", function(self, button, down)
 ---     WoWPro.PickQuestline(WoWPro.QID[row.index], WoWPro.step[row.index])

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -53,12 +53,13 @@ function WoWPro:CreateAction(parent, anchor)
     frame:SetPoint("LEFT", anchor, "RIGHT", 3, 0)
     frame:SetWidth(16)
     frame:SetHeight(16)
+    frame:EnableMouse(true)
 
     local action = frame:CreateTexture()
     action.frame = frame
     action:SetAllPoints()
 
-    local tooltip = _G.CreateFrame("Frame", nil, frame, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
+    local tooltip = _G.CreateFrame("Frame", nil, _G.UIParent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     tooltip:SetBackdrop( {
         bgFile = [[Interface\CHARACTERFRAME\UI-Party-Background]],
         edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],
@@ -83,7 +84,12 @@ function WoWPro:CreateAction(parent, anchor)
     tooltip.text = tooltiptext
 
     frame:SetScript("OnEnter", function()
-        tooltip:SetPoint("BOTTOMLEFT", frame, "TOPRIGHT", 0, 0)
+        tooltip:ClearAllPoints()
+        if WoWPro.GetSide(WoWPro.MainFrame) == "TOP" then
+            tooltip:SetPoint("TOPLEFT", frame, "BOTTOMRIGHT", 0, 0)
+        else
+            tooltip:SetPoint("BOTTOMLEFT", frame, "TOPRIGHT", 0, 0)
+        end
         tooltiptext:SetHeight(125)
         tooltiptext:SetHeight(tooltiptext:GetStringHeight())
         tooltip:SetHeight(tooltiptext:GetStringHeight()+20)
@@ -574,7 +580,6 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
     local row = _G.CreateFrame("Frame", nil, parent, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     local tooltip = WoWPro.GuideRowTooltip
     local tooltiptext = tooltip.tooltiptext
-    tooltip:SetParent(parent)
     tooltip:SetFrameLevel(row:GetFrameLevel() + 1)
     row:SetPoint("LEFT", 12, 0)
     row:SetHeight(rowHeight or 25)
@@ -582,22 +587,31 @@ function WoWPro:CreateGuideRow(parent, rowHeight)
     row.check = WoWPro:CreateCheck(row)
     row.action = WoWPro:CreateAction(row, row.check)
     row.action.frame:SetScript("OnEnter", function()
-        if row.index and WoWPro.why and WoWPro.why[row.index] then
-            tooltip:SetPoint("BOTTOMLEFT", row.action.frame, "TOPRIGHT", 2, -2)
+        if row.index then
+            tooltip:ClearAllPoints()
+            if WoWPro.GetSide(WoWPro.MainFrame) == "TOP" then
+                tooltip:SetPoint("TOPLEFT", row.action.frame, "BOTTOMRIGHT", 2, 2)
+            else
+                tooltip:SetPoint("BOTTOMLEFT", row.action.frame, "TOPRIGHT", 2, -2)
+            end
             tooltiptext:SetHeight(125)
             -- Step Tooltip
-            if WoWPro.active[row.index] and not WoWPro.QID[row.index] then
+            if WoWPro.why and WoWPro.why[row.index] and WoWPro.active[row.index] and not WoWPro.QID[row.index] then
                 tooltiptext:SetText(("Step %d/ACTIVE %s: %s"):format(row.index, tostring(WoWPro.active[row.index]),
                                                                      tostring(WoWPro.why[row.index])))
-            elseif not WoWPro.active[row.index] and WoWPro.QID[row.index] then
+            elseif WoWPro.why and WoWPro.why[row.index] and not WoWPro.active[row.index] and WoWPro.QID[row.index] then
                 tooltiptext:SetText(("Step %d/QID %s: %s"):format(row.index, tostring(WoWPro.QID[row.index]),
                                                                      tostring(WoWPro.why[row.index])))
-            elseif WoWPro.active[row.index] and  WoWPro.QID[row.index] then
+            elseif WoWPro.why and WoWPro.why[row.index] and WoWPro.active[row.index] and  WoWPro.QID[row.index] then
                 tooltiptext:SetText(("Step %d/QID %s/ACTIVE %s: %s"):format(row.index, tostring(WoWPro.QID[row.index]),
                                                                             tostring(WoWPro.active[row.index]),
                                                                             tostring(WoWPro.why[row.index])))
-            else
+            elseif WoWPro.why and WoWPro.why[row.index] then
                 tooltiptext:SetText(("Step %d: %s"):format(row.index, tostring(WoWPro.why[row.index])))
+            elseif row.action and row.action.tooltip and row.action.tooltip.text then
+                tooltiptext:SetText(tostring(row.action.tooltip.text:GetText() or ""))
+            else
+                tooltiptext:SetText(("Step %d"):format(row.index))
             end
             tooltiptext:SetHeight(tooltiptext:GetStringHeight())
             tooltip:SetHeight(tooltiptext:GetStringHeight()+20)

--- a/WoWPro_Dailies/WoWPro_Dailies_CurrentGuide.lua
+++ b/WoWPro_Dailies/WoWPro_Dailies_CurrentGuide.lua
@@ -121,8 +121,10 @@ frame:SetScript("OnShow", function()
 
             local action = WoWPro.action[index]
             row.iconTexture:SetTexture(WoWPro.Dailies.actiontypes[action])
+            row.iconTexture.tooltip.text = WoWPro.actionlabels[action] or ""
             if WoWPro.noncombat[index] then
                 row.iconTexture:SetTexture("Interface\\AddOns\\WoWPro\\Textures\\Config.tga")
+                row.iconTexture.tooltip.text = "No Combat"
             end
 
             local note = WoWPro.note[index]

--- a/WoWPro_Dailies/WoWPro_Dailies_CurrentGuide.lua
+++ b/WoWPro_Dailies/WoWPro_Dailies_CurrentGuide.lua
@@ -61,9 +61,9 @@ frame:SetScript("OnShow", function()
         row:SetHeight(ROWHEIGHT)
 
         row.check = WoWPro:CreateCheck(row)
-        row.action = WoWPro:CreateAction(row, row.check)
-        row.step = WoWPro:CreateStep(row, row.action)
-        row.note = WoWPro:CreateNote(row, row.action)
+        row.iconTexture = WoWPro:CreateIcon(row, row.check)
+        row.step = WoWPro:CreateStep(row, row.iconTexture)
+        row.note = WoWPro:CreateNote(row, row.iconTexture)
 
         rows[i] = row
     end
@@ -120,9 +120,9 @@ frame:SetScript("OnShow", function()
             row.step:SetText(step)
 
             local action = WoWPro.action[index]
-            row.action:SetTexture(WoWPro.Dailies.actiontypes[action])
+            row.iconTexture:SetTexture(WoWPro.Dailies.actiontypes[action])
             if WoWPro.noncombat[index] then
-                row.action:SetTexture("Interface\\AddOns\\WoWPro\\Textures\\Config.tga")
+                row.iconTexture:SetTexture("Interface\\AddOns\\WoWPro\\Textures\\Config.tga")
             end
 
             local note = WoWPro.note[index]


### PR DESCRIPTION
** Not sure if this different than the fix that Spoony presented earlier.

**Bug**
- The tooltip was being drawn inside a box that cuts off anything that sticks out.
- So when the tooltip appeared near the top, its top got chopped.

**What we changed:**
- We moved the tooltip to the main screen layer (not inside that cutting box).
- We still make it appear next to the step icon.
- If the guide is near the top of the screen, we show the tooltip below the icon instead of above it.

**So now:**
- It can extend past the guide window without being clipped.
- It won’t get cut off at the top.


_Researched and prepared using GPT-5-3-Codex_