### PR TITLE
replace deprecated Lua 4 functions with modern equivalents

### DIFF
--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -1,5 +1,5 @@
 -- luacheck: globals tostring tonumber string hooksecurefunc
--- luacheck: globals select foreach ipairs pairs next tinsert type unpack
+-- luacheck: globals select ipairs pairs next tinsert type unpack
 
 --------------------------
 --  WoWPro_Events.lua   --
@@ -468,16 +468,16 @@ WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 				if (WoWPro.playerGroup[sender] ~= nil) then
 					local tbl = {string.split(" ", message)}
 					WoWPro.playerGroup[sender]["step"] = {}
-					foreach(tbl, function(k,v)
+					for k,v in ipairs(tbl) do
 						if (v ~= "") then
 							WoWPro.playerGroup[sender]["step"][tonumber(v)] = true
 						end
-					end);
+					end
 					WoWPro.mygroupsteps = {}
 					for index,gvalue in pairs(WoWPro.playerGroup) do
-						foreach(gvalue["step"], function(gkey,gval)
+						for gkey,gval in pairs(gvalue["step"]) do
 							WoWPro.mygroupsteps[tonumber(gkey)] = true
-						end);
+						end
 					end
 				else
 					_G.C_ChatInfo.SendAddonMessage("WoWPro", "NeedGroup NOW" , "PARTY")
@@ -489,9 +489,9 @@ WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 					WoWPro.playerGroup[sender]["track"][tonumber(gindex)] = gtrack
 					WoWPro.myGroupTrack = {}
 					for index,gvalue in pairs(WoWPro.playerGroup) do
-						foreach(gvalue["track"], function(gkey,gval)
+						for gkey,gval in pairs(gvalue["track"]) do
 							WoWPro.myGroupTrack[tonumber(gkey)] = (WoWPro.myGroupTrack[tonumber(gkey)] or "") .. "\n" .. gname .. ": " .. gval
-						end);
+						end
 					end
 				else
 					_G.C_ChatInfo.SendAddonMessage("WoWPro", "NeedGroup NOW" , "PARTY")

--- a/WoWPro/WoWPro_GuideRegistry.lua
+++ b/WoWPro/WoWPro_GuideRegistry.lua
@@ -115,7 +115,7 @@ function WoWPro.RegisterGuideInMenuList2(AddonType, GuideType, GuideName, GID, e
     end
     local AddonIndex = WoWPro.findIndexWithText(GuideMenuList, AddonAndType)
     if AddonIndex < 1 then
-        if table.getn(GuideMenuList) == 0 then
+        if #GuideMenuList == 0 then
             table.insert(GuideMenuList, { text = "Guide Group", isTitle = true })
         end
         local stuff = { text = AddonAndType, hasArrow = true, menuList = {} }
@@ -125,12 +125,12 @@ function WoWPro.RegisterGuideInMenuList2(AddonType, GuideType, GuideName, GID, e
             end
         end
         table.insert(GuideMenuList, stuff)
-        AddonIndex = table.getn(GuideMenuList)
+        AddonIndex = #GuideMenuList
     end
 
     local GuideNameIndex = WoWPro.findIndexWithText(GuideMenuList[AddonIndex].menuList, GuideName)
     if GuideNameIndex < 1 then
-        if table.getn(GuideMenuList[AddonIndex].menuList) == 0 then
+        if #GuideMenuList[AddonIndex].menuList == 0 then
             table.insert(GuideMenuList[AddonIndex].menuList,
                 { text = "Select a Guide", isTitle = true })
         end
@@ -148,7 +148,7 @@ function WoWPro.RegisterGuideInMenuList3(AddonType, GuideType, GuideName, GID, e
     local GuideMenuList = WoWPro.GuideMenuList
     local AddonIndex = WoWPro.findIndexWithText(GuideMenuList, AddonType)
     if AddonIndex < 1 then
-        if table.getn(GuideMenuList) == 0 then
+        if #GuideMenuList == 0 then
             table.insert(GuideMenuList, { text = "Guide Group", isTitle = true })
         end
         local stuff = { text = AddonType, hasArrow = true, menuList = {} }
@@ -158,21 +158,21 @@ function WoWPro.RegisterGuideInMenuList3(AddonType, GuideType, GuideName, GID, e
             end
         end
         table.insert(GuideMenuList, stuff)
-        AddonIndex = table.getn(GuideMenuList)
+        AddonIndex = #GuideMenuList
     end
 
     local GTypeIndex = WoWPro.findIndexWithText(GuideMenuList[AddonIndex].menuList, GuideType)
     if GTypeIndex < 1 then
-        if table.getn(GuideMenuList[AddonIndex].menuList) == 0 then
+        if #GuideMenuList[AddonIndex].menuList == 0 then
             table.insert(GuideMenuList[AddonIndex].menuList, { text = "Select a Guide Category", isTitle = true })
         end
         table.insert(GuideMenuList[AddonIndex].menuList, { text = GuideType, hasArrow = true, menuList = {} })
-        GTypeIndex = table.getn(GuideMenuList[AddonIndex].menuList)
+        GTypeIndex = #GuideMenuList[AddonIndex].menuList
     end
 
     local GuideNameIndex = WoWPro.findIndexWithText(GuideMenuList[AddonIndex].menuList[GTypeIndex].menuList, GuideName)
     if GuideNameIndex < 1 then
-        if table.getn(GuideMenuList[AddonIndex].menuList[GTypeIndex].menuList) == 0 then
+        if #GuideMenuList[AddonIndex].menuList[GTypeIndex].menuList == 0 then
             table.insert(GuideMenuList[AddonIndex].menuList[GTypeIndex].menuList,
                 { text = "Select a Guide", isTitle = true })
         end


### PR DESCRIPTION
- Replace table.getn(t) with # operator (8 occurrences in WoWPro_GuideRegistry.lua)
- Replace foreach() calls with for loops using ipairs/pairs (3 occurrences in WoWPro_Events.lua)
- Remove foreach from luacheck globals declaration in WoWPro_Events.lua

Both table.getn and foreach were removed in Lua 5.1+. These changes prevent nil-call errors if Blizzard removes their legacy compatibility shims.