### PR TITLE
Previous Recursive fix wasn't enough

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -18,6 +18,8 @@ WoWPro.mygroupsteps = {}
 WoWPro.myGroupTrack = {}
 WoWPro.playerGroup = {}
 
+WoWPro.UpdateGuideRealInProgress = false
+
 -- Debug toggles
 WoWPro.DEBUG_STICKY_PAIRING = false -- Set to true to enable sticky pairing debug output
 WoWPro.DEBUG_REPEATABLE = false -- Set to true to enable debug output for repeatable A step resets and quest log changes
@@ -39,6 +41,10 @@ end
 
 
 local quids_debug = false
+
+local function CanCompleteStepImmediateRefresh(step)
+    return step == WoWPro.ActiveStep and WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible() and not WoWPro.InitLockdown and not _G.InCombatLockdown()
+end
 
 local function QidMapReduce(list, default, or_string, and_string, func, why, debug, abs_quid)
     if not list then
@@ -2021,13 +2027,19 @@ function WoWPro.UpdateGuideRealSlow(From)
 end
 
 function WoWPro.UpdateGuideReal(From)
-    local GID = WoWProDB.char.currentguide
-    local why = ""
-    for who, count in pairs(From) do
-        why = why .. ("[%s]=%s "):format(tostring(who), tostring(count))
+    if WoWPro.UpdateGuideRealInProgress then
+        WoWPro:dbp("UpdateGuideReal(): nested update suppressed")
+        return
     end
-    WoWPro:dbp("UpdateGuideReal(%s): Running", why)
-    if not WoWPro.GuideFrame:IsVisible() then
+    WoWPro.UpdateGuideRealInProgress = true
+    local function runUpdate()
+        local GID = WoWProDB.char.currentguide
+        local why = ""
+        for who, count in pairs(From) do
+            why = why .. ("[%s]=%s "):format(tostring(who), tostring(count))
+        end
+        WoWPro:dbp("UpdateGuideReal(%s): Running", why)
+        if not WoWPro.GuideFrame:IsVisible() then
         -- Cinematic hides things (or user collapsed frame with double-click).
         -- Only re-queue if the user did not intentionally collapse the frame.
         if not WoWPro.UserCollapsed then
@@ -2235,6 +2247,9 @@ function WoWPro.UpdateGuideReal(From)
         WoWPro.ZONE_CHANGED_NEW_AREA("ZONE_CHANGED_NEW_AREA_GUIDE_UPDATE")
         WoWPro.EventReplayStart()
     end
+end
+    runUpdate()
+    WoWPro.UpdateGuideRealInProgress = false
 end
 
 
@@ -4190,9 +4205,8 @@ function WoWPro.CompleteStep(step, why, noUpdate)
             return true
         end
     end
-    WoWPro.why[step] = why
     if not noUpdate then
-        if step == WoWPro.ActiveStep and WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible() and not WoWPro.InitLockdown and not _G.InCombatLockdown() then
+        if CanCompleteStepImmediateRefresh(step) then
             WoWPro:print("BUCKET_BYPASS: CompleteStep(%d) ActiveStep=%s visible=%s initLockdown=%s combat=%s immediate refresh", step, tostring(WoWPro.ActiveStep), tostring(WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()), tostring(WoWPro.InitLockdown), tostring(_G.InCombatLockdown()))
             WoWPro:RemoveMapPoint()
             WoWPro.UpdateGuideReal({["WoWPro.CompleteStep"] = 1})

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -4609,27 +4609,23 @@ function WoWPro:IsQuestFlaggedCompleted(qid,force)
         WoWProCharDB.completedQIDsWarband = {}
     end
 
-    if not force and type(WoWProCharDB.completedQIDs[QID]) ~= "nil" then
-        if QID > 0 then
-            if is_int(QID) then
-                return questCompleted(QID, force)
-            else
-                QID = floor(QID)
-                WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]
-                return WoWProCharDB.completedQIDs[-QID]
-            end
-        else
-            local value = questCompleted(-QID, force)
-            return not value
-        end
+    local cacheKey = QID
+    if QID > 0 and not is_int(QID) then
+        cacheKey = -floor(QID)
     end
+
+    if not force and type(WoWProCharDB.completedQIDs[cacheKey]) ~= "nil" then
+        return WoWProCharDB.completedQIDs[cacheKey]
+    end
+
     if QID > 0 then
         if is_int(QID) then
             return questCompleted(QID, force)
         else
-            QID = floor(QID)
-            WoWProCharDB.completedQIDs[-QID] = not WoWPro.QuestLog[-QID]
-            return WoWProCharDB.completedQIDs[QID]
+            local baseQID = floor(QID)
+            local value = not WoWPro.QuestLog[-baseQID]
+            WoWProCharDB.completedQIDs[-baseQID] = value
+            return value
         end
     else
         return not questCompleted(-QID, force)


### PR DESCRIPTION
I fixed a bug in WoWPro_Broker.lua where completing a step could call `UpdateGuideReal()` while the guide was already updating, which caused a recursive loop and overflow.

The previous fix added a guard, but the problem was that `CompleteStep()` could still choose the direct `UpdateGuideReal()` path too often. That fast path can still be dangerous if the guide is already in the middle of updating, so the fix is to only do it when it is clearly safe and otherwise fall back to the normal queued update.

The code now only does an immediate refresh when it is safe to do so, and it keeps the existing `UpdateGuideRealInProgress` guard to stop nested updates. This should prevent the guide from recursing and crashing during step completion.

***
** I'm also tacking on a fix for a bug that was discovered while researching the original issue.

**Root cause:** 
- Decimal QIDs like `1234.1` or `1234.2` could be checked using the wrong internal key.
- That means the addon might think a quest step is completed when it is not, or not completed when it is.
- Guides using decimal QIDs could fail to advance correctly or skip steps incorrectly.
- **In short:** fractional QIDs would report the wrong completion status.

**10 years in hiding**
- If a guide uses plain integer QIDs or the player never reaches that exact step, the bug stays hidden.
- Also, the wrong result can be subtle: the guide may still work most of the time, or it may only skip one step.
- it was a rare, edge-case bug tied to a special QID form, so it could easily go unnoticed.

**Fix**
- In `WoWPro:IsQuestFlaggedCompleted(qid, force)` the code now detects positive decimal QIDs like `1234.1`.
- It uses` -floor(QID)` as the cache key instead of trying to cache the raw decimal.
- For a decimal QID, it checks completion using the base quest ID `(floor(QID))` and stores the result under that negative base key.

_So the fix is_: when QID is positive and not an integer, normalize it by `-floor(QID)` before caching and checking completion.