### PR TITLE
reduce guide update churn from loot autocomplete events

### DIFF
--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -250,6 +250,7 @@ end
 -- Auto-Complete: Loot based --
 function WoWPro.AutoCompleteLoot()
     if not WoWPro.GuideLoaded then return end
+    local guideStateChanged = false
     for i = 1, 1 + WoWPro:GetActiveStickyCount() do
         local index = WoWPro.rows[i].index
         local lootItems = WoWPro.lootitem[index]
@@ -271,12 +272,15 @@ function WoWPro.AutoCompleteLoot()
             if allComplete and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
                 WoWPro:dbp("AutoCompleteLoot: Time to complete step.")
                 WoWPro.CompleteStep(index, "AutoCompleteLoot", nil, "AutoCompleteLoot")
+                guideStateChanged = true
             else
                 WoWPro:dbp("AutoCompleteLoot: Not enough yet!")
             end
         end
     end
-    WoWPro:UpdateGuide("WoWPro.AutoCompleteLoot")
+    if guideStateChanged then
+        WoWPro:UpdateGuide("WoWPro.AutoCompleteLoot")
+    end
 end
 
 local LUNARFALL_MAPID

--- a/WoWPro/WoWPro_AutoComplete.lua
+++ b/WoWPro/WoWPro_AutoComplete.lua
@@ -250,15 +250,12 @@ end
 -- Auto-Complete: Loot based --
 function WoWPro.AutoCompleteLoot()
     if not WoWPro.GuideLoaded then return end
-    local guideStateChanged = false
     for i = 1, 1 + WoWPro:GetActiveStickyCount() do
         local index = WoWPro.rows[i].index
         local lootItems = WoWPro.lootitem[index]
         if lootItems then
             if WoWProDB.profile.track then
-                local track = WoWPro.GetLootTrackingInfo(lootItems)
-                WoWPro.rows[i].track:SetText(track:trim())
-                WoWPro:dbp("AutoCompleteLoot: Update tracking text to %s", track)
+                WoWPro.UpdateQuestTrackerRow(WoWPro.rows[i])
             end
             local allComplete = true
             for itemID, qty in pairs(lootItems) do
@@ -272,14 +269,10 @@ function WoWPro.AutoCompleteLoot()
             if allComplete and not WoWProCharDB.Guide[WoWProDB.char.currentguide].completion[index] then
                 WoWPro:dbp("AutoCompleteLoot: Time to complete step.")
                 WoWPro.CompleteStep(index, "AutoCompleteLoot", nil, "AutoCompleteLoot")
-                guideStateChanged = true
             else
                 WoWPro:dbp("AutoCompleteLoot: Not enough yet!")
             end
         end
-    end
-    if guideStateChanged then
-        WoWPro:UpdateGuide("WoWPro.AutoCompleteLoot")
     end
 end
 


### PR DESCRIPTION
AutoComplete loot processing was triggering guide refreshes on every bucketed loot/bag event, even when no step state changed. During crafting/loot bursts this could cause repeated UpdateGuideReal passes and visible stutter for some users.

Changes:

Updated AutoCompleteLoot to track whether guide state actually changed.
Set a local flag only when a loot step is newly completed.
Call UpdateGuide("WoWPro.AutoCompleteLoot") only when that flag is true.
Preserve existing completion behavior and tracking text updates.

Impact:
Significantly fewer unnecessary guide recomputations during CHAT_MSG_LOOT/BAG_UPDATE bursts.
Lower UI work during high-frequency loot activity.
No functional change to loot-step completion semantics.