### PR TITLE
No more peeking at auras in combat

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -3886,6 +3886,10 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             -- This tests for spells that are cast on you and show up as buffs
             if WoWPro.buff and WoWPro.buff[guideIndex] then
                 local buff = WoWPro.buff[guideIndex]
+                if _G.InCombatLockdown() then
+                    WoWPro:dbp("Skipping buff check because in combat.", buff)
+                    break
+                end
                 local buffy = WoWPro:CheckPlayerForBuffs(buff)
                 if buffy then
                     skip = true

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -226,7 +226,7 @@ end
 
 
 WoWPro.RegisterEventHandler("UNIT_AURA", function(event, ...)
-    if not WoWPro.MaybeCombatLockdown() then
+    if not _G.InCombatLockdown() then
         WoWPro.AutoCompleteBuff(...)
     end
     end)


### PR DESCRIPTION
Addresses user reported issue

- The 12.1.0 restrictions mean we're no longer able to interact with aura data at all in combat so I've added strict combat checks for all calls.
- This will likely delay step updates/skips till we exit combat - not ideal but we are where we are.

Tested with the Maldraxxus guide which uses |BUFF| a fair bit and it seems to behave sensibly - but me may have to watch for corner cases.
