### PR TITLE
That's not how it works

### DIFF
--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -413,7 +413,7 @@ end
 
 -- Auto-Complete: Set hearth --
 function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
-    if event and event ~= "HEARTHSTONE_BOUND" then
+    if event ~= "HEARTHSTONE_BOUND" then
         return
     end
     if not loc or (_G.issecretvalue and _G.issecretvalue(loc)) then


### PR DESCRIPTION
The `nil` test was done wrong.

TBH, there's no need to test for nil anyway.

if the event isn't "`HEARTHSTONE_BOUND`", then it doesn't matter anyway; return early.