### PR TITLE
Be Quiet: completion sound refactor

### DIFF
--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -24,7 +24,7 @@ function WoWPro:RecordTaxiLocations(...)
     end
     WoWPro:dbp("RecordTaxiLocations(%s): Step %s/%d [%s]?", tostring(_event), tostring(WoWPro.action[index]), index, tostring(WoWPro.step[index]))
     if (WoWPro.action[index] == 'f') and WoWProCharDB.Taxi[WoWPro.step[index]] then
-        WoWPro.CompleteStep(index, "RecordTaxiLocations")
+            WoWPro.CompleteStep(index, "RecordTaxiLocations", nil, { origin = "RecordTaxiLocations" })
     end
 end
 
@@ -102,7 +102,7 @@ function WoWPro:AutoCompleteGetFP(...)
              WoWPro:dbp(msg)
              if WoWPro.rows[i]:IsVisible() and WoWPro.action[index] == "f" then
                 if not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
-                    WoWPro.CompleteStep(index, "AutoCompleteGetFP("..msg..")")
+                        WoWPro.CompleteStep(index, "AutoCompleteGetFP("..msg..")", nil, { origin = "AutoCompleteGetFP" })
                     return
                 end
              end
@@ -181,7 +181,7 @@ function WoWPro.AutoCompleteBuff(unit, ...)
         if WoWPro.buff and WoWPro.buff[index] and  WoWPro:CheckPlayerForBuffs(WoWPro.buff[index]) then
             -- Log only the usefull ones!
             WoWPro:LogEvent("UNIT_AURA", unit, ...)
-            WoWPro.CompleteStep(index, "AutoCompleteBuff")
+            WoWPro.CompleteStep(index, "AutoCompleteBuff", nil, { origin = "AutoCompleteBuff" })
         end
     end
 end
@@ -191,7 +191,7 @@ function WoWPro:AutoCompleteDeath(...)
     local index = WoWPro.rows[1].index
     local dead = _G.UnitIsDeadOrGhost("player")
     if (WoWPro.action[index] == "d" and dead) or (WoWPro.action[index] == "s" and not dead)then
-        WoWPro.CompleteStep(index, "AutoCompleteDeath")
+        WoWPro.CompleteStep(index, "AutoCompleteDeath", nil, { origin = "AutoCompleteDeath" })
     end
 end
 
@@ -270,7 +270,7 @@ function WoWPro.AutoCompleteLoot()
             end
             if allComplete and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
                 WoWPro:dbp("AutoCompleteLoot: Time to complete step.")
-                WoWPro.CompleteStep(index, "AutoCompleteLoot")
+                WoWPro.CompleteStep(index, "AutoCompleteLoot", nil, { origin = "AutoCompleteLoot" })
             else
                 WoWPro:dbp("AutoCompleteLoot: Not enough yet!")
             end
@@ -340,7 +340,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
 
                 -- Quest Turn-Ins --
                 if WoWPro.CompletingQuest and action == "T" and not completion and WoWPro.missingQuest == QID then
-                    WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.")
+                    WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.", nil, { origin = "AutoCompleteQuestUpdate" })
                     if not WoWPro.nocache[i] then
                         WoWProCharDB.completedQIDs[QID] = true
                     end
@@ -363,7 +363,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     elseif WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
                         break
                     else
-                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete", nil, { origin = "AutoCompleteQuestUpdate" })
                     end
                 end
 
@@ -375,7 +375,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     elseif WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
                         break
                     else
-                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog")
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog", nil, { origin = "AutoCompleteQuestUpdate" })
                         WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}
                         WoWPro.oldQuests[QID].complete = true -- We got it, dont let the recorder get it!
                     end
@@ -396,7 +396,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     end
                     if complete then
                         --if the step has been found to be complete, run the completion function
-                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: complete")
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: complete", nil, { origin = "AutoCompleteQuestUpdate" })
                     end
                 end
             end
@@ -438,7 +438,7 @@ function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
             if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
             and not guideData.completion[index] then
                 WoWPro:dbp("AutoCompleteSetHearth: completing h-step index %d step [%s] because hearth matches", index, loc)
-                WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate)
+                    WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate, { origin = "AutoCompleteSetHearth" })
             end
         end
     end
@@ -463,16 +463,16 @@ function WoWPro.AutoCompleteZone(index)
     if action == "F" or action == "H" or action == "b" or action == "P" or action == "R" then
         if not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[currentindex] then
             if (step == zonetext) or (step == subzonetext) then
-                WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..step)
+                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..step, nil, { origin = "AutoCompleteZone" })
                 return true
             end
             if (zoneTag == zonetext) or (zoneTag == subzonetext) then
-                WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone)
+                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone, nil, { origin = "AutoCompleteZone" })
                 return true
             end
             local _, _, mapId = WoWPro:GetPlayerZonePosition()
             if (tonumber(zoneTag) and tonumber(zoneTag) == mapId) then
-                WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone)
+                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone, nil, { origin = "AutoCompleteZone" })
                 return true
             end
         end
@@ -486,7 +486,7 @@ function WoWPro.AutoCompleteCriteria()
 
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
     if WoWPro.QID[qidx] and WoWPro:IsQuestFlaggedCompleted(WoWPro.QID[qidx],true) then
-        WoWPro.CompleteStep(qidx,"AutoCompleteCriteria-Quest")
+           WoWPro.CompleteStep(qidx,"AutoCompleteCriteria-Quest", nil, { origin = "AutoCompleteCriteria" })
     else
         WoWPro:UpdateGuide("WoWPro.AutoCompleteCriteria?")
     end
@@ -500,7 +500,7 @@ function WoWPro.AutoCompleteChest()
     if zone == "Timeless Isle" then
         local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
         if WoWPro.QID[qidx] and WoWPro:IsQuestFlaggedCompleted(WoWPro.QID[qidx],true) then
-            WoWPro.CompleteStep(qidx,"AutoCompleteChest")
+                WoWPro.CompleteStep(qidx,"AutoCompleteChest", nil, { origin = "AutoCompleteChest" })
         end
     end
 end
@@ -515,7 +515,7 @@ function WoWPro:AutoCompleteLevel(...)
             if not WoWProCharDB.Guide[GID].completion[i]
                 and WoWPro.level[i]
                 and tonumber(WoWPro.level[i]) <= newlevel then
-                    WoWPro.CompleteStep(i,"AutoCompleteLevel")
+                        WoWPro.CompleteStep(i,"AutoCompleteLevel", nil, { origin = "AutoCompleteLevel" })
             end
         end
     end

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -24,7 +24,7 @@ function WoWPro:RecordTaxiLocations(...)
     end
     WoWPro:dbp("RecordTaxiLocations(%s): Step %s/%d [%s]?", tostring(_event), tostring(WoWPro.action[index]), index, tostring(WoWPro.step[index]))
     if (WoWPro.action[index] == 'f') and WoWProCharDB.Taxi[WoWPro.step[index]] then
-            WoWPro.CompleteStep(index, "RecordTaxiLocations", nil, { origin = "RecordTaxiLocations" })
+            WoWPro.CompleteStep(index, "RecordTaxiLocations", nil, "RecordTaxiLocations")
     end
 end
 
@@ -102,7 +102,7 @@ function WoWPro:AutoCompleteGetFP(...)
              WoWPro:dbp(msg)
              if WoWPro.rows[i]:IsVisible() and WoWPro.action[index] == "f" then
                 if not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
-                        WoWPro.CompleteStep(index, "AutoCompleteGetFP("..msg..")", nil, { origin = "AutoCompleteGetFP" })
+                        WoWPro.CompleteStep(index, "AutoCompleteGetFP("..msg..")", nil, "AutoCompleteGetFP")
                     return
                 end
              end
@@ -181,7 +181,7 @@ function WoWPro.AutoCompleteBuff(unit, ...)
         if WoWPro.buff and WoWPro.buff[index] and  WoWPro:CheckPlayerForBuffs(WoWPro.buff[index]) then
             -- Log only the usefull ones!
             WoWPro:LogEvent("UNIT_AURA", unit, ...)
-            WoWPro.CompleteStep(index, "AutoCompleteBuff", nil, { origin = "AutoCompleteBuff" })
+            WoWPro.CompleteStep(index, "AutoCompleteBuff", nil, "AutoCompleteBuff")
         end
     end
 end
@@ -191,7 +191,7 @@ function WoWPro:AutoCompleteDeath(...)
     local index = WoWPro.rows[1].index
     local dead = _G.UnitIsDeadOrGhost("player")
     if (WoWPro.action[index] == "d" and dead) or (WoWPro.action[index] == "s" and not dead)then
-        WoWPro.CompleteStep(index, "AutoCompleteDeath", nil, { origin = "AutoCompleteDeath" })
+        WoWPro.CompleteStep(index, "AutoCompleteDeath", nil, "AutoCompleteDeath")
     end
 end
 
@@ -270,7 +270,7 @@ function WoWPro.AutoCompleteLoot()
             end
             if allComplete and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
                 WoWPro:dbp("AutoCompleteLoot: Time to complete step.")
-                WoWPro.CompleteStep(index, "AutoCompleteLoot", nil, { origin = "AutoCompleteLoot" })
+                WoWPro.CompleteStep(index, "AutoCompleteLoot", nil, "AutoCompleteLoot")
             else
                 WoWPro:dbp("AutoCompleteLoot: Not enough yet!")
             end
@@ -340,7 +340,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
 
                 -- Quest Turn-Ins --
                 if WoWPro.CompletingQuest and action == "T" and not completion and WoWPro.missingQuest == QID then
-                    WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.", nil, { origin = "AutoCompleteQuestUpdate" })
+                    WoWPro.CompleteStep(i,"AutoCompleteQuestUpdate: quest turn-in.", nil, "AutoCompleteQuestUpdate")
                     if not WoWPro.nocache[i] then
                         WoWProCharDB.completedQIDs[QID] = true
                     end
@@ -363,7 +363,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     elseif WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
                         break
                     else
-                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete", nil, { origin = "AutoCompleteQuestUpdate" })
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete", nil, "AutoCompleteQuestUpdate")
                     end
                 end
 
@@ -375,7 +375,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     elseif WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
                         break
                     else
-                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog", nil, { origin = "AutoCompleteQuestUpdate" })
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog", nil, "AutoCompleteQuestUpdate")
                         WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}
                         WoWPro.oldQuests[QID].complete = true -- We got it, dont let the recorder get it!
                     end
@@ -396,7 +396,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
                     end
                     if complete then
                         --if the step has been found to be complete, run the completion function
-                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: complete", nil, { origin = "AutoCompleteQuestUpdate" })
+                        WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: complete", nil, "AutoCompleteQuestUpdate")
                     end
                 end
             end
@@ -438,7 +438,7 @@ function WoWPro:AutoCompleteSetHearth(event, loc, noUpdate)
             if WoWPro.action[index] == "h" and WoWPro.step[index] == loc
             and not guideData.completion[index] then
                 WoWPro:dbp("AutoCompleteSetHearth: completing h-step index %d step [%s] because hearth matches", index, loc)
-                    WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate, { origin = "AutoCompleteSetHearth" })
+                    WoWPro.CompleteStep(index, "AutoCompleteSetHearth", noUpdate, "AutoCompleteSetHearth")
             end
         end
     end
@@ -463,16 +463,16 @@ function WoWPro.AutoCompleteZone(index)
     if action == "F" or action == "H" or action == "b" or action == "P" or action == "R" then
         if not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[currentindex] then
             if (step == zonetext) or (step == subzonetext) then
-                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..step, nil, { origin = "AutoCompleteZone" })
+                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..step, nil, "AutoCompleteZone")
                 return true
             end
             if (zoneTag == zonetext) or (zoneTag == subzonetext) then
-                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone, nil, { origin = "AutoCompleteZone" })
+                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone, nil, "AutoCompleteZone")
                 return true
             end
             local _, _, mapId = WoWPro:GetPlayerZonePosition()
             if (tonumber(zoneTag) and tonumber(zoneTag) == mapId) then
-                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone, nil, { origin = "AutoCompleteZone" })
+                    WoWPro.CompleteStep(currentindex,"AutoCompleteZone:"..targetzone, nil, "AutoCompleteZone")
                 return true
             end
         end
@@ -486,7 +486,7 @@ function WoWPro.AutoCompleteCriteria()
 
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
     if WoWPro.QID[qidx] and WoWPro:IsQuestFlaggedCompleted(WoWPro.QID[qidx],true) then
-           WoWPro.CompleteStep(qidx,"AutoCompleteCriteria-Quest", nil, { origin = "AutoCompleteCriteria" })
+           WoWPro.CompleteStep(qidx,"AutoCompleteCriteria-Quest", nil, "AutoCompleteCriteria")
     else
         WoWPro:UpdateGuide("WoWPro.AutoCompleteCriteria?")
     end
@@ -500,7 +500,7 @@ function WoWPro.AutoCompleteChest()
     if zone == "Timeless Isle" then
         local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
         if WoWPro.QID[qidx] and WoWPro:IsQuestFlaggedCompleted(WoWPro.QID[qidx],true) then
-                WoWPro.CompleteStep(qidx,"AutoCompleteChest", nil, { origin = "AutoCompleteChest" })
+                WoWPro.CompleteStep(qidx,"AutoCompleteChest", nil, "AutoCompleteChest")
         end
     end
 end
@@ -515,7 +515,7 @@ function WoWPro:AutoCompleteLevel(...)
             if not WoWProCharDB.Guide[GID].completion[i]
                 and WoWPro.level[i]
                 and tonumber(WoWPro.level[i]) <= newlevel then
-                        WoWPro.CompleteStep(i,"AutoCompleteLevel", nil, { origin = "AutoCompleteLevel" })
+                        WoWPro.CompleteStep(i,"AutoCompleteLevel", nil, "AutoCompleteLevel")
             end
         end
     end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -966,9 +966,6 @@ function WoWPro:CheckFunction(row, button, down)
     elseif button == "RightButton" and row.check:GetChecked() then
         row.check:SetGold()
         WoWPro:dbp("WoWPro:CheckFunction: User marked step %d as complete.", row.index)
-        if WoWProDB.profile.checksound then
-            _G.PlaySoundFile(WoWProDB.profile.checksoundfile)
-        end
         -- if CompleteStep() did a LoadGuide, skip out.
         if WoWPro.CompleteStep(row.index,"Right-Click") then
             return

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -96,7 +96,7 @@ local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, soundC
     if alreadyComplete then
         return false
     end
-    if noUpdate then
+    if noUpdate and not (soundCtx and soundCtx.allowSoundWhileNoUpdate) then
         return false
     end
     if soundCtx and soundCtx.suppressSound then
@@ -2165,8 +2165,8 @@ function WoWPro.UpdateGuideReal(From)
         local guide = WoWProCharDB.Guide[GID]
         local foundSticky = WoWPro.FindPairedStickyStep(WoWPro.ActiveStep)
         if foundSticky and not guide.completion[foundSticky] then
-            SoundDiag("StickyPair complete us=%s sticky=%s", tostring(WoWPro.ActiveStep), tostring(foundSticky))
-            WoWPro.CompleteStep(foundSticky, "[Broker] Active US step paired completion", true)
+            SoundDiag("StickyPair complete us=%s sticky=%s visible=%s", tostring(WoWPro.ActiveStep), tostring(foundSticky), tostring(IsStepVisibleInGuide(foundSticky)))
+            WoWPro.CompleteStep(foundSticky, "[Broker] Active US step paired completion", true, { origin = "STICKY_UNSTICKY_PAIR", allowSoundWhileNoUpdate = true })
             if WoWPro.DEBUG_STICKY_PAIRING then
                 WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d", WoWPro.ActiveStep, foundSticky)
             end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -72,10 +72,40 @@ local function SoundDiag(fmt, ...)
     end
 end
 
--- Chapter 1 helper skeleton: centralized sound eligibility with feature parity.
+local function IsStepVisibleInGuide(step)
+    if not step then
+        return false
+    end
+    if not WoWPro.rows then
+        return false
+    end
+    for _, row in ipairs(WoWPro.rows) do
+        if row and row.index == step and row.IsVisible and row:IsVisible() then
+            return true
+        end
+    end
+    return false
+end
+
+-- Chapter 2 helper: universal visibility-gated completion sound policy.
 local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
     local checksoundEnabled = WoWProDB.profile.checksound
-    return checksoundEnabled and (not noUpdate) and (not alreadyComplete)
+    if not checksoundEnabled then
+        return false
+    end
+    if alreadyComplete then
+        return false
+    end
+    if noUpdate then
+        return false
+    end
+    if not (WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()) then
+        return false
+    end
+    if not IsStepVisibleInGuide(step) then
+        return false
+    end
+    return true
 end
 
 local function CanCompleteStepImmediateRefresh(step)
@@ -4218,13 +4248,17 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     WoWProCharDB.Guide[GID].completion = WoWProCharDB.Guide[GID].completion or {}
     local alreadyComplete = not not WoWProCharDB.Guide[GID].completion[step]
     local checksoundEnabled = WoWProDB.profile.checksound
+    local guideVisible = WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()
+    local stepVisible = IsStepVisibleInGuide(step)
     local soundEligible = ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
-    SoundDiag("CompleteStep step=%s origin=%s action=%s noUpdate=%s checksound=%s alreadyComplete=%s eligible=%s why=%q",
+    SoundDiag("CompleteStep step=%s origin=%s action=%s noUpdate=%s checksound=%s guideVisible=%s stepVisible=%s alreadyComplete=%s eligible=%s why=%q",
         tostring(step),
         SoundDiagOrigin(why),
         tostring(WoWPro.action[step]),
         tostring(noUpdate),
         tostring(checksoundEnabled),
+        tostring(guideVisible),
+        tostring(stepVisible),
         tostring(alreadyComplete),
         tostring(soundEligible),
         tostring(why))

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2160,15 +2160,16 @@ function WoWPro.UpdateGuideReal(From)
     WoWPro.ActiveStep = WoWPro.NextStepNotSticky(1)
     WoWPro:print("UpdateGuideReal(%d): ActiveStep=%s", WoWPro.ActiveStep, WoWPro.EmitSafeStep(WoWPro.ActiveStep))
 
-    -- If the active step is a US step, mark its paired S step complete now
+    -- If the active step is a US step, defer paired S completion until after rows are rebuilt.
+    -- This ensures sound visibility checks use current-pass row state, not stale row visibility.
+    local pendingPairedSticky
     if WoWPro.ActiveStep and WoWPro.unsticky[WoWPro.ActiveStep] and not WoWPro.sticky[WoWPro.ActiveStep] then
         local guide = WoWProCharDB.Guide[GID]
         local foundSticky = WoWPro.FindPairedStickyStep(WoWPro.ActiveStep)
         if foundSticky and not guide.completion[foundSticky] then
-            SoundDiag("StickyPair complete us=%s sticky=%s visible=%s", tostring(WoWPro.ActiveStep), tostring(foundSticky), tostring(IsStepVisibleInGuide(foundSticky)))
-            WoWPro.CompleteStep(foundSticky, "[Broker] Active US step paired completion", true, { origin = "STICKY_UNSTICKY_PAIR", allowSoundWhileNoUpdate = true })
+            pendingPairedSticky = foundSticky
             if WoWPro.DEBUG_STICKY_PAIRING then
-                WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d", WoWPro.ActiveStep, foundSticky)
+                WoWPro:dbp("[Broker] ActiveStep is US step %d: Queued paired S step %d for completion after row rebuild", WoWPro.ActiveStep, foundSticky)
             end
         end
     end
@@ -2243,6 +2244,14 @@ function WoWPro.UpdateGuideReal(From)
     -- Reloading until all stickies that need to unsticky have done so --
     while reload do
         reload = rowContentUpdate()
+    end
+
+    if pendingPairedSticky and not WoWProCharDB.Guide[GID].completion[pendingPairedSticky] then
+        SoundDiag("StickyPair complete us=%s sticky=%s visible=%s (post-row rebuild)", tostring(WoWPro.ActiveStep), tostring(pendingPairedSticky), tostring(IsStepVisibleInGuide(pendingPairedSticky)))
+        WoWPro.CompleteStep(pendingPairedSticky, "[Broker] Active US step paired completion", true, { origin = "STICKY_UNSTICKY_PAIR", allowSoundWhileNoUpdate = true })
+        if WoWPro.DEBUG_STICKY_PAIRING then
+            WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d after row rebuild", WoWPro.ActiveStep, pendingPairedSticky)
+        end
     end
 
     -- Updating the guide list or current guide panels if they are shown --

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -23,6 +23,7 @@ WoWPro.UpdateGuideRealInProgress = false
 -- Debug toggles
 WoWPro.DEBUG_STICKY_PAIRING = false -- Set to true to enable sticky pairing debug output
 WoWPro.DEBUG_REPEATABLE = false -- Set to true to enable debug output for repeatable A step resets and quest log changes
+WoWPro.DEBUG_SOUND_DIAGNOSTICS = false -- Set to true to enable chapter-0 completion sound diagnostics
 
 -- Encapsulated sticky count to prevent taint from direct global access
 local _activeStickyCount = 0
@@ -41,6 +42,35 @@ end
 
 
 local quids_debug = false
+
+local function SoundDiagOrigin(why)
+    why = tostring(why or "")
+    if why == "Right-Click" then
+        return "MANUAL_RIGHTCLICK"
+    end
+    if why:find("Active US step paired completion", 1, true) then
+        return "STICKY_UNSTICKY_PAIR"
+    end
+    if why:find("NextStep()", 1, true) then
+        return "NEXTSTEP_AUTOCOMPLETE"
+    end
+    if why:find("AutoComplete", 1, true) then
+        return "AUTOCOMPLETE_EVENT"
+    end
+    if why:find("autoarrival=", 1, true) then
+        return "MAPPING_AUTOARRIVAL"
+    end
+    if why:find("RecordTaxiLocations", 1, true) then
+        return "TRAVEL_TAXI_DISCOVERY"
+    end
+    return "OTHER"
+end
+
+local function SoundDiag(fmt, ...)
+    if WoWPro.DEBUG_SOUND_DIAGNOSTICS then
+        WoWPro:print("SOUND_DIAG: " .. tostring(fmt), ...)
+    end
+end
 
 local function CanCompleteStepImmediateRefresh(step)
     return step == WoWPro.ActiveStep and WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible() and not WoWPro.InitLockdown and not _G.InCombatLockdown()
@@ -2043,6 +2073,7 @@ function WoWPro.UpdateGuideReal(From)
             why = why .. ("[%s]=%s "):format(tostring(who), tostring(count))
         end
         WoWPro:dbp("UpdateGuideReal(%s): Running", why)
+        SoundDiag("UpdateGuideReal source=%s", why)
         if not WoWPro.GuideFrame:IsVisible() then
         -- Cinematic hides things (or user collapsed frame with double-click).
         -- Only re-queue if the user did not intentionally collapse the frame.
@@ -2098,6 +2129,7 @@ function WoWPro.UpdateGuideReal(From)
         local guide = WoWProCharDB.Guide[GID]
         local foundSticky = WoWPro.FindPairedStickyStep(WoWPro.ActiveStep)
         if foundSticky and not guide.completion[foundSticky] then
+            SoundDiag("StickyPair complete us=%s sticky=%s", tostring(WoWPro.ActiveStep), tostring(foundSticky))
             WoWPro.CompleteStep(foundSticky, "[Broker] Active US step paired completion", true)
             if WoWPro.DEBUG_STICKY_PAIRING then
                 WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d", WoWPro.ActiveStep, foundSticky)
@@ -2542,6 +2574,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             if WoWPro.available[guideIndex] then
                 if not WoWPro.QuestAvailable(WoWPro.available[guideIndex], false, "AVAILABLE") then
                     skip = true
+                    SoundDiag("NextStep AVAILABLE auto-complete step=%s action=%s available=%s qid=%s name=%q", tostring(guideIndex), tostring(stepAction), tostring(WoWPro.available[guideIndex]), tostring(QID), tostring(step))
                     WoWPro.CompleteStep(guideIndex,"NextStep(): Skipping step, available quest is currently complete or active")
                     break
                 end
@@ -4177,7 +4210,19 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     local GID = WoWProDB.char.currentguide
     WoWProCharDB.Guide[GID] = WoWProCharDB.Guide[GID] or {}
     WoWProCharDB.Guide[GID].completion = WoWProCharDB.Guide[GID].completion or {}
-    if WoWProDB.profile.checksound and (not noUpdate) and (not WoWProCharDB.Guide[GID].completion[step]) then
+    local alreadyComplete = not not WoWProCharDB.Guide[GID].completion[step]
+    local checksoundEnabled = WoWProDB.profile.checksound
+    local soundEligible = checksoundEnabled and (not noUpdate) and (not alreadyComplete)
+    SoundDiag("CompleteStep step=%s origin=%s action=%s noUpdate=%s checksound=%s alreadyComplete=%s eligible=%s why=%q",
+        tostring(step),
+        SoundDiagOrigin(why),
+        tostring(WoWPro.action[step]),
+        tostring(noUpdate),
+        tostring(checksoundEnabled),
+        tostring(alreadyComplete),
+        tostring(soundEligible),
+        tostring(why))
+    if soundEligible then
         _G.PlaySoundFile(WoWProDB.profile.checksoundfile)
     end
     why = tostring(why)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -88,7 +88,7 @@ local function IsStepVisibleInGuide(step)
 end
 
 -- Chapter 2 helper: universal visibility-gated completion sound policy.
-local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
+local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, soundCtx)
     local checksoundEnabled = WoWProDB.profile.checksound
     if not checksoundEnabled then
         return false
@@ -97,6 +97,9 @@ local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
         return false
     end
     if noUpdate then
+        return false
+    end
+    if soundCtx and soundCtx.suppressSound then
         return false
     end
     if not (WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()) then
@@ -4235,7 +4238,7 @@ function WoWPro.NextStepNotSticky(guideIndex)
 end
 
 -- Step Completion Tasks --
-function WoWPro.CompleteStep(step, why, noUpdate)
+function WoWPro.CompleteStep(step, why, noUpdate, soundCtx)
     if not step then
         WoWPro:print("WoWPro.CompleteStep called with nil step; reason='%s'", tostring(why))
         return false
@@ -4247,10 +4250,11 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     local checksoundEnabled = WoWProDB.profile.checksound
     local guideVisible = WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()
     local stepVisible = IsStepVisibleInGuide(step)
-    local soundEligible = ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
+    local soundEligible = ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, soundCtx)
+    local soundOrigin = (soundCtx and soundCtx.origin) or SoundDiagOrigin(why)
     SoundDiag("CompleteStep step=%s origin=%s action=%s noUpdate=%s checksound=%s guideVisible=%s stepVisible=%s alreadyComplete=%s eligible=%s why=%q",
         tostring(step),
-        SoundDiagOrigin(why),
+        tostring(soundOrigin),
         tostring(WoWPro.action[step]),
         tostring(noUpdate),
         tostring(checksoundEnabled),

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -88,7 +88,7 @@ local function IsStepVisibleInGuide(step)
 end
 
 -- Chapter 2 helper: universal visibility-gated completion sound policy.
-local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, soundCtx)
+local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, origin)
     local checksoundEnabled = WoWProDB.profile.checksound
     if not checksoundEnabled then
         return false
@@ -96,10 +96,7 @@ local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, soundC
     if alreadyComplete then
         return false
     end
-    if noUpdate and not (soundCtx and soundCtx.allowSoundWhileNoUpdate) then
-        return false
-    end
-    if soundCtx and soundCtx.suppressSound then
+    if noUpdate and origin ~= "STICKY_UNSTICKY_PAIR" then
         return false
     end
     if not (WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()) then
@@ -2248,7 +2245,7 @@ function WoWPro.UpdateGuideReal(From)
 
     if pendingPairedSticky and not WoWProCharDB.Guide[GID].completion[pendingPairedSticky] then
         SoundDiag("StickyPair complete us=%s sticky=%s visible=%s (post-row rebuild)", tostring(WoWPro.ActiveStep), tostring(pendingPairedSticky), tostring(IsStepVisibleInGuide(pendingPairedSticky)))
-        WoWPro.CompleteStep(pendingPairedSticky, "[Broker] Active US step paired completion", true, { origin = "STICKY_UNSTICKY_PAIR", allowSoundWhileNoUpdate = true })
+        WoWPro.CompleteStep(pendingPairedSticky, "[Broker] Active US step paired completion", true, "STICKY_UNSTICKY_PAIR")
         if WoWPro.DEBUG_STICKY_PAIRING then
             WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d after row rebuild", WoWPro.ActiveStep, pendingPairedSticky)
         end
@@ -4247,7 +4244,7 @@ function WoWPro.NextStepNotSticky(guideIndex)
 end
 
 -- Step Completion Tasks --
-function WoWPro.CompleteStep(step, why, noUpdate, soundCtx)
+function WoWPro.CompleteStep(step, why, noUpdate, origin)
     if not step then
         WoWPro:print("WoWPro.CompleteStep called with nil step; reason='%s'", tostring(why))
         return false
@@ -4259,8 +4256,8 @@ function WoWPro.CompleteStep(step, why, noUpdate, soundCtx)
     local checksoundEnabled = WoWProDB.profile.checksound
     local guideVisible = WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible()
     local stepVisible = IsStepVisibleInGuide(step)
-    local soundEligible = ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, soundCtx)
-    local soundOrigin = (soundCtx and soundCtx.origin) or SoundDiagOrigin(why)
+    local soundEligible = ShouldPlayCompletionSound(step, noUpdate, alreadyComplete, origin)
+    local soundOrigin = origin or SoundDiagOrigin(why)
     SoundDiag("CompleteStep step=%s origin=%s action=%s noUpdate=%s checksound=%s guideVisible=%s stepVisible=%s alreadyComplete=%s eligible=%s why=%q",
         tostring(step),
         tostring(soundOrigin),

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -72,6 +72,12 @@ local function SoundDiag(fmt, ...)
     end
 end
 
+-- Chapter 1 helper skeleton: centralized sound eligibility with feature parity.
+local function ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
+    local checksoundEnabled = WoWProDB.profile.checksound
+    return checksoundEnabled and (not noUpdate) and (not alreadyComplete)
+end
+
 local function CanCompleteStepImmediateRefresh(step)
     return step == WoWPro.ActiveStep and WoWPro.GuideFrame and WoWPro.GuideFrame:IsVisible() and not WoWPro.InitLockdown and not _G.InCombatLockdown()
 end
@@ -4212,7 +4218,7 @@ function WoWPro.CompleteStep(step, why, noUpdate)
     WoWProCharDB.Guide[GID].completion = WoWProCharDB.Guide[GID].completion or {}
     local alreadyComplete = not not WoWProCharDB.Guide[GID].completion[step]
     local checksoundEnabled = WoWProDB.profile.checksound
-    local soundEligible = checksoundEnabled and (not noUpdate) and (not alreadyComplete)
+    local soundEligible = ShouldPlayCompletionSound(step, noUpdate, alreadyComplete)
     SoundDiag("CompleteStep step=%s origin=%s action=%s noUpdate=%s checksound=%s alreadyComplete=%s eligible=%s why=%q",
         tostring(step),
         SoundDiagOrigin(why),

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -347,7 +347,7 @@ WoWPro.RegisterModernEventHandler("PET_BATTLE_PET_CHANGED", function(event,team)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
     if team == 1 and WoWPro.switch and WoWPro.switch[qidx] == 0 then
         -- Waiting for forced swap.
-        WoWPro.CompleteStep(qidx,"Forced Swap", nil, { origin = "PetBattleForcedSwap" })
+        WoWPro.CompleteStep(qidx,"Forced Swap", nil, "PetBattleForcedSwap")
     end
     end)
 
@@ -509,7 +509,7 @@ WoWPro.RegisterEventHandler("MERCHANT_SHOW" , function(event, ...)
         if WoWPro.rows[index]:IsVisible() then
             local qidx = WoWPro.rows[index].index
             if _G.CanMerchantRepair() and WoWPro.action[qidx] == "r" then
-                WoWPro.CompleteStep(qidx,"Talked to Repairing Merchant, index="..tostring(index), nil, { origin = "MerchantRepair" })
+                WoWPro.CompleteStep(qidx,"Talked to Repairing Merchant, index="..tostring(index), nil, "MerchantRepair")
             end
         else
             break

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -347,7 +347,7 @@ WoWPro.RegisterModernEventHandler("PET_BATTLE_PET_CHANGED", function(event,team)
     local qidx = WoWPro.rows[WoWPro:GetActiveStickyCount()+1].index
     if team == 1 and WoWPro.switch and WoWPro.switch[qidx] == 0 then
         -- Waiting for forced swap.
-        WoWPro.CompleteStep(qidx,"Forced Swap")
+        WoWPro.CompleteStep(qidx,"Forced Swap", nil, { origin = "PetBattleForcedSwap" })
     end
     end)
 
@@ -509,7 +509,7 @@ WoWPro.RegisterEventHandler("MERCHANT_SHOW" , function(event, ...)
         if WoWPro.rows[index]:IsVisible() then
             local qidx = WoWPro.rows[index].index
             if _G.CanMerchantRepair() and WoWPro.action[qidx] == "r" then
-                WoWPro.CompleteStep(qidx,"Talked to Repairing Merchant, index="..tostring(index))
+                WoWPro.CompleteStep(qidx,"Talked to Repairing Merchant, index="..tostring(index), nil, { origin = "MerchantRepair" })
             end
         else
             break

--- a/WoWPro/WoWPro_Mapping.lua
+++ b/WoWPro/WoWPro_Mapping.lua
@@ -145,7 +145,7 @@ local function WoWProMapping_distance(event, uid, range, distance, lastdistance)
         end
 
         if iactual == 1 and autoComplete then
-            WoWPro.CompleteStep(index, "autoarrival=1", nil, { origin = "MappingAutoArrival" })
+            WoWPro.CompleteStep(index, "autoarrival=1", nil, "MappingAutoArrival")
         end
 
     elseif autoarrival == 2 then
@@ -154,7 +154,7 @@ local function WoWProMapping_distance(event, uid, range, distance, lastdistance)
             return
         elseif iactual == 1 then
             if autoComplete then
-                WoWPro.CompleteStep(index, "autoarrival=2", nil, { origin = "MappingAutoArrival" })
+                WoWPro.CompleteStep(index, "autoarrival=2", nil, "MappingAutoArrival")
             end
         else
             WoWPro:dbp("Mapping(AA2): removing uid #%d %s.", iactual, tostring(cache[iactual].uid))

--- a/WoWPro/WoWPro_Mapping.lua
+++ b/WoWPro/WoWPro_Mapping.lua
@@ -145,7 +145,7 @@ local function WoWProMapping_distance(event, uid, range, distance, lastdistance)
         end
 
         if iactual == 1 and autoComplete then
-            WoWPro.CompleteStep(index, "autoarrival=1")
+            WoWPro.CompleteStep(index, "autoarrival=1", nil, { origin = "MappingAutoArrival" })
         end
 
     elseif autoarrival == 2 then
@@ -154,7 +154,7 @@ local function WoWProMapping_distance(event, uid, range, distance, lastdistance)
             return
         elseif iactual == 1 then
             if autoComplete then
-                WoWPro.CompleteStep(index, "autoarrival=2")
+                WoWPro.CompleteStep(index, "autoarrival=2", nil, { origin = "MappingAutoArrival" })
             end
         else
             WoWPro:dbp("Mapping(AA2): removing uid #%d %s.", iactual, tostring(cache[iactual].uid))

--- a/WoWPro/WoWPro_Pets.lua
+++ b/WoWPro/WoWPro_Pets.lua
@@ -520,7 +520,7 @@ function WoWPro.ProcessFinalRound(winner, qidx)
         WoWPro:DelFauxQuest(QID)
         for i=1, WoWPro.stepcount do
             if not WoWProCharDB.Guide[GID].completion[i] and WoWPro.strategy[i] and ((WoWPro.QID[i] and WoWPro.QID[i] == QID) or (WoWPro.available[i] and WoWPro.available[i] == QID))  then
-                WoWPro.CompleteStep(i,"Pet battle WON!", nil, { origin = "PetBattleFinalRound" })
+                WoWPro.CompleteStep(i,"Pet battle WON!", nil, "PetBattleFinalRound")
             end
         end
         WoWPro.current_strategy = false

--- a/WoWPro/WoWPro_Pets.lua
+++ b/WoWPro/WoWPro_Pets.lua
@@ -520,7 +520,7 @@ function WoWPro.ProcessFinalRound(winner, qidx)
         WoWPro:DelFauxQuest(QID)
         for i=1, WoWPro.stepcount do
             if not WoWProCharDB.Guide[GID].completion[i] and WoWPro.strategy[i] and ((WoWPro.QID[i] and WoWPro.QID[i] == QID) or (WoWPro.available[i] and WoWPro.available[i] == QID))  then
-                WoWPro.CompleteStep(i,"Pet battle WON!")
+                WoWPro.CompleteStep(i,"Pet battle WON!", nil, { origin = "PetBattleFinalRound" })
             end
         end
         WoWPro.current_strategy = false


### PR DESCRIPTION
This PR tightens completion-sound behavior in WoWPro so the check sound only plays when the completed step is actually visible in the guide window. The sound decision now flows through a centralized helper in CompleteStep, which keeps the behavior consistent and makes future changes easier to reason about.

I also removed the manual right-click sound bypass and added diagnostics for the main background completion paths, including quest updates, travel, bucketed refreshes, and sticky/unsticky pairing.

Each commit was a progressive advancement in implementing the code. Cherry-pick each commit if you wish to do testing