### PR TITLE
Fix combat lockdown frame dragging

### DIFF
--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -106,7 +106,7 @@ end
 function WoWPro:DragSet()
     if WoWProDB.profile.drag then
         WoWPro.ButtonBar:SetScript("OnMouseDown", function(this, button)
-            if button == "LeftButton" and WoWProDB.profile.drag then
+            if button == "LeftButton" and WoWProDB.profile.drag and not _G.InCombatLockdown() then
                 WoWPro.InhibitAnchorRestore = true
                 WoWPro:StartMoveClamp()
                 WoWPro.MainFrame:StartMoving()
@@ -128,7 +128,7 @@ function WoWPro:DragSet()
 
         -- Enable titlebar dragging regardless of button bar visibility
         WoWPro.Titlebar:SetScript("OnMouseDown", function(this, button)
-            if button == "LeftButton" and WoWProDB.profile.drag then
+            if button == "LeftButton" and WoWProDB.profile.drag and not _G.InCombatLockdown() then
                 WoWPro.InhibitAnchorRestore = true
                 WoWPro:StartMoveClamp()
                 WoWPro.MainFrame:StartMoving()
@@ -1222,7 +1222,7 @@ function WoWPro:CreateMainFrame()
     WoWPro.MainFrame = frame
     -- Scripts --
     WoWPro.MainFrame:SetScript("OnMouseDown", function(this, button)
-        if button == "LeftButton" and WoWProDB.profile.drag then
+        if button == "LeftButton" and WoWProDB.profile.drag and not _G.InCombatLockdown() then
             WoWPro.InhibitAnchorRestore = true
             WoWPro:StartMoveClamp()
             this:StartMoving()
@@ -1806,7 +1806,7 @@ function WoWPro:CreateGuideFrame()
     WoWPro.GuideFrame:EnableMouse(true)
     WoWPro.GuideFrame:SetClipsChildren(true)
     WoWPro.GuideFrame:SetScript("OnMouseDown", function(this, button)
-        if button == "LeftButton" and WoWProDB.profile.drag then
+        if button == "LeftButton" and WoWProDB.profile.drag and not _G.InCombatLockdown() then
             WoWPro.InhibitAnchorRestore = true
             WoWPro:StartMoveClamp()
             WoWPro.MainFrame:StartMoving()
@@ -1874,7 +1874,7 @@ function WoWPro:CreateRows()
         row:RegisterForClicks("AnyUp");
         row:RegisterForDrag("LeftButton")
         row:SetScript("OnDragStart", function()
-            if WoWProDB.profile.drag then
+            if WoWProDB.profile.drag and not _G.InCombatLockdown() then
                 WoWPro.InhibitAnchorRestore = true
                 WoWPro:StartMoveClamp()
                 WoWPro.MainFrame:StartMoving()


### PR DESCRIPTION
Guard all `StartMoving()` calls in WoWPro_Frames.lua with `not InCombatLockdown()` to prevent protected function errors while in combat. This prevents accidental drag attempts from triggering [ADDON_ACTION_BLOCKED] when the user clicks the frame during combat.