### PR TITLE
Potential fix for guide frame jumping to bottom of screen

### DIFF
--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -120,12 +120,16 @@ function WoWPro:DragSet()
         end)
         WoWPro.ButtonBar:SetScript("OnMouseUp", function(this, button)
             if button == "LeftButton" and WoWProDB.profile.drag then
-                WoWPro.MainFrame:StopMovingOrSizing()
-                WoWPro.MainFrame:SetUserPlaced(false)
-                WoWPro:StopMoveClamp()
-                WoWPro:DisableLeftHandedIfOffScreen()
-                WoWPro.SetMouseNotesPoints()
-                WoWPro.AnchorStore("OnMouseUp0")
+                if not _G.InCombatLockdown() then
+                    WoWPro.MainFrame:StopMovingOrSizing()
+                    WoWPro.MainFrame:SetUserPlaced(false)
+                    WoWPro:StopMoveClamp()
+                    WoWPro:DisableLeftHandedIfOffScreen()
+                    WoWPro.SetMouseNotesPoints()
+                    WoWPro.AnchorStore("OnMouseUp0")
+                else
+                    WoWPro:Print("Cannot stop moving WoWPro frame while in combat.")
+                end
                 WoWPro.InhibitAnchorRestore = false
             end
         end)
@@ -146,12 +150,16 @@ function WoWPro:DragSet()
         end)
         WoWPro.Titlebar:SetScript("OnMouseUp", function(this, button)
             if button == "LeftButton" and WoWProDB.profile.drag then
-                WoWPro.MainFrame:StopMovingOrSizing()
-                WoWPro.MainFrame:SetUserPlaced(false)
-                WoWPro:StopMoveClamp()
-                WoWPro:DisableLeftHandedIfOffScreen()
-                WoWPro.SetMouseNotesPoints()
-                WoWPro.AnchorStore("OnMouseUpTitlebar")
+                if not _G.InCombatLockdown() then
+                    WoWPro.MainFrame:StopMovingOrSizing()
+                    WoWPro.MainFrame:SetUserPlaced(false)
+                    WoWPro:StopMoveClamp()
+                    WoWPro:DisableLeftHandedIfOffScreen()
+                    WoWPro.SetMouseNotesPoints()
+                    WoWPro.AnchorStore("OnMouseUpTitlebar")
+                else
+                    WoWPro:Print("Cannot stop moving WoWPro frame while in combat.")
+                end
                 WoWPro.InhibitAnchorRestore = false
             end
         end)

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -107,9 +107,13 @@ function WoWPro:DragSet()
     if WoWProDB.profile.drag then
         WoWPro.ButtonBar:SetScript("OnMouseDown", function(this, button)
             if button == "LeftButton" and WoWProDB.profile.drag then
-                WoWPro.InhibitAnchorRestore = true
-                WoWPro:StartMoveClamp()
-                WoWPro.MainFrame:StartMoving()
+                if not _G.InCombatLockdown() then
+                    WoWPro.InhibitAnchorRestore = true
+                    WoWPro:StartMoveClamp()
+                    WoWPro.MainFrame:StartMoving()
+                else
+                    WoWPro:Print("Cannot drag WoWPro frame while in combat.")
+                end
             elseif button == "RightButton" then
                 WoWPro.EasyMenu(WoWPro.DropdownMenu, this, "cursor", 0 , 0, "MENU");
             end
@@ -129,9 +133,13 @@ function WoWPro:DragSet()
         -- Enable titlebar dragging regardless of button bar visibility
         WoWPro.Titlebar:SetScript("OnMouseDown", function(this, button)
             if button == "LeftButton" and WoWProDB.profile.drag then
-                WoWPro.InhibitAnchorRestore = true
-                WoWPro:StartMoveClamp()
-                WoWPro.MainFrame:StartMoving()
+                if not _G.InCombatLockdown() then
+                    WoWPro.InhibitAnchorRestore = true
+                    WoWPro:StartMoveClamp()
+                    WoWPro.MainFrame:StartMoving()
+                else
+                    WoWPro:Print("Cannot drag WoWPro frame while in combat.")
+                end
             elseif button == "RightButton" then
                 WoWPro.EasyMenu(WoWPro.DropdownMenu, this, "cursor", 0 , 0, "MENU");
             end


### PR DESCRIPTION
Update frame drag handlers in WoWPro_Frames.lua to avoid calling StartMoving() during combat lockdown and log a friendly message instead.