### PR TITLE
Ensure recorder shows steps

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1294,18 +1294,30 @@ function WoWPro:RowUpdate(offset)
     -- Paired S completion is handled in UpdateGuideReal().
     -- US steps should be visible even if their paired sticky S is not yet complete.
     local stepList = {}
-    for _, v in ipairs(stickySteps) do
-        table.insert(stepList, v)
-    end
-    for _, v in ipairs(regularSteps) do
-        if not completion[v] then
-            if WoWPro.unsticky[v] and not WoWPro.sticky[v] then
-                local foundSticky = WoWPro.FindPairedStickyStep(v)
-                if not foundSticky or completion[foundSticky] or v == WoWPro.ActiveStep then
+    if WoWPro.Recorder then
+        local firstStep = WoWPro.Recorder.SelectedStep or k or 1
+        if type(firstStep) ~= "number" or firstStep < 1 or firstStep > WoWPro.stepcount or not WoWPro.step[firstStep] then
+            firstStep = 1
+        end
+        WoWPro.Recorder.SelectedStep = firstStep
+        for idx = firstStep, math.min(WoWPro.stepcount, firstStep + 14) do
+            table.insert(stepList, idx)
+        end
+        stickySteps = {}
+    else
+        for _, v in ipairs(stickySteps) do
+            table.insert(stepList, v)
+        end
+        for _, v in ipairs(regularSteps) do
+            if not completion[v] then
+                if WoWPro.unsticky[v] and not WoWPro.sticky[v] then
+                    local foundSticky = WoWPro.FindPairedStickyStep(v)
+                    if not foundSticky or completion[foundSticky] or v == WoWPro.ActiveStep then
+                        table.insert(stepList, v)
+                    end
+                else
                     table.insert(stepList, v)
                 end
-            else
-                table.insert(stepList, v)
             end
         end
     end

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -1331,13 +1331,14 @@ function WoWPro.Recorder:CreateRecorderFrame()
                     values = function()
                         local infoTable = {}
                         for GID, guideInfo in pairs(WoWPro.Guides) do
+                            local guideName = WoWPro:GetGuideName(GID)
                             if WoWPro.Recorder.Advanced then
-                                infoTable[GID] = GID .." "..tostring(guideInfo.zone).." by "..tostring(guideInfo.author)
+                                infoTable[GID] = guideName .." ("..GID..") "..tostring(guideInfo.zone).." by "..tostring(guideInfo.author)
                                 if WoWPro_RecorderDB and WoWPro_RecorderDB[GID] then
                                     infoTable[GID] = "!" .. infoTable[GID]
                                 end
                             else
-                                infoTable[GID] = GID
+                                infoTable[GID] = guideName
                             end
                         end
                         return infoTable
@@ -1382,12 +1383,19 @@ function WoWPro.Recorder:CreateRecorderFrame()
                     name = "Delete",
                     width = "full",
                     func = function(info,val)
-                        if WoWPro.Guides[WoWProDB.char.currentguide] then
-                            if WoWPro.Guides[WoWProDB.char.currentguide].original then
-                                WoWPro.Guides[WoWProDB.char.currentguide] = WoWPro.Guides[WoWProDB.char.currentguide].original
+                        local GID = WoWProDB.char.currentguide
+                        if GID and WoWPro.Guides[GID] then
+                            if WoWPro.Guides[GID].original then
+                                WoWPro.Guides[GID] = WoWPro.Guides[GID].original
+                            else
+                                WoWPro.Guides[GID] = nil
                             end
-                            WoWPro_RecorderDB[WoWProDB.char.currentguide] = nil
                         end
+                        if GID and WoWPro_RecorderDB then
+                            WoWPro_RecorderDB[GID] = nil
+                        end
+                        WoWProDB.char.currentguide = nil
+                        WoWPro.Recorder.SelectedStep = nil
                         WoWPro:LoadGuide()
                         dialog:Close("WoWPro Recorder - Delete");
 


### PR DESCRIPTION
When the recorder is active, build the visible row list directly from the recorded guide steps instead, starting from the selected step.

This keeps normal guide filtering unchanged outside recorder mode while allowing recorded guides to display their editable steps.

After
<img width="375" height="132" alt="image" src="https://github.com/user-attachments/assets/d4d3cfe5-bc01-4c6e-a86d-13eec0dc133f" />

Before 

<img width="372" height="207" alt="image" src="https://github.com/user-attachments/assets/041f891e-1368-4b8d-9e68-c5566066bd7d" />

